### PR TITLE
Add workflow templates support

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,21 +1,16 @@
 <!--
 Sync Impact Report
 ==================
-Version change: 1.0.0 → 1.1.0
+Version change: 1.1.0 → 1.2.0
 Modified principles:
-  - IV. Security-First: replaced EncryptedSharedPreferences with
-    DataStore + Tink/Android Keystore (ESP deprecated in
-    androidx.security:security-crypto:1.1.0-alpha07)
-  - V. Lean Dependencies: updated security dependency reference
+  - VI. API-Driven Design: added workflow template endpoints
+    (/api/v2/workflow_job_templates/, workflow_jobs, workflow_nodes)
 Modified sections:
-  - Technology Constraints: updated Security row
+  - None beyond Principle VI endpoint list
 Templates requiring updates:
-  - .specify/templates/plan-template.md ✅ no changes needed
-  - .specify/templates/spec-template.md ✅ no changes needed
-  - .specify/templates/tasks-template.md ✅ no changes needed
-  - No command files found — N/A
+  - None — endpoint list is informational, not template-referenced
 Follow-up TODOs:
-  - Update CLAUDE.md to reflect DataStore + Tink replacement
+  - None
 -->
 
 # AAP Remote Control Constitution
@@ -99,6 +94,10 @@ be driven by API endpoints:
 - `/api/v2/job_templates/{id}/launch/` — job execution
 - `/api/v2/jobs/{id}/` — job status monitoring
 - `/api/v2/tokens/` — token acquisition
+- `/api/v2/workflow_job_templates/` — workflow template listing
+- `/api/v2/workflow_job_templates/{id}/launch/` — workflow execution
+- `/api/v2/workflow_jobs/{id}/` — workflow job status
+- `/api/v2/workflow_jobs/{id}/workflow_nodes/` — workflow sub-job listing
 
 The network layer MUST be defined as a Retrofit interface
 (`AapApiService`) with a Koin-provided `networkModule`. No
@@ -158,4 +157,4 @@ conflicting guidance except explicit user overrides.
 these principles. Any deviation MUST be flagged and justified
 before merge.
 
-**Version**: 1.1.0 | **Ratified**: 2026-04-02 | **Last Amended**: 2026-04-02
+**Version**: 1.2.0 | **Ratified**: 2026-04-02 | **Last Amended**: 2026-04-03

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ All authenticated requests use header: `Authorization: Bearer <TOKEN>`
 - Jetpack DataStore + Tink (encrypted, local only) (001-aap-remote-control)
 - Kotlin (JVM 17), compileSdk 35, minSdk 31 + Jetpack Compose (Material 3 BOM), Navigation Compose, Retrofit, Koin (002-nav-ui-modernize)
 - DataStore + Tink (unchanged) (002-nav-ui-modernize)
+- Kotlin (latest stable, targeting JVM 17) + Jetpack Compose (Material 3 BOM), Navigation Compose, Retrofit + Kotlin Serialization, Koin (004-workflow-templates)
+- DataStore + Tink (unchanged — no new storage needs) (004-workflow-templates)
 
 ## Recent Changes
 - 001-aap-remote-control: Added Kotlin (latest stable, targeting JVM 17) + Jetpack Compose (Material 3), Retrofit,

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ A lightweight Android app for remotely controlling [Ansible Automation Platform 
 - **Connect** to any AAP instance using a Personal Access Token (PAT)
 - **Self-signed certificate** support for lab/dev environments
 - **Auto-detect** AAP API version (2.4 controller vs 2.5+ gateway)
-- **Browse** job templates with search and label filtering
-- **Launch** jobs with optional extra variables (JSON)
+- **Browse** job templates and workflow templates with search and label filtering
+- **Launch** jobs and workflows with optional extra variables (JSON)
 - **Monitor** job status with live polling and stdout output
+- **Monitor** workflow job status with sub-job tracking
 - **Recent jobs** history
 
 ## Screenshots
@@ -45,6 +46,50 @@ A lightweight Android app for remotely controlling [Ansible Automation Platform 
 ```bash
 ./gradlew assembleDebug
 ```
+
+## Usage
+
+### Connecting to AAP
+
+1. Enter your AAP instance URL (e.g., `https://aap.example.com`)
+2. Enter your Personal Access Token (PAT) — generate one from your AAP user settings under **Tokens**
+3. For lab/dev environments with self-signed certificates, toggle **Allow self-signed certificates**
+4. Tap **Login**
+
+### Browsing Templates
+
+The **Templates** tab has two segments accessible via the segmented buttons at the top:
+
+- **Job Templates** — standard playbook-based templates
+- **Workflow Templates** — multi-step workflow templates
+
+Both segments support:
+
+- **Search** — type in the search bar to filter by name
+- **Label filtering** — tap a label chip to filter by label; tap again to clear
+- **Pagination** — scroll to the bottom to load more templates automatically
+- **Pull-to-refresh** — pull down on the list to reload data from the server (useful when templates are added or modified on the AAP side while the app is open)
+
+### Launching Jobs
+
+1. Tap the play button on a template card (only visible if your user has launch permission)
+2. If the template accepts extra variables, an input dialog appears first — enter valid JSON
+3. Confirm the launch in the confirmation dialog
+4. The app navigates to the job status screen automatically
+
+### Monitoring Jobs
+
+- **Job status** — shows job name, status badge, template name, start/finish/elapsed times, and stdout output
+- **Workflow job status** — same details plus a **Sub-Jobs** section listing each workflow node with its status; tap any sub-job to expand it and view its stdout output inline
+- Status auto-updates every 5 seconds while the job is running; polling stops when the job completes
+
+### Activity Tab
+
+The **Activity** tab shows recent jobs (both regular and workflow) sorted by creation time. Tap any job to view its status.
+
+### Settings
+
+Access settings via the gear icon in the top bar. Shows the connected server URL and a logout button.
 
 ## Security
 

--- a/app/src/main/kotlin/com/example/aapremote/data/DataModule.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/DataModule.kt
@@ -9,4 +9,5 @@ val dataModule = module {
     single { AuthRepository(get()) }
     single { TemplateRepository(get()) }
     single { JobRepository(get()) }
+    single { WorkflowRepository(get()) }
 }

--- a/app/src/main/kotlin/com/example/aapremote/data/WorkflowRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/WorkflowRepository.kt
@@ -1,0 +1,89 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.LaunchRequest
+import com.example.aapremote.model.WorkflowJob
+import com.example.aapremote.model.WorkflowJobTemplate
+import com.example.aapremote.model.WorkflowNode
+import com.example.aapremote.network.AapApiService
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class WorkflowRepository(private val apiService: AapApiService) {
+
+    suspend fun getWorkflowTemplates(
+        page: Int = 1,
+        search: String? = null,
+        labelFilter: String? = null
+    ): Result<WorkflowTemplateListResult> {
+        return try {
+            val response = apiService.getWorkflowJobTemplates(
+                page = page,
+                search = search,
+                labelsFilter = labelFilter
+            )
+            Result.success(
+                WorkflowTemplateListResult(
+                    templates = response.results,
+                    hasMore = response.next != null,
+                    totalCount = response.count
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun launchWorkflow(templateId: Int, extraVars: String? = null): Result<Int> {
+        return try {
+            val request = LaunchRequest(extraVars = extraVars)
+            val response = apiService.launchWorkflowJob(templateId, request)
+            Result.success(response.workflowJob)
+        } catch (e: retrofit2.HttpException) {
+            val message = when (e.code()) {
+                400 -> "Invalid request. Check your extra variables."
+                403 -> "You don't have permission to launch this workflow template."
+                else -> "Launch failed (${e.code()}): ${e.message()}"
+            }
+            Result.failure(Exception(message))
+        } catch (e: Exception) {
+            Result.failure(Exception("Launch failed: ${e.message}"))
+        }
+    }
+
+    suspend fun getWorkflowJobStatus(workflowJobId: Int): Result<WorkflowJob> {
+        return try {
+            Result.success(apiService.getWorkflowJob(workflowJobId))
+        } catch (e: Exception) {
+            Result.failure(Exception("Failed to get workflow job status: ${e.message}"))
+        }
+    }
+
+    fun pollWorkflowJobStatus(workflowJobId: Int): Flow<WorkflowJob> = flow {
+        while (true) {
+            try {
+                val job = apiService.getWorkflowJob(workflowJobId)
+                emit(job)
+                if (job.status.isTerminal) break
+                delay(5000)
+            } catch (e: Exception) {
+                throw Exception("Failed to poll workflow job status: ${e.message}")
+            }
+        }
+    }
+
+    suspend fun getWorkflowNodes(workflowJobId: Int): Result<List<WorkflowNode>> {
+        return try {
+            val response = apiService.getWorkflowNodes(workflowJobId)
+            Result.success(response.results)
+        } catch (e: Exception) {
+            Result.failure(Exception("Failed to get workflow nodes: ${e.message}"))
+        }
+    }
+}
+
+data class WorkflowTemplateListResult(
+    val templates: List<WorkflowJobTemplate>,
+    val hasMore: Boolean,
+    val totalCount: Int
+)

--- a/app/src/main/kotlin/com/example/aapremote/model/WorkflowJob.kt
+++ b/app/src/main/kotlin/com/example/aapremote/model/WorkflowJob.kt
@@ -1,0 +1,30 @@
+package com.example.aapremote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WorkflowJob(
+    val id: Int,
+    val name: String = "",
+    val status: JobStatus,
+    val failed: Boolean = false,
+    val started: String? = null,
+    val finished: String? = null,
+    val elapsed: Double? = null,
+    @SerialName("summary_fields") val summaryFields: WorkflowJobSummaryFields = WorkflowJobSummaryFields()
+) {
+    val workflowJobTemplateName: String
+        get() = summaryFields.workflowJobTemplate?.name ?: name
+}
+
+@Serializable
+data class WorkflowJobSummaryFields(
+    @SerialName("workflow_job_template") val workflowJobTemplate: WorkflowJobTemplateRef? = null
+)
+
+@Serializable
+data class WorkflowJobTemplateRef(
+    val id: Int,
+    val name: String
+)

--- a/app/src/main/kotlin/com/example/aapremote/model/WorkflowJobTemplate.kt
+++ b/app/src/main/kotlin/com/example/aapremote/model/WorkflowJobTemplate.kt
@@ -1,0 +1,21 @@
+package com.example.aapremote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WorkflowJobTemplate(
+    val id: Int,
+    val name: String,
+    val description: String = "",
+    @SerialName("ask_variables_on_launch") val askVariablesOnLaunch: Boolean = false,
+    val status: String? = null,
+    @SerialName("last_job_run") val lastJobRun: String? = null,
+    @SerialName("summary_fields") val summaryFields: WorkflowTemplateSummaryFields = WorkflowTemplateSummaryFields()
+)
+
+@Serializable
+data class WorkflowTemplateSummaryFields(
+    val labels: LabelSummary = LabelSummary(),
+    @SerialName("user_capabilities") val userCapabilities: UserCapabilities = UserCapabilities()
+)

--- a/app/src/main/kotlin/com/example/aapremote/model/WorkflowLaunchResponse.kt
+++ b/app/src/main/kotlin/com/example/aapremote/model/WorkflowLaunchResponse.kt
@@ -1,0 +1,11 @@
+package com.example.aapremote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WorkflowLaunchResponse(
+    @SerialName("workflow_job") val workflowJob: Int,
+    val id: Int,
+    val status: String = ""
+)

--- a/app/src/main/kotlin/com/example/aapremote/model/WorkflowNode.kt
+++ b/app/src/main/kotlin/com/example/aapremote/model/WorkflowNode.kt
@@ -1,0 +1,24 @@
+package com.example.aapremote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WorkflowNode(
+    val id: Int,
+    @SerialName("summary_fields") val summaryFields: WorkflowNodeSummaryFields = WorkflowNodeSummaryFields(),
+    @SerialName("do_not_run") val doNotRun: Boolean = false
+)
+
+@Serializable
+data class WorkflowNodeSummaryFields(
+    val job: WorkflowNodeJob? = null
+)
+
+@Serializable
+data class WorkflowNodeJob(
+    val id: Int,
+    val name: String,
+    val status: JobStatus,
+    val type: String = ""
+)

--- a/app/src/main/kotlin/com/example/aapremote/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/example/aapremote/navigation/AppNavigation.kt
@@ -19,6 +19,7 @@ import com.example.aapremote.ui.auth.AuthScreen
 import com.example.aapremote.ui.jobs.JobStatusScreen
 import com.example.aapremote.ui.main.MainScreen
 import com.example.aapremote.ui.settings.SettingsScreen
+import com.example.aapremote.ui.workflows.WorkflowJobStatusScreen
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.compose.koinInject
 
@@ -26,9 +27,11 @@ object Routes {
     const val AUTH = "auth"
     const val MAIN = "main"
     const val JOB_STATUS = "job_status/{jobId}"
+    const val WORKFLOW_JOB_STATUS = "workflow_job_status/{workflowJobId}"
     const val SETTINGS = "settings"
 
     fun jobStatus(jobId: Int) = "job_status/$jobId"
+    fun workflowJobStatus(workflowJobId: Int) = "workflow_job_status/$workflowJobId"
 }
 
 @Composable
@@ -76,6 +79,9 @@ fun AppNavigation(
                     segment = segment,
                     onNavigateToJobStatus = { jobId ->
                         navController.navigate(Routes.jobStatus(jobId))
+                    },
+                    onNavigateToWorkflowJobStatus = { workflowJobId ->
+                        navController.navigate(Routes.workflowJobStatus(workflowJobId))
                     }
                 )
             }
@@ -90,6 +96,19 @@ fun AppNavigation(
             popExitTransition = { slideOutHorizontally { it } }
         ) {
             JobStatusScreen(
+                onNavigateBack = { navController.popBackStack() }
+            )
+        }
+
+        composable(
+            route = Routes.WORKFLOW_JOB_STATUS,
+            arguments = listOf(navArgument("workflowJobId") { type = NavType.IntType }),
+            enterTransition = { slideInHorizontally { it } },
+            exitTransition = { slideOutHorizontally { -it } },
+            popEnterTransition = { slideInHorizontally { -it } },
+            popExitTransition = { slideOutHorizontally { it } }
+        ) {
+            WorkflowJobStatusScreen(
                 onNavigateBack = { navController.popBackStack() }
             )
         }

--- a/app/src/main/kotlin/com/example/aapremote/navigation/MainNavigation.kt
+++ b/app/src/main/kotlin/com/example/aapremote/navigation/MainNavigation.kt
@@ -6,12 +6,14 @@ import com.example.aapremote.ui.jobs.RecentJobsScreen
 import com.example.aapremote.ui.main.Segment
 import com.example.aapremote.ui.main.TopLevelTab
 import com.example.aapremote.ui.templates.TemplateListScreen
+import com.example.aapremote.ui.workflows.WorkflowTemplateListScreen
 
 @Composable
 fun TabContent(
     tab: TopLevelTab,
     segment: Segment,
-    onNavigateToJobStatus: (Int) -> Unit
+    onNavigateToJobStatus: (Int) -> Unit,
+    onNavigateToWorkflowJobStatus: (Int) -> Unit = {}
 ) {
     if (!segment.isImplemented) {
         PlaceholderScreen(title = segment.label)
@@ -23,6 +25,9 @@ fun TabContent(
             when (segment.label) {
                 "Job Templates" -> TemplateListScreen(
                     onNavigateToJobStatus = onNavigateToJobStatus
+                )
+                "Workflow Templates" -> WorkflowTemplateListScreen(
+                    onNavigateToWorkflowJobStatus = onNavigateToWorkflowJobStatus
                 )
                 else -> PlaceholderScreen(title = segment.label)
             }

--- a/app/src/main/kotlin/com/example/aapremote/network/AapApiService.kt
+++ b/app/src/main/kotlin/com/example/aapremote/network/AapApiService.kt
@@ -38,4 +38,28 @@ interface AapApiService {
         @Query("page_size") pageSize: Int = 20,
         @Query("page") page: Int = 1
     ): PaginatedResponse<Job>
+
+    @GET("workflow_job_templates/")
+    suspend fun getWorkflowJobTemplates(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("labels__name__icontains") labelsFilter: String? = null,
+        @Query("order_by") orderBy: String = "-modified"
+    ): PaginatedResponse<WorkflowJobTemplate>
+
+    @POST("workflow_job_templates/{id}/launch/")
+    suspend fun launchWorkflowJob(
+        @Path("id") id: Int,
+        @Body request: LaunchRequest = LaunchRequest()
+    ): WorkflowLaunchResponse
+
+    @GET("workflow_jobs/{id}/")
+    suspend fun getWorkflowJob(@Path("id") id: Int): WorkflowJob
+
+    @GET("workflow_jobs/{id}/workflow_nodes/")
+    suspend fun getWorkflowNodes(
+        @Path("id") id: Int,
+        @Query("page_size") pageSize: Int = 200
+    ): PaginatedResponse<WorkflowNode>
 }

--- a/app/src/main/kotlin/com/example/aapremote/presentation/PresentationModule.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/PresentationModule.kt
@@ -4,6 +4,8 @@ import com.example.aapremote.presentation.auth.AuthViewModel
 import com.example.aapremote.presentation.jobs.JobStatusViewModel
 import com.example.aapremote.presentation.jobs.RecentJobsViewModel
 import com.example.aapremote.presentation.templates.TemplatesViewModel
+import com.example.aapremote.presentation.workflows.WorkflowJobStatusViewModel
+import com.example.aapremote.presentation.workflows.WorkflowTemplatesViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
@@ -12,4 +14,6 @@ val presentationModule = module {
     viewModelOf(::TemplatesViewModel)
     viewModelOf(::JobStatusViewModel)
     viewModelOf(::RecentJobsViewModel)
+    viewModelOf(::WorkflowTemplatesViewModel)
+    viewModelOf(::WorkflowJobStatusViewModel)
 }

--- a/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowJobStatusUiState.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowJobStatusUiState.kt
@@ -1,0 +1,17 @@
+package com.example.aapremote.presentation.workflows
+
+import com.example.aapremote.model.WorkflowJob
+import com.example.aapremote.model.WorkflowNode
+
+sealed interface WorkflowJobStatusUiState {
+    data object Loading : WorkflowJobStatusUiState
+    data class Active(
+        val workflowJob: WorkflowJob,
+        val nodes: List<WorkflowNode> = emptyList()
+    ) : WorkflowJobStatusUiState
+    data class Completed(
+        val workflowJob: WorkflowJob,
+        val nodes: List<WorkflowNode> = emptyList()
+    ) : WorkflowJobStatusUiState
+    data class Error(val message: String) : WorkflowJobStatusUiState
+}

--- a/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowJobStatusViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowJobStatusViewModel.kt
@@ -1,0 +1,98 @@
+package com.example.aapremote.presentation.workflows
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.aapremote.data.JobRepository
+import com.example.aapremote.data.WorkflowRepository
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+
+sealed interface NodeStdoutState {
+    data object Loading : NodeStdoutState
+    data class Loaded(val stdout: String) : NodeStdoutState
+    data class Error(val message: String) : NodeStdoutState
+}
+
+class WorkflowJobStatusViewModel(
+    savedStateHandle: SavedStateHandle,
+    private val workflowRepository: WorkflowRepository,
+    private val jobRepository: JobRepository
+) : ViewModel() {
+
+    private val workflowJobId: Int = savedStateHandle.get<Int>("workflowJobId") ?: -1
+
+    private val _uiState = MutableStateFlow<WorkflowJobStatusUiState>(WorkflowJobStatusUiState.Loading)
+    val uiState: StateFlow<WorkflowJobStatusUiState> = _uiState.asStateFlow()
+
+    private val _expandedNodeId = MutableStateFlow<Int?>(null)
+    val expandedNodeId: StateFlow<Int?> = _expandedNodeId.asStateFlow()
+
+    private val _nodeStdout = MutableStateFlow<Map<Int, NodeStdoutState>>(emptyMap())
+    val nodeStdout: StateFlow<Map<Int, NodeStdoutState>> = _nodeStdout.asStateFlow()
+
+    private var pollingJob: Job? = null
+
+    fun startPolling() {
+        if (workflowJobId <= 0 || pollingJob?.isActive == true) return
+
+        pollingJob = viewModelScope.launch {
+            workflowRepository.pollWorkflowJobStatus(workflowJobId)
+                .catch { e ->
+                    _uiState.value = WorkflowJobStatusUiState.Error(e.message ?: "Unknown error")
+                }
+                .collect { workflowJob ->
+                    val nodes = workflowRepository.getWorkflowNodes(workflowJobId).getOrDefault(emptyList())
+                    _uiState.value = if (workflowJob.status.isTerminal) {
+                        WorkflowJobStatusUiState.Completed(workflowJob, nodes)
+                    } else {
+                        WorkflowJobStatusUiState.Active(workflowJob, nodes)
+                    }
+                }
+        }
+    }
+
+    fun toggleNodeExpansion(jobId: Int) {
+        if (_expandedNodeId.value == jobId) {
+            _expandedNodeId.value = null
+        } else {
+            _expandedNodeId.value = jobId
+            if (_nodeStdout.value[jobId] == null) {
+                fetchNodeStdout(jobId)
+            }
+        }
+    }
+
+    private fun fetchNodeStdout(jobId: Int) {
+        _nodeStdout.value = _nodeStdout.value + (jobId to NodeStdoutState.Loading)
+        viewModelScope.launch {
+            val result = jobRepository.getJobStdout(jobId)
+            _nodeStdout.value = _nodeStdout.value + (jobId to result.fold(
+                onSuccess = { stdout ->
+                    if (stdout.isBlank()) NodeStdoutState.Loaded("No output available")
+                    else NodeStdoutState.Loaded(stdout)
+                },
+                onFailure = { e -> NodeStdoutState.Error(e.message ?: "Failed to load output") }
+            ))
+        }
+    }
+
+    fun stopPolling() {
+        pollingJob?.cancel()
+        pollingJob = null
+    }
+
+    fun retry() {
+        _uiState.value = WorkflowJobStatusUiState.Loading
+        startPolling()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        stopPolling()
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesUiState.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesUiState.kt
@@ -1,0 +1,25 @@
+package com.example.aapremote.presentation.workflows
+
+import com.example.aapremote.model.Label
+import com.example.aapremote.model.WorkflowJobTemplate
+
+sealed interface WorkflowTemplatesUiState {
+    data object Idle : WorkflowTemplatesUiState
+    data object Loading : WorkflowTemplatesUiState
+    data class Success(
+        val templates: List<WorkflowJobTemplate>,
+        val availableLabels: List<Label>,
+        val hasMore: Boolean,
+        val isLoadingMore: Boolean = false
+    ) : WorkflowTemplatesUiState
+    data class Error(val message: String) : WorkflowTemplatesUiState
+}
+
+sealed interface WorkflowLaunchState {
+    data object Idle : WorkflowLaunchState
+    data class Confirming(val template: WorkflowJobTemplate) : WorkflowLaunchState
+    data class EnteringVars(val template: WorkflowJobTemplate) : WorkflowLaunchState
+    data object Launching : WorkflowLaunchState
+    data class Launched(val workflowJobId: Int) : WorkflowLaunchState
+    data class LaunchError(val message: String) : WorkflowLaunchState
+}

--- a/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesViewModel.kt
@@ -1,0 +1,149 @@
+package com.example.aapremote.presentation.workflows
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.aapremote.data.WorkflowRepository
+import com.example.aapremote.model.Label
+import com.example.aapremote.model.WorkflowJobTemplate
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class WorkflowTemplatesViewModel(
+    private val workflowRepository: WorkflowRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<WorkflowTemplatesUiState>(WorkflowTemplatesUiState.Idle)
+    val uiState: StateFlow<WorkflowTemplatesUiState> = _uiState.asStateFlow()
+
+    private val _launchState = MutableStateFlow<WorkflowLaunchState>(WorkflowLaunchState.Idle)
+    val launchState: StateFlow<WorkflowLaunchState> = _launchState.asStateFlow()
+
+    private var currentPage = 1
+    private var currentSearch: String? = null
+    private var currentLabelFilter: String? = null
+    private var allTemplates = mutableListOf<WorkflowJobTemplate>()
+    private var searchJob: Job? = null
+
+    init {
+        loadTemplates()
+    }
+
+    fun loadTemplates() {
+        currentPage = 1
+        allTemplates.clear()
+        _uiState.value = WorkflowTemplatesUiState.Loading
+        viewModelScope.launch {
+            fetchTemplates()
+        }
+    }
+
+    fun refresh() {
+        currentPage = 1
+        allTemplates.clear()
+        viewModelScope.launch {
+            fetchTemplates()
+        }
+    }
+
+    fun loadMore() {
+        val current = _uiState.value
+        if (current is WorkflowTemplatesUiState.Success && current.hasMore && !current.isLoadingMore) {
+            currentPage++
+            _uiState.value = current.copy(isLoadingMore = true)
+            viewModelScope.launch {
+                fetchTemplates(append = true)
+            }
+        }
+    }
+
+    fun search(query: String) {
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            delay(300)
+            currentSearch = query.ifBlank { null }
+            currentPage = 1
+            allTemplates.clear()
+            _uiState.value = WorkflowTemplatesUiState.Loading
+            fetchTemplates()
+        }
+    }
+
+    fun filterByLabel(label: Label?) {
+        currentLabelFilter = label?.name
+        currentPage = 1
+        allTemplates.clear()
+        _uiState.value = WorkflowTemplatesUiState.Loading
+        viewModelScope.launch {
+            fetchTemplates()
+        }
+    }
+
+    fun requestLaunch(template: WorkflowJobTemplate) {
+        _launchState.value = if (template.askVariablesOnLaunch) {
+            WorkflowLaunchState.EnteringVars(template)
+        } else {
+            WorkflowLaunchState.Confirming(template)
+        }
+    }
+
+    fun confirmLaunch(extraVars: String? = null) {
+        val template = when (val state = _launchState.value) {
+            is WorkflowLaunchState.Confirming -> state.template
+            is WorkflowLaunchState.EnteringVars -> state.template
+            else -> return
+        }
+
+        _launchState.value = WorkflowLaunchState.Launching
+        viewModelScope.launch {
+            val result = workflowRepository.launchWorkflow(template.id, extraVars)
+            _launchState.value = result.fold(
+                onSuccess = { workflowJobId -> WorkflowLaunchState.Launched(workflowJobId) },
+                onFailure = { error -> WorkflowLaunchState.LaunchError(error.message ?: "Launch failed") }
+            )
+        }
+    }
+
+    fun cancelLaunch() {
+        _launchState.value = WorkflowLaunchState.Idle
+    }
+
+    fun resetLaunchState() {
+        _launchState.value = WorkflowLaunchState.Idle
+    }
+
+    private suspend fun fetchTemplates(append: Boolean = false) {
+        val result = workflowRepository.getWorkflowTemplates(
+            page = currentPage,
+            search = currentSearch,
+            labelFilter = currentLabelFilter
+        )
+
+        result.fold(
+            onSuccess = { listResult ->
+                if (append) {
+                    allTemplates.addAll(listResult.templates)
+                } else {
+                    allTemplates = listResult.templates.toMutableList()
+                }
+
+                val labels = allTemplates
+                    .flatMap { it.summaryFields.labels.results }
+                    .distinctBy { it.id }
+                    .sortedBy { it.name }
+
+                _uiState.value = WorkflowTemplatesUiState.Success(
+                    templates = allTemplates.toList(),
+                    availableLabels = labels,
+                    hasMore = listResult.hasMore
+                )
+            },
+            onFailure = { error ->
+                _uiState.value = WorkflowTemplatesUiState.Error(error.message ?: "Failed to load workflow templates")
+            }
+        )
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/ui/components/WorkflowNodeItem.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/components/WorkflowNodeItem.kt
@@ -1,0 +1,125 @@
+package com.example.aapremote.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.example.aapremote.model.WorkflowNode
+import com.example.aapremote.presentation.workflows.NodeStdoutState
+
+@Composable
+fun WorkflowNodeItem(
+    node: WorkflowNode,
+    isExpanded: Boolean = false,
+    stdoutState: NodeStdoutState? = null,
+    onToggleExpand: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
+    val job = node.summaryFields.job
+    val isClickable = job != null && onToggleExpand != null
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(
+                    if (isClickable) Modifier.clickable { onToggleExpand?.invoke() }
+                    else Modifier
+                )
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            if (isClickable) {
+                Icon(
+                    imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                    contentDescription = if (isExpanded) "Collapse" else "Expand",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .size(20.dp)
+                        .padding(end = 4.dp)
+                )
+            }
+            Text(
+                text = job?.name ?: if (node.doNotRun) "Skipped" else "Pending",
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+            if (job != null) {
+                JobStatusBadge(status = job.status)
+            } else if (node.doNotRun) {
+                Text(
+                    text = "Skipped",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        AnimatedVisibility(visible = isExpanded && job != null) {
+            when (stdoutState) {
+                is NodeStdoutState.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                    }
+                }
+                is NodeStdoutState.Loaded -> {
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                        shape = MaterialTheme.shapes.small,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 4.dp)
+                    ) {
+                        Text(
+                            text = stdoutState.stdout,
+                            style = MaterialTheme.typography.bodySmall.copy(
+                                fontFamily = FontFamily.Monospace
+                            ),
+                            modifier = Modifier
+                                .padding(12.dp)
+                                .horizontalScroll(rememberScrollState())
+                        )
+                    }
+                }
+                is NodeStdoutState.Error -> {
+                    Text(
+                        text = stdoutState.message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
+                null -> {}
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/ui/main/TabDefinitions.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/main/TabDefinitions.kt
@@ -29,7 +29,7 @@ sealed class TopLevelTab(
         selectedIcon = Icons.Filled.Description,
         segments = listOf(
             Segment(label = "Job Templates", isDefault = true, isImplemented = true),
-            Segment(label = "Workflow Templates")
+            Segment(label = "Workflow Templates", isImplemented = true)
         )
     )
 

--- a/app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowJobStatusScreen.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowJobStatusScreen.kt
@@ -1,0 +1,227 @@
+package com.example.aapremote.ui.workflows
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.aapremote.model.WorkflowJob
+import com.example.aapremote.model.WorkflowNode
+import com.example.aapremote.presentation.workflows.NodeStdoutState
+import com.example.aapremote.presentation.workflows.WorkflowJobStatusUiState
+import com.example.aapremote.presentation.workflows.WorkflowJobStatusViewModel
+import com.example.aapremote.ui.components.ErrorMessage
+import com.example.aapremote.ui.components.JobStatusBadge
+import com.example.aapremote.ui.components.WorkflowNodeItem
+import org.koin.compose.viewmodel.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WorkflowJobStatusScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: WorkflowJobStatusViewModel = koinViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val expandedNodeId by viewModel.expandedNodeId.collectAsStateWithLifecycle()
+    val nodeStdout by viewModel.nodeStdout.collectAsStateWithLifecycle()
+
+    DisposableEffect(Unit) {
+        viewModel.startPolling()
+        onDispose { viewModel.stopPolling() }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Workflow Job Status") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            when (val state = uiState) {
+                is WorkflowJobStatusUiState.Loading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+                is WorkflowJobStatusUiState.Error -> {
+                    ErrorMessage(
+                        message = state.message,
+                        onRetry = { viewModel.retry() },
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+                is WorkflowJobStatusUiState.Active -> {
+                    WorkflowJobDetailContent(
+                        workflowJob = state.workflowJob,
+                        nodes = state.nodes,
+                        isActive = true,
+                        expandedNodeId = expandedNodeId,
+                        nodeStdout = nodeStdout,
+                        onToggleNode = { jobId -> viewModel.toggleNodeExpansion(jobId) }
+                    )
+                }
+                is WorkflowJobStatusUiState.Completed -> {
+                    WorkflowJobDetailContent(
+                        workflowJob = state.workflowJob,
+                        nodes = state.nodes,
+                        isActive = false,
+                        expandedNodeId = expandedNodeId,
+                        nodeStdout = nodeStdout,
+                        onToggleNode = { jobId -> viewModel.toggleNodeExpansion(jobId) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WorkflowJobDetailContent(
+    workflowJob: WorkflowJob,
+    nodes: List<WorkflowNode>,
+    isActive: Boolean,
+    expandedNodeId: Int?,
+    nodeStdout: Map<Int, NodeStdoutState>,
+    onToggleNode: (Int) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(
+                        text = workflowJob.name,
+                        style = MaterialTheme.typography.headlineSmall
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "Template: ${workflowJob.workflowJobTemplateName}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        JobStatusBadge(status = workflowJob.status)
+                        if (isActive) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.padding(start = 8.dp),
+                                strokeWidth = 2.dp
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("Details", style = MaterialTheme.typography.titleMedium)
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    workflowJob.started?.let { started ->
+                        DetailRow("Started", started)
+                    }
+                    workflowJob.finished?.let { finished ->
+                        DetailRow("Finished", finished)
+                    }
+                    workflowJob.elapsed?.let { elapsed ->
+                        DetailRow("Elapsed", String.format("%.1f seconds", elapsed))
+                    }
+                    DetailRow("Job ID", "#${workflowJob.id}")
+                }
+            }
+        }
+
+        if (nodes.isNotEmpty()) {
+            item {
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = "Sub-Jobs",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 8.dp)
+                )
+            }
+
+            item {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        nodes.forEachIndexed { index, node ->
+                            val jobId = node.summaryFields.job?.id
+                            WorkflowNodeItem(
+                                node = node,
+                                isExpanded = jobId != null && jobId == expandedNodeId,
+                                stdoutState = jobId?.let { nodeStdout[it] },
+                                onToggleExpand = jobId?.let { id -> { onToggleNode(id) } }
+                            )
+                            if (index < nodes.lastIndex) {
+                                HorizontalDivider()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowTemplateListItem.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowTemplateListItem.kt
@@ -1,0 +1,104 @@
+package com.example.aapremote.ui.workflows
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.example.aapremote.model.WorkflowJobTemplate
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun WorkflowTemplateListItem(
+    template: WorkflowJobTemplate,
+    onLaunch: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ElevatedCard(
+        onClick = onLaunch,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = template.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                if (template.description.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = template.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                val labels = template.summaryFields.labels.results
+                if (labels.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        labels.forEach { label ->
+                            SuggestionChip(
+                                onClick = {},
+                                label = {
+                                    Text(
+                                        text = label.name,
+                                        style = MaterialTheme.typography.labelSmall
+                                    )
+                                },
+                                border = AssistChipDefaults.assistChipBorder(enabled = true)
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (template.summaryFields.userCapabilities.start) {
+                IconButton(
+                    onClick = onLaunch,
+                    modifier = Modifier.size(48.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.PlayArrow,
+                        contentDescription = "Launch ${template.name}",
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowTemplateListScreen.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowTemplateListScreen.kt
@@ -1,0 +1,201 @@
+package com.example.aapremote.ui.workflows
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.aapremote.model.Label
+import com.example.aapremote.presentation.workflows.WorkflowLaunchState
+import com.example.aapremote.presentation.workflows.WorkflowTemplatesUiState
+import com.example.aapremote.presentation.workflows.WorkflowTemplatesViewModel
+import com.example.aapremote.ui.components.ErrorMessage
+import com.example.aapremote.ui.components.ExtraVarsDialog
+import com.example.aapremote.ui.components.LabelChips
+import com.example.aapremote.ui.components.LaunchConfirmDialog
+import com.example.aapremote.ui.components.SearchBar
+import com.example.aapremote.ui.components.SkeletonCard
+import org.koin.compose.viewmodel.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WorkflowTemplateListScreen(
+    onNavigateToWorkflowJobStatus: (Int) -> Unit,
+    viewModel: WorkflowTemplatesViewModel = koinViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val launchState by viewModel.launchState.collectAsStateWithLifecycle()
+    var selectedLabel by remember { mutableStateOf<Label?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    var isRefreshing by remember { mutableStateOf(false) }
+
+    LaunchedEffect(uiState) {
+        if (uiState is WorkflowTemplatesUiState.Success || uiState is WorkflowTemplatesUiState.Error) {
+            isRefreshing = false
+        }
+    }
+
+    LaunchedEffect(launchState) {
+        when (val state = launchState) {
+            is WorkflowLaunchState.Launched -> {
+                viewModel.resetLaunchState()
+                onNavigateToWorkflowJobStatus(state.workflowJobId)
+            }
+            is WorkflowLaunchState.LaunchError -> {
+                snackbarHostState.showSnackbar(state.message)
+                viewModel.resetLaunchState()
+            }
+            else -> {}
+        }
+    }
+
+    // Launch dialogs
+    when (val state = launchState) {
+        is WorkflowLaunchState.Confirming -> {
+            LaunchConfirmDialog(
+                templateName = state.template.name,
+                onConfirm = { viewModel.confirmLaunch() },
+                onDismiss = { viewModel.cancelLaunch() }
+            )
+        }
+        is WorkflowLaunchState.EnteringVars -> {
+            ExtraVarsDialog(
+                templateName = state.template.name,
+                onConfirm = { extraVars -> viewModel.confirmLaunch(extraVars) },
+                onDismiss = { viewModel.cancelLaunch() }
+            )
+        }
+        else -> {}
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            when (val state = uiState) {
+                is WorkflowTemplatesUiState.Idle, is WorkflowTemplatesUiState.Loading -> {
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(5) { SkeletonCard() }
+                    }
+                }
+                is WorkflowTemplatesUiState.Error -> {
+                    ErrorMessage(
+                        message = state.message,
+                        onRetry = { viewModel.loadTemplates() },
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+                is WorkflowTemplatesUiState.Success -> {
+                    SearchBar(onSearch = { viewModel.search(it) })
+
+                    LabelChips(
+                        labels = state.availableLabels,
+                        selectedLabel = selectedLabel,
+                        onLabelSelected = { label ->
+                            selectedLabel = label
+                            viewModel.filterByLabel(label)
+                        }
+                    )
+
+                    PullToRefreshBox(
+                        isRefreshing = isRefreshing,
+                        onRefresh = {
+                            isRefreshing = true
+                            viewModel.refresh()
+                        },
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        if (state.templates.isEmpty()) {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = "No workflow templates available",
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        } else {
+                            val listState = rememberLazyListState()
+
+                            // Load more when reaching the end
+                            if (state.hasMore) {
+                                val shouldLoadMore by remember {
+                                    derivedStateOf {
+                                        val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                                        state.templates.size > 3 && lastVisibleItem >= state.templates.size - 3
+                                    }
+                                }
+
+                                LaunchedEffect(shouldLoadMore) {
+                                    if (shouldLoadMore) viewModel.loadMore()
+                                }
+                            }
+
+                            LazyColumn(
+                                state = listState,
+                                modifier = Modifier.fillMaxSize()
+                            ) {
+                                items(
+                                    items = state.templates,
+                                    key = { it.id }
+                                ) { template ->
+                                    WorkflowTemplateListItem(
+                                        template = template,
+                                        onLaunch = { viewModel.requestLaunch(template) }
+                                    )
+                                }
+
+                                if (state.isLoadingMore) {
+                                    item {
+                                        LinearProgressIndicator(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(16.dp)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Show loading overlay during launch
+            if (launchState is WorkflowLaunchState.Launching) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
+    }
+}

--- a/specs/004-workflow-templates/checklists/requirements.md
+++ b/specs/004-workflow-templates/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Workflow Templates Support
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-03  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- Workflow templates follow the same patterns as existing job templates, so reasonable defaults were applied for search, filtering, pagination, and card design.
+- Assumption documented that workflow job stdout may not be available (workflows orchestrate sub-jobs).
+- The API endpoint paths are mentioned in assumptions (not in requirements) as they inform scope, not implementation.

--- a/specs/004-workflow-templates/contracts/api-endpoints.md
+++ b/specs/004-workflow-templates/contracts/api-endpoints.md
@@ -1,0 +1,193 @@
+# API Contracts: Workflow Templates
+
+**Feature**: 004-workflow-templates | **Date**: 2026-04-03
+
+All endpoints use the existing base URL + `/api/v2/` prefix configured in `AapApiService`.
+All requests include `Authorization: Bearer <TOKEN>` via the existing `AuthInterceptor`.
+
+## Endpoints
+
+### 1. List Workflow Job Templates
+
+```
+GET workflow_job_templates/
+```
+
+**Query Parameters** (same pattern as job_templates):
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| page | Int | 1 | Page number |
+| page_size | Int | 25 | Results per page |
+| search | String? | null | Name search filter |
+| labels__name__icontains | String? | null | Label name filter |
+| order_by | String | -modified | Sort order |
+
+**Response**: `PaginatedResponse<WorkflowJobTemplate>`
+
+```json
+{
+  "count": 42,
+  "next": "https://aap.example.com/api/v2/workflow_job_templates/?page=2",
+  "previous": null,
+  "results": [
+    {
+      "id": 10,
+      "name": "Deploy Full Stack",
+      "description": "Deploys frontend and backend",
+      "ask_variables_on_launch": true,
+      "status": "successful",
+      "last_job_run": "2026-04-01T12:00:00Z",
+      "summary_fields": {
+        "labels": {
+          "count": 1,
+          "results": [{"id": 1, "name": "production"}]
+        },
+        "user_capabilities": {
+          "start": true
+        }
+      }
+    }
+  ]
+}
+```
+
+### 2. Launch Workflow Job Template
+
+```
+POST workflow_job_templates/{id}/launch/
+```
+
+**Path Parameters**: `id` (Int) — workflow job template ID
+
+**Request Body**: `LaunchRequest` (reused)
+
+```json
+{
+  "extra_vars": "{\"env\": \"staging\"}"
+}
+```
+
+**Response**: `WorkflowLaunchResponse`
+
+```json
+{
+  "workflow_job": 123,
+  "id": 123,
+  "status": "pending"
+}
+```
+
+**Error Responses**:
+- 400: Invalid extra variables
+- 403: User lacks launch permission
+- 404: Template not found
+
+### 3. Get Workflow Job Status
+
+```
+GET workflow_jobs/{id}/
+```
+
+**Path Parameters**: `id` (Int) — workflow job ID
+
+**Response**: `WorkflowJob`
+
+```json
+{
+  "id": 123,
+  "name": "Deploy Full Stack",
+  "status": "running",
+  "failed": false,
+  "started": "2026-04-03T10:00:00Z",
+  "finished": null,
+  "elapsed": 45.2,
+  "summary_fields": {
+    "workflow_job_template": {
+      "id": 10,
+      "name": "Deploy Full Stack"
+    }
+  }
+}
+```
+
+### 4. Get Workflow Nodes (Sub-Jobs)
+
+```
+GET workflow_jobs/{id}/workflow_nodes/
+```
+
+**Path Parameters**: `id` (Int) — workflow job ID
+
+**Response**: `PaginatedResponse<WorkflowNode>`
+
+```json
+{
+  "count": 3,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "do_not_run": false,
+      "summary_fields": {
+        "job": {
+          "id": 456,
+          "name": "Deploy Frontend",
+          "status": "successful",
+          "type": "job"
+        }
+      }
+    },
+    {
+      "id": 2,
+      "do_not_run": false,
+      "summary_fields": {
+        "job": {
+          "id": 457,
+          "name": "Deploy Backend",
+          "status": "running",
+          "type": "job"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "do_not_run": true,
+      "summary_fields": {
+        "job": null
+      }
+    }
+  ]
+}
+```
+
+## Retrofit Interface Additions
+
+```kotlin
+// Add to AapApiService.kt:
+
+@GET("workflow_job_templates/")
+suspend fun getWorkflowJobTemplates(
+    @Query("page") page: Int = 1,
+    @Query("page_size") pageSize: Int = 25,
+    @Query("search") search: String? = null,
+    @Query("labels__name__icontains") labelsFilter: String? = null,
+    @Query("order_by") orderBy: String = "-modified"
+): PaginatedResponse<WorkflowJobTemplate>
+
+@POST("workflow_job_templates/{id}/launch/")
+suspend fun launchWorkflowJob(
+    @Path("id") id: Int,
+    @Body request: LaunchRequest = LaunchRequest()
+): WorkflowLaunchResponse
+
+@GET("workflow_jobs/{id}/")
+suspend fun getWorkflowJob(@Path("id") id: Int): WorkflowJob
+
+@GET("workflow_jobs/{id}/workflow_nodes/")
+suspend fun getWorkflowNodes(
+    @Path("id") id: Int,
+    @Query("page_size") pageSize: Int = 200
+): PaginatedResponse<WorkflowNode>
+```

--- a/specs/004-workflow-templates/data-model.md
+++ b/specs/004-workflow-templates/data-model.md
@@ -1,0 +1,121 @@
+# Data Model: Workflow Templates Support
+
+**Feature**: 004-workflow-templates | **Date**: 2026-04-03
+
+## Entities
+
+### WorkflowJobTemplate
+
+Represents a workflow job template from the AAP instance. Mirrors `JobTemplate` structure.
+
+| Field | Type | Source JSON | Default | Notes |
+|-------|------|-------------|---------|-------|
+| id | Int | `id` | required | Unique template identifier |
+| name | String | `name` | required | Display name |
+| description | String | `description` | `""` | Optional description text |
+| askVariablesOnLaunch | Boolean | `ask_variables_on_launch` | `false` | Whether to prompt for extra vars |
+| status | String? | `status` | `null` | Last run status (may be null) |
+| lastJobRun | String? | `last_job_run` | `null` | ISO timestamp of last run |
+| summaryFields | WorkflowTemplateSummaryFields | `summary_fields` | default | Nested labels + capabilities |
+
+**Nested: WorkflowTemplateSummaryFields**
+
+| Field | Type | Source JSON | Default |
+|-------|------|-------------|---------|
+| labels | LabelSummary | `labels` | `LabelSummary()` |
+| userCapabilities | UserCapabilities | `user_capabilities` | `UserCapabilities()` |
+
+Reuses existing `LabelSummary`, `Label`, and `UserCapabilities` model classes.
+
+### WorkflowJob
+
+Represents a running or completed workflow job instance.
+
+| Field | Type | Source JSON | Default | Notes |
+|-------|------|-------------|---------|-------|
+| id | Int | `id` | required | Unique job identifier |
+| name | String | `name` | `""` | Job name |
+| status | JobStatus | `status` | required | Reuses existing JobStatus enum |
+| failed | Boolean | `failed` | `false` | Whether the job failed |
+| started | String? | `started` | `null` | ISO timestamp |
+| finished | String? | `finished` | `null` | ISO timestamp |
+| elapsed | Double? | `elapsed` | `null` | Duration in seconds |
+| summaryFields | WorkflowJobSummaryFields | `summary_fields` | default | Nested template ref |
+
+**Nested: WorkflowJobSummaryFields**
+
+| Field | Type | Source JSON | Default |
+|-------|------|-------------|---------|
+| workflowJobTemplate | WorkflowJobTemplateRef? | `workflow_job_template` | `null` |
+
+**Nested: WorkflowJobTemplateRef**
+
+| Field | Type | Source JSON | Default |
+|-------|------|-------------|---------|
+| id | Int | `id` | required |
+| name | String | `name` | required |
+
+### WorkflowNode
+
+Represents a sub-job (node) within a workflow job execution.
+
+| Field | Type | Source JSON | Default | Notes |
+|-------|------|-------------|---------|-------|
+| id | Int | `id` | required | Node identifier |
+| summaryFields | WorkflowNodeSummaryFields | `summary_fields` | default | Contains job details |
+| doNotRun | Boolean | `do_not_run` | `false` | Whether node was skipped |
+
+**Nested: WorkflowNodeSummaryFields**
+
+| Field | Type | Source JSON | Default |
+|-------|------|-------------|---------|
+| job | WorkflowNodeJob? | `job` | `null` |
+
+**Nested: WorkflowNodeJob**
+
+| Field | Type | Source JSON | Default |
+|-------|------|-------------|---------|
+| id | Int | `id` | required |
+| name | String | `name` | required |
+| status | JobStatus | `status` | required |
+| type | String | `type` | `""` |
+
+### WorkflowLaunchResponse
+
+Response from launching a workflow template.
+
+| Field | Type | Source JSON | Default | Notes |
+|-------|------|-------------|---------|-------|
+| workflowJob | Int | `workflow_job` | required | The created workflow job ID |
+| id | Int | `id` | required | Same as workflow_job |
+| status | String | `status` | `""` | Initial status |
+
+## Reused Entities (no changes needed)
+
+- **PaginatedResponse<T>** — generic paginated response wrapper (already parameterized)
+- **Label** — label chip data (id, name)
+- **LabelSummary** — label count + results list
+- **UserCapabilities** — user permission flags (start boolean)
+- **LaunchRequest** — launch body with extra_vars (reused for workflow launches)
+- **JobStatus** — status enum (same values for workflow jobs)
+
+## State Transitions
+
+### WorkflowJob Status Flow
+
+```
+NEW → PENDING → WAITING → RUNNING → SUCCESSFUL
+                                   → FAILED
+                                   → ERROR
+                    (any active) → CANCELED
+```
+
+Same as regular Job — reuses `JobStatus` enum with `isActive` and `isTerminal` properties.
+
+## Relationships
+
+```
+WorkflowJobTemplate  --launches-->  WorkflowJob
+WorkflowJob          --contains-->  WorkflowNode (1:many)
+WorkflowNode         --references--> Job (via summary_fields.job)
+```

--- a/specs/004-workflow-templates/plan.md
+++ b/specs/004-workflow-templates/plan.md
@@ -1,0 +1,87 @@
+# Implementation Plan: Workflow Templates Support
+
+**Branch**: `004-workflow-templates` | **Date**: 2026-04-03 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/004-workflow-templates/spec.md`
+
+## Summary
+
+Add workflow job template browsing, search/filter, launching, and job status monitoring to the existing "Workflow Templates" segment under the Templates tab. The implementation mirrors the existing job templates pattern (TemplateRepository → TemplatesViewModel → TemplateListScreen) with workflow-specific models, a new repository, ViewModel, and screens. A workflow job status screen displays sub-jobs (workflow nodes). Workflow jobs also appear in the Activity > Jobs list via the AAP unified jobs endpoint.
+
+## Technical Context
+
+**Language/Version**: Kotlin (latest stable, targeting JVM 17)
+**Primary Dependencies**: Jetpack Compose (Material 3 BOM), Navigation Compose, Retrofit + Kotlin Serialization, Koin
+**Storage**: DataStore + Tink (unchanged — no new storage needs)
+**Testing**: Manual verification in Android Studio (no automated test framework in project)
+**Target Platform**: Android (minSdk 31, compileSdk 35)
+**Project Type**: Mobile app (Android)
+**Performance Goals**: List loads within 2 seconds, search results update within 500ms
+**Constraints**: HTTPS-only, single ComponentActivity, no Fragments/XML
+**Scale/Scope**: ~10 new/modified files, follows existing patterns exactly
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Kotlin-Only | PASS | All new code in Kotlin |
+| II. Compose-First UI | PASS | All UI in Jetpack Compose with Material 3 |
+| III. MVVM + UDF | PASS | New ViewModel with StateFlow, sealed UiState |
+| IV. Security-First | PASS | No new credential handling; reuses existing auth interceptor |
+| V. Lean Dependencies | PASS | No new dependencies — reuses Retrofit, Koin, Compose |
+| VI. API-Driven | PASS | New endpoints added to AapApiService Retrofit interface |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-workflow-templates/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+app/src/main/kotlin/com/example/aapremote/
+├── model/
+│   ├── WorkflowJobTemplate.kt      # NEW — data class for workflow templates
+│   ├── WorkflowJob.kt              # NEW — data class for workflow jobs
+│   └── WorkflowNode.kt             # NEW — data class for workflow nodes (sub-jobs)
+├── network/
+│   └── AapApiService.kt            # MODIFIED — add workflow endpoints
+├── data/
+│   ├── WorkflowRepository.kt       # NEW — workflow template + job API calls
+│   └── DataModule.kt               # MODIFIED — register WorkflowRepository
+├── presentation/
+│   ├── workflows/
+│   │   ├── WorkflowTemplatesViewModel.kt   # NEW — list/search/filter/launch
+│   │   ├── WorkflowTemplatesUiState.kt     # NEW — sealed UI state
+│   │   ├── WorkflowJobStatusUiState.kt     # NEW — sealed UI state for status screen
+│   │   └── WorkflowJobStatusViewModel.kt   # NEW — workflow job status polling + sub-job stdout
+│   └── PresentationModule.kt       # MODIFIED — register new ViewModels
+├── ui/
+│   ├── workflows/
+│   │   ├── WorkflowTemplateListScreen.kt   # NEW — list screen (mirrors TemplateListScreen)
+│   │   ├── WorkflowTemplateListItem.kt     # NEW — card component
+│   │   └── WorkflowJobStatusScreen.kt      # NEW — status with sub-jobs list
+│   └── components/
+│       └── WorkflowNodeItem.kt             # NEW — expandable sub-job row with inline stdout
+├── navigation/
+│   ├── MainNavigation.kt           # MODIFIED — route Workflow Templates segment
+│   └── AppNavigation.kt            # MODIFIED — add workflow job status route
+└── ui/main/
+    └── TabDefinitions.kt           # MODIFIED — mark Workflow Templates as implemented
+```
+
+**Structure Decision**: Follows existing feature-based packaging within each layer. Workflow-specific files go in `workflows/` packages mirroring the `templates/` and `jobs/` pattern. Shared components (SearchBar, LabelChips, SkeletonCard, ExtraVarsDialog, LaunchConfirmDialog) are reused from `ui/components/`.
+
+## Complexity Tracking
+
+No constitution violations to justify. All patterns mirror existing implementations.

--- a/specs/004-workflow-templates/quickstart.md
+++ b/specs/004-workflow-templates/quickstart.md
@@ -1,0 +1,77 @@
+# Quickstart: Workflow Templates Support
+
+**Feature**: 004-workflow-templates | **Date**: 2026-04-03
+
+## Integration Scenarios
+
+### Scenario 1: Browse Workflow Templates
+
+1. User logs in and navigates to Templates tab
+2. User taps "Workflow Templates" segment
+3. Skeleton loading cards display while data loads
+4. Workflow templates appear with name, description, and label chips
+5. User scrolls to bottom — more templates load automatically
+
+**Key files**: `WorkflowTemplateListScreen.kt`, `WorkflowTemplatesViewModel.kt`, `WorkflowRepository.kt`
+
+### Scenario 2: Search and Filter
+
+1. User types in search bar — list filters after 300ms debounce
+2. User taps a label chip — list filters to that label
+3. User clears filter — full list restores
+
+**Key files**: `WorkflowTemplatesViewModel.kt` (search/filterByLabel methods)
+
+### Scenario 3: Launch Workflow Template
+
+1. User taps play button on a workflow template card
+2. If `askVariablesOnLaunch` is true → ExtraVarsDialog appears first
+3. LaunchConfirmDialog appears → user confirms
+4. App calls `POST workflow_job_templates/{id}/launch/`
+5. On success → navigates to WorkflowJobStatusScreen with returned workflow_job ID
+6. On error → snackbar shows error message
+
+**Key files**: `WorkflowTemplatesViewModel.kt`, `WorkflowRepository.kt`, `AppNavigation.kt`
+
+### Scenario 4: Monitor Workflow Job Status
+
+1. WorkflowJobStatusScreen loads with workflow job ID from navigation argument
+2. Polls `GET workflow_jobs/{id}/` every 5 seconds while job is active
+3. Also fetches `GET workflow_jobs/{id}/workflow_nodes/` to show sub-jobs
+4. Displays: job name, status badge, template name, start/finish times, elapsed time
+5. Sub-jobs section shows list of workflow nodes with name and status badge
+6. Tap any sub-job to expand it inline and view its stdout output (fetched on demand, cached)
+7. Tap the expanded sub-job again to collapse it
+8. When job reaches terminal status, polling stops
+
+**Key files**: `WorkflowJobStatusScreen.kt`, `WorkflowJobStatusViewModel.kt`, `WorkflowRepository.kt`
+
+### Scenario 5: Workflow Jobs in Activity Tab
+
+1. User navigates to Activity > Jobs
+2. Existing RecentJobsScreen loads jobs from `GET /api/v2/jobs/`
+3. Workflow jobs appear alongside regular jobs (AAP includes them in unified response)
+4. No code changes needed — the existing endpoint already returns workflow jobs
+
+**Key files**: No changes — existing `RecentJobsScreen` and `JobRepository` handle this automatically.
+
+## Build Sequence
+
+1. **Models** — WorkflowJobTemplate, WorkflowJob, WorkflowNode, WorkflowLaunchResponse
+2. **API** — Add 4 endpoints to AapApiService
+3. **Repository** — WorkflowRepository with list/launch/status/nodes methods
+4. **DI** — Register WorkflowRepository and ViewModels in Koin modules
+5. **ViewModels** — WorkflowTemplatesViewModel + WorkflowJobStatusViewModel
+6. **UI** — WorkflowTemplateListItem, WorkflowTemplateListScreen, WorkflowNodeItem, WorkflowJobStatusScreen
+7. **Navigation** — Wire segment routing + workflow job status route
+8. **Tab** — Mark "Workflow Templates" segment as implemented
+
+## Shared Components (reused, no changes)
+
+- `SearchBar` — search input with debounce
+- `LabelChips` — horizontal label filter chips
+- `SkeletonCard` — shimmer loading placeholder
+- `LaunchConfirmDialog` — launch confirmation dialog
+- `ExtraVarsDialog` — extra variables input dialog
+- `ErrorMessage` — error display with retry button
+- `JobStatusBadge` — status indicator chip (reusable for workflow job statuses)

--- a/specs/004-workflow-templates/research.md
+++ b/specs/004-workflow-templates/research.md
@@ -1,0 +1,76 @@
+# Research: Workflow Templates Support
+
+**Feature**: 004-workflow-templates | **Date**: 2026-04-03
+
+## Research Tasks
+
+### 1. Workflow Job Templates API Structure
+
+**Decision**: The AAP `/api/v2/workflow_job_templates/` endpoint follows the same paginated response pattern as `/api/v2/job_templates/`. The response includes `count`, `next`, `previous`, and `results` fields. Each result has `id`, `name`, `description`, `ask_variables_on_launch`, and `summary_fields` (containing `labels` and `user_capabilities` with `start` boolean).
+
+**Rationale**: The AAP Controller API is consistent across resource types. Workflow job templates use the same pagination, filtering (`search`, `labels__name__icontains`), and ordering (`order_by`) query parameters as job templates. This was confirmed by the spec assumptions and AAP API v2 documentation patterns.
+
+**Alternatives considered**:
+- Custom pagination implementation → rejected; reuse existing `PaginatedResponse<T>` generic
+- Different query parameter names → not needed; AAP uses the same parameter names across template types
+
+### 2. Workflow Job Templates Launch API
+
+**Decision**: Launch endpoint is `POST /api/v2/workflow_job_templates/{id}/launch/`. It accepts the same `extra_vars` body parameter as job template launch. The response returns a `workflow_job` field (integer ID) instead of `job` field.
+
+**Rationale**: AAP API uses a consistent launch pattern but returns the job reference under a type-specific key. The existing `LaunchRequest` model can be reused. A new `WorkflowLaunchResponse` model is needed for the different response key.
+
+**Alternatives considered**:
+- Reuse `LaunchResponse` with nullable fields → rejected; cleaner to have a dedicated response model for the different field name
+- Unified launch response with `@JsonNames` → adds complexity; separate model is simpler
+
+### 3. Workflow Job Status API
+
+**Decision**: Workflow job status is at `GET /api/v2/workflow_jobs/{id}/`. Response fields mirror regular jobs: `id`, `name`, `status`, `failed`, `started`, `finished`, `elapsed`, `summary_fields`. The `status` field uses the same enum values as regular jobs (new, pending, waiting, running, successful, failed, error, canceled).
+
+**Rationale**: The existing `JobStatus` enum is reusable. A new `WorkflowJob` model is needed because the `summary_fields` structure differs (references `workflow_job_template` instead of `job_template`).
+
+**Alternatives considered**:
+- Reuse `Job` model → rejected; different summary_fields structure and different API endpoint
+- Abstract base class for Job/WorkflowJob → over-engineering; the models are small and simple
+
+### 4. Workflow Nodes (Sub-Jobs) API
+
+**Decision**: Workflow nodes are fetched via `GET /api/v2/workflow_jobs/{id}/workflow_nodes/`. Returns paginated list of nodes, each with `id`, `job` (reference to the actual sub-job ID), and `summary_fields` containing `job` with `id`, `name`, `status`, `type` (e.g., "job", "project_update"). The node also has `do_not_run` and `unified_job_template` fields.
+
+**Rationale**: To display sub-job names and statuses as specified in FR-015, we need the workflow_nodes endpoint. The `summary_fields.job` contains the displayable name and status without requiring a separate API call per node.
+
+**Alternatives considered**:
+- Fetch each sub-job individually via `/api/v2/jobs/{id}/` → rejected; N+1 query problem, workflow_nodes endpoint provides all needed data in one call
+- Use `workflow_jobs/{id}/` response's `related.workflow_nodes` URL → same endpoint, just a different way to discover it
+
+### 5. Unified Jobs Endpoint for Activity Tab
+
+**Decision**: The existing `GET /api/v2/jobs/` endpoint in AAP already returns both regular jobs and workflow jobs in a unified list. The `type` field distinguishes them (`job` vs `workflow_job`). No additional endpoint needed for FR-016.
+
+**Rationale**: AAP's `/api/v2/jobs/` is actually the unified jobs endpoint that includes all job types. The current `RecentJobsScreen` will automatically show workflow jobs once they exist on the server. However, the `Job` model may need a `type` field to distinguish them in the UI, and the `summary_fields` for workflow jobs will reference `workflow_job_template` instead of `job_template`.
+
+**Alternatives considered**:
+- Separate API call to `/api/v2/workflow_jobs/` merged client-side → rejected; unnecessary complexity when `/api/v2/jobs/` already includes them
+- `/api/v2/unified_jobs/` endpoint → this is the actual name in some AAP versions, but `/api/v2/jobs/` works equivalently for our needs
+
+### 6. Workflow Job Status Screen - Stdout Handling
+
+**Decision**: Workflow jobs do not produce stdout directly (they orchestrate sub-jobs). The workflow job status screen will not attempt to fetch stdout. Individual sub-job stdout could be viewed by navigating to the sub-job's regular job status screen (future enhancement).
+
+**Rationale**: Per spec assumption: "Workflow job stdout output may not be available." The status screen focuses on showing overall workflow status and sub-job statuses.
+
+**Alternatives considered**:
+- Fetch stdout for each sub-job → scope creep; deferred to potential future enhancement
+- Show "No output available" placeholder → acceptable fallback if stdout endpoint returns empty/error
+
+### 7. Polling Strategy for Workflow Job Status
+
+**Decision**: Reuse the same 5-second polling interval as `JobRepository.pollJobStatus()`. Poll both the workflow job status and workflow nodes in parallel during each poll cycle.
+
+**Rationale**: Consistent with existing job status polling. Workflow jobs may run longer, but the polling interval is already reasonable. Fetching nodes on each poll ensures sub-job status updates are reflected.
+
+**Alternatives considered**:
+- WebSocket-based updates → AAP doesn't expose WebSocket for job status; polling is the standard approach
+- Longer polling interval for workflows → unnecessary differentiation; 5 seconds is fine
+- Poll nodes separately at different interval → adds complexity for minimal benefit

--- a/specs/004-workflow-templates/spec.md
+++ b/specs/004-workflow-templates/spec.md
@@ -1,0 +1,153 @@
+# Feature Specification: Workflow Templates Support
+
+**Feature Branch**: `004-workflow-templates`  
+**Created**: 2026-04-03  
+**Status**: Draft  
+**Input**: GitHub issue #4 — Add Workflow Templates support
+
+## Clarifications
+
+### Session 2026-04-03
+
+- Q: Should the workflow job status screen show sub-job details? → A: Show top-level status plus a simple list of sub-jobs with their individual statuses. Visual node graph deferred to issue #9.
+- Q: Should workflow jobs appear in the Activity > Jobs list? → A: Yes, show workflow jobs alongside regular jobs in Activity > Jobs.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Browse Workflow Templates (Priority: P1)
+
+As a user on the Templates tab, I can switch to the "Workflow Templates" segment and see a list of workflow job templates from my AAP instance. Each template shows its name, description, and labels. I can scroll through the list with pagination loading more templates as I reach the bottom.
+
+**Why this priority**: Browsing is the foundational interaction — users need to see what workflow templates exist before they can do anything with them. This replaces the current placeholder screen with real content.
+
+**Independent Test**: Can be tested by logging in, navigating to Templates > Workflow Templates, and verifying the list displays workflow templates from the AAP server with names, descriptions, and labels.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the Templates tab, **When** they tap the "Workflow Templates" segment, **Then** the content switches to show a list of workflow job templates from the connected AAP instance.
+2. **Given** the user is viewing the workflow templates list, **When** templates are loading, **Then** skeleton loading placeholders are displayed instead of a spinner.
+3. **Given** the user has scrolled near the bottom of the list, **When** more templates are available, **Then** additional templates load automatically (pagination).
+4. **Given** there are no workflow templates on the server, **When** the list loads, **Then** an empty state message "No workflow templates available" is displayed.
+
+---
+
+### User Story 2 - Search and Filter Workflow Templates (Priority: P1)
+
+As a user viewing the workflow templates list, I can search by name and filter by label to find specific workflow templates, just like I do with job templates.
+
+**Why this priority**: With many workflow templates, users need search and filter to find what they need quickly. This matches the existing job templates experience and is essential for usability.
+
+**Independent Test**: Can be tested by typing in the search bar and verifying results filter, and by tapping label chips to filter by label.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the workflow templates list, **When** they type in the search bar, **Then** the list filters to show only templates matching the search query.
+2. **Given** workflow templates have labels, **When** the user taps a label chip, **Then** the list filters to show only templates with that label.
+3. **Given** the user has an active search or filter, **When** they clear it, **Then** the full template list is restored.
+
+---
+
+### User Story 3 - Launch Workflow Template (Priority: P1)
+
+As a user, I can launch a workflow template directly from the list. If the template requires extra variables, I am prompted to enter them before launch. After launching, I am navigated to a workflow job status screen to monitor progress.
+
+**Why this priority**: Launching workflows is the primary action users want to take. Without it, the workflow templates list is view-only and limited in value.
+
+**Independent Test**: Can be tested by tapping a workflow template's launch button, confirming the launch dialog, and verifying navigation to the workflow job status screen.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has permission to launch a workflow template, **When** they tap the play button on a template card, **Then** a confirmation dialog appears asking to confirm the launch.
+2. **Given** a workflow template requires extra variables, **When** the user taps launch, **Then** an extra variables input dialog appears before the confirmation.
+3. **Given** the user confirms the launch, **When** the workflow job is created successfully, **Then** the user is navigated to the workflow job status screen.
+4. **Given** the user does not have permission to launch, **When** they view the template card, **Then** no launch button is displayed.
+
+---
+
+### User Story 4 - Monitor Workflow Job Status (Priority: P2)
+
+As a user who has launched a workflow template, I can view the workflow job status screen showing the job's current state, progress, and details. The status updates automatically while the job is running.
+
+**Why this priority**: Monitoring job status completes the launch-and-track loop. Without it, users launch workflows blindly with no feedback. It is P2 because users can still see workflow jobs in the Activity > Jobs list as a workaround.
+
+**Independent Test**: Can be tested by launching a workflow template and verifying the status screen shows job name, status, elapsed time, and auto-updates while running.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has just launched a workflow template, **When** they are navigated to the status screen, **Then** the workflow job's name, status, and template name are displayed.
+2. **Given** a workflow job is running, **When** the user views the status screen, **Then** the status updates automatically via polling.
+3. **Given** a workflow job has completed (success or failure), **When** the user views the status screen, **Then** the final status, elapsed time, and start/finish timestamps are shown.
+4. **Given** the user is on the workflow job status screen, **When** they view the sub-jobs section, **Then** a list of sub-jobs is displayed with each sub-job's name and current status.
+5. **Given** the user is on the workflow job status screen, **When** they tap a sub-job, **Then** the sub-job expands inline to show its stdout output. Tapping again collapses it.
+6. **Given** the user is on the workflow job status screen, **When** they press back, **Then** they return to the workflow templates list with their previous state preserved.
+
+---
+
+### User Story 5 - Pull-to-Refresh Workflow Templates (Priority: P2)
+
+As a user viewing the workflow templates list, I can pull down to refresh the data and see updated templates from the server.
+
+**Why this priority**: Pull-to-refresh is a standard mobile interaction that users expect, consistent with the job templates and recent jobs lists.
+
+**Independent Test**: Can be tested by pulling down on the workflow templates list and verifying data reloads with a visible refresh indicator.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the workflow templates list, **When** they pull down, **Then** a refresh indicator appears and the list reloads from the server.
+2. **Given** a refresh fails due to a network error, **When** the refresh completes, **Then** an error message is shown and the existing list data is preserved.
+
+---
+
+### Edge Cases
+
+- What happens when the AAP instance does not support workflow templates (older version)? The API will return 404; the app MUST display an appropriate error message (e.g., "Workflow templates are not available on this AAP instance") and MUST NOT crash.
+- What happens when a workflow template launch fails on the server side? An error snackbar should display the server's error message.
+- What happens when the user rotates the device while on the workflow templates list? The list state, search query, selected label, and scroll position should be preserved. *(Handled by architecture: ViewModel survives configuration changes; Compose restores scroll position via LazyListState.)*
+- What happens when a workflow job is launched but the status endpoint returns an error? The status screen should show an error with a retry option.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The "Workflow Templates" segment under the Templates tab MUST display a list of workflow job templates fetched from the AAP instance.
+- **FR-002**: Each workflow template card MUST display the template name, description (if present), labels (as chips), and a launch button (if the user has launch permission).
+- **FR-003**: The workflow templates list MUST support infinite scroll pagination, loading more templates as the user scrolls near the bottom.
+- **FR-004**: The workflow templates list MUST show skeleton loading placeholders during initial data loading.
+- **FR-005**: The workflow templates list MUST support search by template name with 300ms debounced input.
+- **FR-006**: The workflow templates list MUST support filtering by label using label chips.
+- **FR-007**: Users with launch permission MUST be able to launch a workflow template via a confirmation dialog.
+- **FR-008**: If a workflow template requires extra variables on launch, the app MUST present an extra variables input dialog before confirmation.
+- **FR-009**: After a successful launch, the app MUST navigate the user to a workflow job status screen.
+- **FR-010**: The workflow job status screen MUST display the job's name, status, template name, start time, finish time, and elapsed time.
+- **FR-011**: The workflow job status screen MUST poll for status updates while the job is active (running, pending, waiting).
+- **FR-012**: The workflow templates list MUST support pull-to-refresh to reload data from the server.
+- **FR-013**: The workflow template cards MUST use the same enhanced card design (elevated card, typography hierarchy, label chips) as job template cards.
+- **FR-014**: The workflow templates list MUST display an empty state message when no templates are available.
+- **FR-015**: The workflow job status screen MUST display a list of sub-jobs (workflow nodes) with each sub-job's name and current status.
+- **FR-016**: Workflow jobs MUST appear alongside regular jobs in the Activity > Jobs list.
+- **FR-017**: Users MUST be able to tap a sub-job in the workflow job status screen to expand it inline and view its stdout output. Only one sub-job can be expanded at a time. Stdout is fetched on first expansion and cached for the session.
+
+### Key Entities
+
+- **WorkflowJobTemplate**: A workflow template on the AAP instance with a name, description, labels, launch permissions, and an option to require extra variables on launch. Similar structure to a job template but fetched from a different endpoint.
+- **WorkflowJob**: A running or completed instance of a workflow template with a status, timestamps, and associated template reference. Similar to a regular job but tracked at a different endpoint.
+- **WorkflowNode**: A sub-job (workflow node) within a workflow job, representing one step in the workflow's execution. Has a name, status, and reference to the underlying job. In user-facing text, referred to as "sub-job"; in code and API, referred to as "workflow node".
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can browse workflow templates with the same speed and responsiveness as job templates (list loads within 2 seconds on typical connectivity).
+- **SC-002**: Users can search and filter workflow templates and see results update within 500 milliseconds of input.
+- **SC-003**: Users can launch a workflow template and reach the status screen in under 3 interactions (tap launch → confirm → view status).
+- **SC-004**: The workflow job status screen updates automatically while the job runs, with no manual refresh needed.
+- **SC-005**: All existing functionality (job templates, recent jobs, settings, logout) remains unaffected by this addition.
+
+## Assumptions
+
+- The AAP instance supports the workflow job templates API endpoints (`/api/v2/workflow_job_templates/`, `/api/v2/workflow_job_templates/{id}/launch/`, `/api/v2/workflow_jobs/{id}/`).
+- The workflow job templates API response structure is similar to job templates (paginated, with summary_fields containing labels and user_capabilities).
+- The workflow job status API response structure is similar to regular jobs (id, name, status, started, finished, elapsed, summary_fields).
+- The existing authentication token has permissions to access workflow template endpoints — no additional authentication is needed.
+- Workflow jobs do not produce stdout directly (they orchestrate sub-jobs). Individual sub-job stdout is available via the standard job stdout endpoint and is shown inline when a sub-job is expanded.
+- The "Workflow Templates" segment already exists in the TabDefinitions and currently shows a PlaceholderScreen — this feature replaces that placeholder with real content.

--- a/specs/004-workflow-templates/tasks.md
+++ b/specs/004-workflow-templates/tasks.md
@@ -1,0 +1,242 @@
+# Tasks: Workflow Templates Support
+
+**Input**: Design documents from `/specs/004-workflow-templates/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: No automated tests — manual verification in Android Studio per project convention.
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+
+## Phase Mapping
+
+| Phase | User Story | Priority | Description |
+|-------|-----------|----------|-------------|
+| Phase 1 | — | — | Setup: shared models and API endpoints |
+| Phase 2 | — | — | Foundational: repository, DI, navigation wiring |
+| Phase 3 | US1 - Browse Workflow Templates | P1 | ViewModel, list screen, list item, segment routing |
+| Phase 4 | US2 - Search and Filter | P1 | Search/filter in ViewModel (reuses existing UI components) |
+| Phase 5 | US3 - Launch Workflow Template | P1 | Launch flow in ViewModel + navigation to status |
+| Phase 6 | US4 - Monitor Workflow Job Status | P2 | Status ViewModel, status screen with sub-jobs |
+| Phase 7 | US5 - Pull-to-Refresh | P2 | Refresh support in ViewModel + screen |
+| Phase 8 | — | — | Polish: Activity tab integration, empty states, error handling |
+
+---
+
+## Phase 1: Setup (Shared Models & API)
+
+**Purpose**: Create all data models and API endpoints needed across user stories
+
+- [X] T001 [P] Create WorkflowJobTemplate model (with WorkflowTemplateSummaryFields) in app/src/main/kotlin/com/example/aapremote/model/WorkflowJobTemplate.kt
+- [X] T002 [P] Create WorkflowJob model (with WorkflowJobSummaryFields, WorkflowJobTemplateRef) in app/src/main/kotlin/com/example/aapremote/model/WorkflowJob.kt
+- [X] T003 [P] Create WorkflowNode model (with WorkflowNodeSummaryFields, WorkflowNodeJob) in app/src/main/kotlin/com/example/aapremote/model/WorkflowNode.kt
+- [X] T004 [P] Create WorkflowLaunchResponse model in app/src/main/kotlin/com/example/aapremote/model/WorkflowLaunchResponse.kt
+- [X] T005 Add workflow API endpoints (getWorkflowJobTemplates, launchWorkflowJob, getWorkflowJob, getWorkflowNodes) to app/src/main/kotlin/com/example/aapremote/network/AapApiService.kt
+
+**Note**: T005 depends on T001-T004 completing first (return types reference the new models). T001-T004 are parallel.
+
+---
+
+## Phase 2: Foundational (Repository, DI, Navigation)
+
+**Purpose**: Core infrastructure that MUST complete before any user story work
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T006 Create WorkflowRepository with getWorkflowTemplates, launchWorkflow, getWorkflowJobStatus, pollWorkflowJobStatus, and getWorkflowNodes methods in app/src/main/kotlin/com/example/aapremote/data/WorkflowRepository.kt
+- [X] T007 Register WorkflowRepository in Koin dataModule in app/src/main/kotlin/com/example/aapremote/data/DataModule.kt
+- [X] T008 Add WORKFLOW_JOB_STATUS route (with workflowJobId argument) to app/src/main/kotlin/com/example/aapremote/navigation/AppNavigation.kt
+
+**Checkpoint**: Foundation ready — user story implementation can begin
+
+---
+
+## Phase 3: User Story 1 — Browse Workflow Templates (Priority: P1) 🎯 MVP
+
+**Goal**: Users can switch to "Workflow Templates" segment and see a paginated list of workflow templates with name, description, and labels
+
+**Independent Test**: Log in → Templates tab → tap "Workflow Templates" segment → verify list loads with skeleton placeholders, shows template cards with name/description/labels, and scrolls with pagination
+
+### Implementation for User Story 1
+
+- [X] T009 [P] [US1] Create WorkflowTemplatesUiState sealed interface (Idle, Loading, Success with templates/availableLabels/hasMore/isLoadingMore, Error) in app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesUiState.kt
+- [X] T010 [P] [US1] Create WorkflowTemplateListItem composable (ElevatedCard with name, description, label chips — mirrors TemplateListItem) in app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowTemplateListItem.kt
+- [X] T011 [US1] Create WorkflowTemplatesViewModel with loadTemplates and loadMore methods, StateFlow<WorkflowTemplatesUiState> in app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesViewModel.kt
+- [X] T012 [US1] Register WorkflowTemplatesViewModel in Koin presentationModule in app/src/main/kotlin/com/example/aapremote/presentation/PresentationModule.kt
+- [X] T013 [US1] Create WorkflowTemplateListScreen composable (LazyColumn with SkeletonCard loading, pagination via derivedStateOf, empty state) in app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowTemplateListScreen.kt
+- [X] T014 [US1] Mark "Workflow Templates" segment as isImplemented=true in app/src/main/kotlin/com/example/aapremote/ui/main/TabDefinitions.kt
+- [X] T015 [US1] Route "Workflow Templates" segment to WorkflowTemplateListScreen in app/src/main/kotlin/com/example/aapremote/navigation/MainNavigation.kt
+
+**Checkpoint**: Workflow templates list is browsable with pagination. MVP complete.
+
+---
+
+## Phase 4: User Story 2 — Search and Filter (Priority: P1)
+
+**Goal**: Users can search workflow templates by name and filter by label, matching the job templates experience
+
+**Independent Test**: View workflow templates list → type in search bar → verify results filter → tap label chip → verify label filtering → clear filter → verify full list restores
+
+**Depends on**: US1 (T011 WorkflowTemplatesViewModel, T013 WorkflowTemplateListScreen)
+
+### Implementation for User Story 2
+
+- [X] T016 [US2] Add search (with 300ms debounce) and filterByLabel methods to WorkflowTemplatesViewModel in app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesViewModel.kt
+- [X] T017 [US2] Add SearchBar and LabelChips components to WorkflowTemplateListScreen in app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowTemplateListScreen.kt
+
+**Note**: T016 and T017 touch different files and can run in parallel, but T017 depends on T016's search/filterByLabel methods being available for the ViewModel call. Safer to run sequentially.
+
+**Checkpoint**: Search and filter fully functional on workflow templates list.
+
+---
+
+## Phase 5: User Story 3 — Launch Workflow Template (Priority: P1)
+
+**Goal**: Users can launch a workflow template with optional extra variables and navigate to the status screen
+
+**Independent Test**: Find a workflow template with launch permission → tap play button → confirm dialog appears → confirm launch → verify navigation to workflow job status screen
+
+**Depends on**: US1 (T011 WorkflowTemplatesViewModel, T013 WorkflowTemplateListScreen), Phase 2 (T008 WORKFLOW_JOB_STATUS route)
+
+### Implementation for User Story 3
+
+- [X] T018 [US3] Add LaunchState sealed interface and requestLaunch/confirmLaunch/cancelLaunch/resetLaunchState methods to WorkflowTemplatesViewModel in app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesViewModel.kt
+- [X] T019 [US3] Add launch button to WorkflowTemplateListItem (show only when userCapabilities.start is true) in app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowTemplateListItem.kt
+- [X] T020 [US3] Add launch dialogs (LaunchConfirmDialog, ExtraVarsDialog), launch state handling, and onNavigateToWorkflowJobStatus callback to WorkflowTemplateListScreen in app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowTemplateListScreen.kt
+- [X] T021 [US3] Wire WORKFLOW_JOB_STATUS route to WorkflowJobStatusScreen (placeholder initially) and update onNavigateToWorkflowJobStatus in navigation in app/src/main/kotlin/com/example/aapremote/navigation/AppNavigation.kt
+- [X] T031 [US3] Add error snackbar for workflow template launch failures in WorkflowTemplateListScreen in app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowTemplateListScreen.kt
+
+**Checkpoint**: Full launch flow works — template → dialog → confirm → navigates to status route. Launch errors display snackbar.
+
+---
+
+## Phase 6: User Story 4 — Monitor Workflow Job Status (Priority: P2)
+
+**Goal**: Users see workflow job status with auto-polling, sub-job list, and completion details
+
+**Independent Test**: Launch a workflow template → verify status screen shows job name, status badge, template name, timestamps → verify auto-updates while running → verify sub-jobs list with names and statuses → verify polling stops on completion
+
+**Depends on**: Phase 2 (T006 WorkflowRepository polling methods, T008 route)
+
+### Implementation for User Story 4
+
+- [X] T022 [P] [US4] Create WorkflowJobStatusUiState sealed interface (Idle, Loading, Active with workflowJob/nodes, Completed with workflowJob/nodes, Error) in app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowJobStatusUiState.kt
+- [X] T023 [P] [US4] Create WorkflowNodeItem composable (Row with node name and JobStatusBadge) in app/src/main/kotlin/com/example/aapremote/ui/components/WorkflowNodeItem.kt
+- [X] T024 [US4] Create WorkflowJobStatusViewModel with pollWorkflowJob (5s interval, fetches job + nodes in parallel), retry, and stopPolling methods in app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowJobStatusViewModel.kt
+- [X] T025 [US4] Register WorkflowJobStatusViewModel in Koin presentationModule in app/src/main/kotlin/com/example/aapremote/presentation/PresentationModule.kt
+- [X] T026 [US4] Create WorkflowJobStatusScreen composable (job name, status badge, template name, start/finish/elapsed times, sub-jobs LazyColumn with WorkflowNodeItem, back navigation) in app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowJobStatusScreen.kt
+- [X] T027 [US4] Replace placeholder in WORKFLOW_JOB_STATUS route with actual WorkflowJobStatusScreen in app/src/main/kotlin/com/example/aapremote/navigation/AppNavigation.kt
+
+**Checkpoint**: Full workflow job monitoring works with auto-polling and sub-job display.
+
+---
+
+## Phase 7: User Story 5 — Pull-to-Refresh (Priority: P2)
+
+**Goal**: Users can pull down on the workflow templates list to refresh data
+
+**Independent Test**: View workflow templates list → pull down → verify refresh indicator appears → verify list reloads → verify error handling on network failure
+
+**Depends on**: US1 (T011 WorkflowTemplatesViewModel, T013 WorkflowTemplateListScreen)
+
+### Implementation for User Story 5
+
+- [X] T028 [US5] Add refresh method to WorkflowTemplatesViewModel in app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesViewModel.kt
+- [X] T029 [US5] Wrap list content in PullToRefreshBox with isRefreshing state tracking in WorkflowTemplateListScreen in app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowTemplateListScreen.kt
+
+**Checkpoint**: Pull-to-refresh works on workflow templates list.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final integration, error handling, and consistency checks
+
+- [X] T030 Verify workflow jobs appear in Activity > Jobs list (AAP /api/v2/jobs/ should include them) — manual verification. If workflow jobs do not appear, check whether the jobs repository filters by type and update the API query to include workflow job types.
+- [X] T032 Add retry option on WorkflowJobStatusScreen error state in app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowJobStatusScreen.kt
+- [X] T033 Run quickstart.md validation — verify all 5 integration scenarios work end-to-end
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 (T001-T005) — BLOCKS all user stories
+- **User Stories (Phase 3-7)**: All depend on Phase 2 completion
+  - US1 (Browse) → US2 (Search/Filter) → US3 (Launch): Sequential dependency chain
+  - US4 (Status): Depends on Phase 2 only — can run in parallel with US1-US3
+  - US5 (Pull-to-Refresh): Depends on US1 (uses ViewModel/Screen)
+- **Polish (Phase 8)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (Browse)**: After Phase 2 — no other story dependencies
+- **US2 (Search/Filter)**: After US1 — extends ViewModel and Screen created in US1
+- **US3 (Launch)**: After US1 — extends ViewModel and Screen, plus needs Phase 2 route
+- **US4 (Status)**: After Phase 2 — independent of US1-US3 (different files)
+- **US5 (Pull-to-Refresh)**: After US1 — extends ViewModel and Screen
+
+### Within Each User Story
+
+- UiState/models before ViewModel
+- ViewModel before Screen
+- Screen before navigation wiring
+
+### File Conflict Warnings
+
+- **WorkflowTemplatesViewModel.kt**: Modified by US1 (T011), US2 (T016), US3 (T018), US5 (T028) — MUST be sequential
+- **WorkflowTemplateListScreen.kt**: Modified by US1 (T013), US2 (T017), US3 (T020), US5 (T029), Polish (T031) — MUST be sequential
+- **WorkflowTemplateListItem.kt**: Modified by US1 (T010), US3 (T019) — MUST be sequential
+- **PresentationModule.kt**: Modified by US1 (T012), US4 (T025) — MUST be sequential
+- **AppNavigation.kt**: Modified by Phase 2 (T008), US3 (T021), US4 (T027) — MUST be sequential
+
+### Parallel Opportunities
+
+```text
+Phase 1: T001 ‖ T002 ‖ T003 ‖ T004  (4 model files in parallel)
+          └── T005 (API service, depends on all models)
+
+Phase 3 ‖ Phase 6 (partially):
+  T009 ‖ T010 ‖ T022 ‖ T023  (UiStates + UI components in parallel)
+
+Phase 6: T022 ‖ T023  (UiState and NodeItem in parallel)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Models + API endpoints
+2. Complete Phase 2: Repository + DI + Route
+3. Complete Phase 3: Browse workflow templates
+4. **STOP and VALIDATE**: Template list loads, shows cards, paginates
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. US1 (Browse) → Skeleton loading, template cards, pagination (MVP!)
+3. US2 (Search/Filter) → Search bar and label chips work
+4. US3 (Launch) → Launch dialog flow, navigates to status
+5. US4 (Status) → Workflow job monitoring with sub-jobs
+6. US5 (Pull-to-Refresh) → Standard refresh interaction
+7. Polish → Activity tab verification, error handling
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story
+- Shared UI components (SearchBar, LabelChips, SkeletonCard, LaunchConfirmDialog, ExtraVarsDialog, JobStatusBadge) are reused — no new shared component creation needed
+- WorkflowNodeItem is the only new shared component (Phase 6)
+- The existing LaunchRequest model is reused for workflow launches
+- The existing JobStatus enum is reused for workflow job/node statuses
+- Commit after each phase or logical group


### PR DESCRIPTION
## Summary

- Add workflow job template browsing with search, label filtering, pagination, and pull-to-refresh
- Add workflow template launching with optional extra variables and confirmation dialog
- Add workflow job status monitoring with auto-polling and expandable sub-jobs with inline stdout output
- Wire navigation, Koin DI, and segment routing for the full workflow lifecycle
- Update README with usage guide covering all features

## Changes

**New files (13):** 4 data models, repository, 3 ViewModels/UiStates, 3 UI screens/components
**Modified files (6):** AapApiService, DataModule, PresentationModule, AppNavigation, MainNavigation, TabDefinitions

## Test plan

- [x] Browse: Templates tab > Workflow Templates segment > verify list loads with cards
- [x] Search: type in search bar > verify filtering by name
- [x] Filter: tap label chip > verify filtering by label
- [x] Pagination: scroll to bottom > verify more templates load
- [x] Pull-to-refresh: pull down > verify list reloads
- [x] Launch: tap play button > confirm dialog > verify navigation to status screen
- [x] Status: verify job name, status badge, timestamps, auto-polling
- [x] Sub-jobs: verify node list with statuses, tap to expand stdout inline
- [x] Activity tab: verify workflow jobs appear in Jobs list
- [x] Existing features: job templates, recent jobs, settings unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)