### PR TITLE
Add Infrastructure section with Inventories and Hosts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ All authenticated requests use header: `Authorization: Bearer <TOKEN>`
 - DataStore + Tink (unchanged — no new storage needs) (004-workflow-templates)
 - Kotlin (JVM 17), compileSdk 35, minSdk 31 + Jetpack Compose (Material 3 BOM), Compose Animation, Retrofit, Koin (007-ui-polish-animations)
 - N/A (no new storage for this feature) (007-ui-polish-animations)
+- Kotlin (JVM 17), compileSdk 35, minSdk 31 + Jetpack Compose (Material 3 BOM), Navigation Compose, Retrofit + Kotlin Serialization, Koin (008-infrastructure-section)
+- N/A (no new local storage — all data fetched from API) (008-infrastructure-section)
 
 ## Recent Changes
 - 001-aap-remote-control: Added Kotlin (latest stable, targeting JVM 17) + Jetpack Compose (Material 3), Retrofit,

--- a/app/src/main/kotlin/com/example/aapremote/data/DataModule.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/DataModule.kt
@@ -12,4 +12,6 @@ val dataModule = module {
     single { WorkflowRepository(get()) }
     single { ScheduleRepository(get()) }
     single { EdaAuditRepository(get()) }
+    single { InventoryRepository(get()) }
+    single { HostRepository(get()) }
 }

--- a/app/src/main/kotlin/com/example/aapremote/data/HostRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/HostRepository.kt
@@ -1,0 +1,100 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.Host
+import com.example.aapremote.model.JobHostSummary
+import com.example.aapremote.network.AapApiService
+import kotlinx.serialization.json.JsonElement
+
+class HostRepository(private val apiService: AapApiService) {
+
+    suspend fun getAllHosts(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<HostListResult> {
+        return try {
+            val response = apiService.getHosts(
+                page = page,
+                pageSize = pageSize,
+                search = search
+            )
+            Result.success(
+                HostListResult(
+                    hosts = response.results,
+                    hasMore = response.next != null,
+                    totalCount = response.count
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getInventoryHosts(
+        inventoryId: Int,
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<HostListResult> {
+        return try {
+            val response = apiService.getInventoryHosts(
+                id = inventoryId,
+                page = page,
+                pageSize = pageSize,
+                search = search
+            )
+            Result.success(
+                HostListResult(
+                    hosts = response.results,
+                    hasMore = response.next != null,
+                    totalCount = response.count
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getHostFacts(hostId: Int): Result<Map<String, JsonElement>> {
+        return try {
+            Result.success(apiService.getHostFacts(hostId))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getHostJobSummaries(
+        hostId: Int,
+        page: Int = 1,
+        pageSize: Int = 20
+    ): Result<JobHostSummaryResult> {
+        return try {
+            val response = apiService.getHostJobSummaries(
+                id = hostId,
+                page = page,
+                pageSize = pageSize
+            )
+            Result.success(
+                JobHostSummaryResult(
+                    summaries = response.results,
+                    hasMore = response.next != null,
+                    totalCount = response.count
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}
+
+data class HostListResult(
+    val hosts: List<Host>,
+    val hasMore: Boolean,
+    val totalCount: Int
+)
+
+data class JobHostSummaryResult(
+    val summaries: List<JobHostSummary>,
+    val hasMore: Boolean,
+    val totalCount: Int
+)

--- a/app/src/main/kotlin/com/example/aapremote/data/InventoryRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/InventoryRepository.kt
@@ -1,0 +1,44 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.Inventory
+import com.example.aapremote.network.AapApiService
+
+class InventoryRepository(private val apiService: AapApiService) {
+
+    suspend fun getInventories(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<InventoryListResult> {
+        return try {
+            val response = apiService.getInventories(
+                page = page,
+                pageSize = pageSize,
+                search = search
+            )
+            Result.success(
+                InventoryListResult(
+                    inventories = response.results,
+                    hasMore = response.next != null,
+                    totalCount = response.count
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getInventory(id: Int): Result<Inventory> {
+        return try {
+            Result.success(apiService.getInventory(id))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}
+
+data class InventoryListResult(
+    val inventories: List<Inventory>,
+    val hasMore: Boolean,
+    val totalCount: Int
+)

--- a/app/src/main/kotlin/com/example/aapremote/model/Host.kt
+++ b/app/src/main/kotlin/com/example/aapremote/model/Host.kt
@@ -1,0 +1,76 @@
+package com.example.aapremote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+@Serializable
+data class Host(
+    val id: Int,
+    val name: String,
+    val description: String = "",
+    val enabled: Boolean = true,
+    val variables: String = "",
+    @SerialName("has_active_failures") val hasActiveFailures: Boolean = false,
+    val inventory: Int = 0,
+    val created: String = "",
+    val modified: String = "",
+    @SerialName("last_job") val lastJob: Int? = null,
+    @SerialName("last_job_host_summary") val lastJobHostSummary: Int? = null,
+    @SerialName("summary_fields") val summaryFields: HostSummaryFields = HostSummaryFields()
+)
+
+@Serializable
+data class HostSummaryFields(
+    val inventory: InventorySummary? = null,
+    val groups: GroupsSummary? = null
+)
+
+@Serializable
+data class InventorySummary(
+    val id: Int,
+    val name: String
+)
+
+@Serializable
+data class GroupsSummary(
+    val count: Int = 0,
+    val results: List<GroupSummary> = emptyList()
+)
+
+@Serializable
+data class GroupSummary(
+    val id: Int,
+    val name: String
+)
+
+@Serializable
+data class HostFacts(
+    @SerialName("ansible_facts") val ansibleFacts: Map<String, JsonElement> = emptyMap()
+)
+
+@Serializable
+data class JobHostSummary(
+    val id: Int,
+    val job: Int,
+    val host: Int,
+    val failed: Boolean = false,
+    val ok: Int = 0,
+    val changed: Int = 0,
+    val failures: Int = 0,
+    val skipped: Int = 0,
+    val created: String = "",
+    @SerialName("summary_fields") val summaryFields: JobHostSummaryFields = JobHostSummaryFields()
+)
+
+@Serializable
+data class JobHostSummaryFields(
+    val job: JobSummaryRef? = null
+)
+
+@Serializable
+data class JobSummaryRef(
+    val id: Int,
+    val name: String = "",
+    val status: String = ""
+)

--- a/app/src/main/kotlin/com/example/aapremote/model/Inventory.kt
+++ b/app/src/main/kotlin/com/example/aapremote/model/Inventory.kt
@@ -1,0 +1,37 @@
+package com.example.aapremote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Inventory(
+    val id: Int,
+    val name: String,
+    val description: String = "",
+    val kind: String = "",
+    @SerialName("total_hosts") val totalHosts: Int = 0,
+    @SerialName("total_groups") val totalGroups: Int = 0,
+    @SerialName("has_inventory_sources") val hasInventorySources: Boolean = false,
+    val variables: String = "",
+    val created: String = "",
+    val modified: String = "",
+    @SerialName("summary_fields") val summaryFields: InventorySummaryFields = InventorySummaryFields()
+) {
+    val displayKind: String
+        get() = when (kind) {
+            "smart" -> "Smart"
+            "constructed" -> "Constructed"
+            else -> "Regular"
+        }
+}
+
+@Serializable
+data class InventorySummaryFields(
+    val organization: OrganizationSummary? = null
+)
+
+@Serializable
+data class OrganizationSummary(
+    val id: Int,
+    val name: String
+)

--- a/app/src/main/kotlin/com/example/aapremote/navigation/MainNavigation.kt
+++ b/app/src/main/kotlin/com/example/aapremote/navigation/MainNavigation.kt
@@ -2,6 +2,8 @@ package com.example.aapremote.navigation
 
 import androidx.compose.runtime.Composable
 import com.example.aapremote.ui.components.PlaceholderScreen
+import com.example.aapremote.ui.hosts.HostsScreen
+import com.example.aapremote.ui.inventory.InventoriesScreen
 import com.example.aapremote.ui.jobs.RecentJobsScreen
 import com.example.aapremote.ui.main.Segment
 import com.example.aapremote.ui.main.TopLevelTab
@@ -45,7 +47,11 @@ fun TabContent(
             }
         }
         is TopLevelTab.Infrastructure -> {
-            PlaceholderScreen(title = segment.label)
+            when (segment.label) {
+                "Inventories" -> InventoriesScreen()
+                "Hosts" -> HostsScreen()
+                else -> PlaceholderScreen(title = segment.label)
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/network/AapApiService.kt
+++ b/app/src/main/kotlin/com/example/aapremote/network/AapApiService.kt
@@ -82,4 +82,43 @@ interface AapApiService {
         @Path("id") id: Int,
         @Query("page_size") pageSize: Int = 200
     ): PaginatedResponse<WorkflowNode>
+
+    @GET("inventories/")
+    suspend fun getInventories(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "-modified"
+    ): PaginatedResponse<Inventory>
+
+    @GET("inventories/{id}/")
+    suspend fun getInventory(@Path("id") id: Int): Inventory
+
+    @GET("inventories/{id}/hosts/")
+    suspend fun getInventoryHosts(
+        @Path("id") id: Int,
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "name"
+    ): PaginatedResponse<Host>
+
+    @GET("hosts/")
+    suspend fun getHosts(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "name"
+    ): PaginatedResponse<Host>
+
+    @GET("hosts/{id}/ansible_facts/")
+    suspend fun getHostFacts(@Path("id") id: Int): Map<String, kotlinx.serialization.json.JsonElement>
+
+    @GET("hosts/{id}/job_host_summaries/")
+    suspend fun getHostJobSummaries(
+        @Path("id") id: Int,
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 20,
+        @Query("order_by") orderBy: String = "-created"
+    ): PaginatedResponse<JobHostSummary>
 }

--- a/app/src/main/kotlin/com/example/aapremote/presentation/PresentationModule.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/PresentationModule.kt
@@ -4,6 +4,9 @@ import com.example.aapremote.presentation.auth.AuthViewModel
 import com.example.aapremote.presentation.jobs.JobStatusViewModel
 import com.example.aapremote.presentation.jobs.RecentJobsViewModel
 import com.example.aapremote.presentation.eda.EdaAuditViewModel
+import com.example.aapremote.presentation.hosts.HostsViewModel
+import com.example.aapremote.presentation.hosts.InventoryHostsViewModel
+import com.example.aapremote.presentation.inventory.InventoriesViewModel
 import com.example.aapremote.presentation.schedules.SchedulesViewModel
 import com.example.aapremote.presentation.templates.TemplatesViewModel
 import com.example.aapremote.presentation.workflows.WorkflowJobStatusViewModel
@@ -20,4 +23,7 @@ val presentationModule = module {
     viewModelOf(::WorkflowJobStatusViewModel)
     viewModelOf(::SchedulesViewModel)
     viewModelOf(::EdaAuditViewModel)
+    viewModelOf(::InventoriesViewModel)
+    viewModelOf(::InventoryHostsViewModel)
+    viewModelOf(::HostsViewModel)
 }

--- a/app/src/main/kotlin/com/example/aapremote/presentation/hosts/HostsUiState.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/hosts/HostsUiState.kt
@@ -1,0 +1,15 @@
+package com.example.aapremote.presentation.hosts
+
+import com.example.aapremote.model.AppError
+import com.example.aapremote.model.Host
+
+sealed interface HostsUiState {
+    data object Loading : HostsUiState
+    data class Success(
+        val hosts: List<Host>,
+        val hasMore: Boolean,
+        val isLoadingMore: Boolean = false
+    ) : HostsUiState
+    data class Empty(val message: String) : HostsUiState
+    data class Error(val error: AppError) : HostsUiState
+}

--- a/app/src/main/kotlin/com/example/aapremote/presentation/hosts/HostsViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/hosts/HostsViewModel.kt
@@ -1,0 +1,99 @@
+package com.example.aapremote.presentation.hosts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.aapremote.data.HostRepository
+import com.example.aapremote.model.AppError
+import com.example.aapremote.model.Host
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class HostsViewModel(
+    private val hostRepository: HostRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<HostsUiState>(HostsUiState.Loading)
+    val uiState: StateFlow<HostsUiState> = _uiState.asStateFlow()
+
+    private var currentPage = 1
+    private var allHosts = mutableListOf<Host>()
+    private var currentSearch: String? = null
+    private var searchJob: Job? = null
+
+    init {
+        loadHosts()
+    }
+
+    fun loadHosts() {
+        currentPage = 1
+        allHosts.clear()
+        _uiState.value = HostsUiState.Loading
+        viewModelScope.launch {
+            fetchHosts()
+        }
+    }
+
+    fun refresh() {
+        currentPage = 1
+        allHosts.clear()
+        viewModelScope.launch {
+            fetchHosts()
+        }
+    }
+
+    fun loadMore() {
+        val current = _uiState.value
+        if (current is HostsUiState.Success && current.hasMore && !current.isLoadingMore) {
+            currentPage++
+            _uiState.value = current.copy(isLoadingMore = true)
+            viewModelScope.launch {
+                fetchHosts(append = true)
+            }
+        }
+    }
+
+    fun search(query: String) {
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            delay(300)
+            currentSearch = query.ifBlank { null }
+            currentPage = 1
+            allHosts.clear()
+            _uiState.value = HostsUiState.Loading
+            fetchHosts()
+        }
+    }
+
+    private suspend fun fetchHosts(append: Boolean = false) {
+        val result = hostRepository.getAllHosts(
+            page = currentPage,
+            search = currentSearch
+        )
+
+        result.fold(
+            onSuccess = { listResult ->
+                if (append) {
+                    allHosts.addAll(listResult.hosts)
+                } else {
+                    allHosts = listResult.hosts.toMutableList()
+                }
+
+                if (allHosts.isEmpty()) {
+                    _uiState.value = HostsUiState.Empty("No hosts found")
+                } else {
+                    _uiState.value = HostsUiState.Success(
+                        hosts = allHosts.toList(),
+                        hasMore = listResult.hasMore
+                    )
+                }
+            },
+            onFailure = { error ->
+                _uiState.value = HostsUiState.Error(AppError.from(error))
+            }
+        )
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/presentation/hosts/InventoryHostsUiState.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/hosts/InventoryHostsUiState.kt
@@ -1,0 +1,15 @@
+package com.example.aapremote.presentation.hosts
+
+import com.example.aapremote.model.AppError
+import com.example.aapremote.model.Host
+
+sealed interface InventoryHostsUiState {
+    data object Loading : InventoryHostsUiState
+    data class Success(
+        val hosts: List<Host>,
+        val hasMore: Boolean,
+        val isLoadingMore: Boolean = false
+    ) : InventoryHostsUiState
+    data class Empty(val message: String) : InventoryHostsUiState
+    data class Error(val error: AppError) : InventoryHostsUiState
+}

--- a/app/src/main/kotlin/com/example/aapremote/presentation/hosts/InventoryHostsViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/hosts/InventoryHostsViewModel.kt
@@ -1,0 +1,97 @@
+package com.example.aapremote.presentation.hosts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.aapremote.data.HostRepository
+import com.example.aapremote.model.AppError
+import com.example.aapremote.model.Host
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class InventoryHostsViewModel(
+    private val hostRepository: HostRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<InventoryHostsUiState>(InventoryHostsUiState.Loading)
+    val uiState: StateFlow<InventoryHostsUiState> = _uiState.asStateFlow()
+
+    private var currentPage = 1
+    private val allHosts = mutableListOf<Host>()
+    private var currentInventoryId: Int = 0
+    private var currentSearch: String? = null
+    private var searchJob: Job? = null
+
+    fun loadHosts(inventoryId: Int) {
+        currentInventoryId = inventoryId
+        currentPage = 1
+        allHosts.clear()
+        _uiState.value = InventoryHostsUiState.Loading
+        viewModelScope.launch {
+            fetchHosts()
+        }
+    }
+
+    fun refresh() {
+        currentPage = 1
+        allHosts.clear()
+        viewModelScope.launch {
+            fetchHosts()
+        }
+    }
+
+    fun loadMore() {
+        val current = _uiState.value
+        if (current is InventoryHostsUiState.Success && current.hasMore && !current.isLoadingMore) {
+            currentPage++
+            _uiState.value = current.copy(isLoadingMore = true)
+            viewModelScope.launch {
+                fetchHosts(append = true)
+            }
+        }
+    }
+
+    fun search(query: String) {
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            delay(300)
+            currentSearch = query.ifBlank { null }
+            currentPage = 1
+            allHosts.clear()
+            _uiState.value = InventoryHostsUiState.Loading
+            fetchHosts()
+        }
+    }
+
+    private suspend fun fetchHosts(append: Boolean = false) {
+        val result = hostRepository.getInventoryHosts(
+            inventoryId = currentInventoryId,
+            page = currentPage,
+            search = currentSearch
+        )
+        result.fold(
+            onSuccess = { hostResult ->
+                if (append) {
+                    allHosts.addAll(hostResult.hosts)
+                } else {
+                    allHosts.clear()
+                    allHosts.addAll(hostResult.hosts)
+                }
+                if (allHosts.isEmpty()) {
+                    _uiState.value = InventoryHostsUiState.Empty("No hosts found")
+                } else {
+                    _uiState.value = InventoryHostsUiState.Success(
+                        hosts = allHosts.toList(),
+                        hasMore = hostResult.hasMore
+                    )
+                }
+            },
+            onFailure = { error ->
+                _uiState.value = InventoryHostsUiState.Error(AppError.from(error))
+            }
+        )
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/presentation/inventory/InventoriesUiState.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/inventory/InventoriesUiState.kt
@@ -1,0 +1,15 @@
+package com.example.aapremote.presentation.inventory
+
+import com.example.aapremote.model.AppError
+import com.example.aapremote.model.Inventory
+
+sealed interface InventoriesUiState {
+    data object Loading : InventoriesUiState
+    data class Success(
+        val inventories: List<Inventory>,
+        val hasMore: Boolean,
+        val isLoadingMore: Boolean = false
+    ) : InventoriesUiState
+    data class Empty(val message: String) : InventoriesUiState
+    data class Error(val error: AppError) : InventoriesUiState
+}

--- a/app/src/main/kotlin/com/example/aapremote/presentation/inventory/InventoriesViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/inventory/InventoriesViewModel.kt
@@ -1,0 +1,79 @@
+package com.example.aapremote.presentation.inventory
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.aapremote.data.InventoryRepository
+import com.example.aapremote.model.AppError
+import com.example.aapremote.model.Inventory
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class InventoriesViewModel(
+    private val inventoryRepository: InventoryRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<InventoriesUiState>(InventoriesUiState.Loading)
+    val uiState: StateFlow<InventoriesUiState> = _uiState.asStateFlow()
+
+    private var currentPage = 1
+    private val allInventories = mutableListOf<Inventory>()
+
+    init {
+        loadInventories()
+    }
+
+    fun loadInventories() {
+        currentPage = 1
+        allInventories.clear()
+        _uiState.value = InventoriesUiState.Loading
+        viewModelScope.launch {
+            fetchInventories()
+        }
+    }
+
+    fun refresh() {
+        currentPage = 1
+        allInventories.clear()
+        viewModelScope.launch {
+            fetchInventories()
+        }
+    }
+
+    fun loadMore() {
+        val current = _uiState.value
+        if (current is InventoriesUiState.Success && current.hasMore && !current.isLoadingMore) {
+            currentPage++
+            _uiState.value = current.copy(isLoadingMore = true)
+            viewModelScope.launch {
+                fetchInventories(append = true)
+            }
+        }
+    }
+
+    private suspend fun fetchInventories(append: Boolean = false) {
+        val result = inventoryRepository.getInventories(page = currentPage)
+        result.fold(
+            onSuccess = { inventoryResult ->
+                if (append) {
+                    allInventories.addAll(inventoryResult.inventories)
+                } else {
+                    allInventories.clear()
+                    allInventories.addAll(inventoryResult.inventories)
+                }
+                if (allInventories.isEmpty()) {
+                    _uiState.value = InventoriesUiState.Empty("No inventories found")
+                } else {
+                    _uiState.value = InventoriesUiState.Success(
+                        inventories = allInventories.toList(),
+                        hasMore = inventoryResult.hasMore
+                    )
+                }
+            },
+            onFailure = { error ->
+                _uiState.value = InventoriesUiState.Error(AppError.from(error))
+            }
+        )
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/ui/hosts/HostDetailSheet.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/hosts/HostDetailSheet.kt
@@ -1,0 +1,389 @@
+package com.example.aapremote.ui.hosts
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.OpenInFull
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import com.example.aapremote.data.HostRepository
+import com.example.aapremote.model.Host
+import com.example.aapremote.model.JobHostSummary
+import kotlinx.serialization.json.JsonElement
+import org.koin.compose.koinInject
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HostDetailSheet(
+    host: Host,
+    onDismiss: () -> Unit
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = isExpanded)
+
+    val scope = rememberCoroutineScope()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        if (isExpanded) {
+            HostDetailFullScreen(
+                host = host,
+                onClose = onDismiss
+            )
+        } else {
+            HostDetailCompact(
+                host = host,
+                onExpand = {
+                    isExpanded = true
+                    scope.launch { sheetState.expand() }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun HostDetailCompact(
+    host: Host,
+    onExpand: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 32.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = host.name,
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.weight(1f),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            IconButton(onClick = onExpand) {
+                Icon(Icons.Default.OpenInFull, contentDescription = "Expand to full screen")
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        HorizontalDivider()
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (host.hasActiveFailures) {
+            DetailRow(label = "Status", value = "Has active failures")
+        }
+
+        host.summaryFields.inventory?.let {
+            DetailRow(label = "Inventory", value = it.name)
+        }
+
+        DetailRow(label = "Enabled", value = if (host.enabled) "Yes" else "No")
+        DetailRow(label = "Created", value = host.created)
+        DetailRow(label = "Modified", value = host.modified)
+
+        if (host.variables.isNotBlank() && host.variables != "{}") {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Variables",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = host.variables,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+private fun HostDetailFullScreen(
+    host: Host,
+    onClose: () -> Unit
+) {
+    val hostRepository: HostRepository = koinInject()
+    var facts by remember { mutableStateOf<Map<String, JsonElement>?>(null) }
+    var factsLoading by remember { mutableStateOf(true) }
+    var jobSummaries by remember { mutableStateOf<List<JobHostSummary>>(emptyList()) }
+    var jobsLoading by remember { mutableStateOf(true) }
+
+    LaunchedEffect(host.id) {
+        hostRepository.getHostFacts(host.id).fold(
+            onSuccess = { facts = it },
+            onFailure = { facts = emptyMap() }
+        )
+        factsLoading = false
+
+        hostRepository.getHostJobSummaries(host.id).fold(
+            onSuccess = { jobSummaries = it.summaries },
+            onFailure = { jobSummaries = emptyList() }
+        )
+        jobsLoading = false
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = {
+                Text(
+                    text = host.name,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            },
+            navigationIcon = {
+                IconButton(onClick = onClose) {
+                    Icon(Icons.Default.Close, contentDescription = "Close")
+                }
+            }
+        )
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp)
+        ) {
+            // Details section
+            item {
+                Text(
+                    text = "Details",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+            }
+            item {
+                host.summaryFields.inventory?.let {
+                    DetailRow(label = "Inventory", value = it.name)
+                }
+                DetailRow(label = "Enabled", value = if (host.enabled) "Yes" else "No")
+                DetailRow(label = "Created", value = host.created)
+                DetailRow(label = "Modified", value = host.modified)
+                if (host.hasActiveFailures) {
+                    DetailRow(label = "Status", value = "Has active failures")
+                }
+            }
+
+            // Groups section
+            val groups = host.summaryFields.groups?.results.orEmpty()
+            if (groups.isNotEmpty()) {
+                item {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    HorizontalDivider()
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "Groups (${groups.size})",
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(vertical = 8.dp)
+                    )
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        groups.forEach { group ->
+                            AssistChip(
+                                onClick = {},
+                                label = { Text(group.name) }
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Facts section
+            item {
+                Spacer(modifier = Modifier.height(16.dp))
+                HorizontalDivider()
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Facts",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+            }
+
+            if (factsLoading) {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    }
+                }
+            } else {
+                val factEntries = facts?.entries?.toList().orEmpty()
+                if (factEntries.isEmpty()) {
+                    item {
+                        Text(
+                            text = "No facts available",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                } else {
+                    items(factEntries, key = { it.key }) { (key, value) ->
+                        DetailRow(label = key, value = value.toString())
+                    }
+                }
+            }
+
+            // Jobs section
+            item {
+                Spacer(modifier = Modifier.height(16.dp))
+                HorizontalDivider()
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Jobs Run",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+            }
+
+            if (jobsLoading) {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    }
+                }
+            } else if (jobSummaries.isEmpty()) {
+                item {
+                    Text(
+                        text = "No job history",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            } else {
+                items(jobSummaries, key = { it.id }) { summary ->
+                    JobHostSummaryItem(summary = summary)
+                }
+            }
+
+            item { Spacer(modifier = Modifier.height(32.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun JobHostSummaryItem(
+    summary: JobHostSummary,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = if (summary.failed) Icons.Default.Error else Icons.Default.CheckCircle,
+                contentDescription = if (summary.failed) "Failed" else "Successful",
+                tint = if (summary.failed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.tertiary,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = summary.summaryFields.job?.name ?: "Job #${summary.job}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = "OK: ${summary.ok} | Changed: ${summary.changed} | Failed: ${summary.failures} | Skipped: ${summary.skipped}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = summary.created,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.padding(vertical = 4.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/ui/hosts/HostsScreen.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/hosts/HostsScreen.kt
@@ -1,0 +1,210 @@
+package com.example.aapremote.ui.hosts
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.aapremote.model.Host
+import com.example.aapremote.presentation.hosts.HostsUiState
+import com.example.aapremote.presentation.hosts.HostsViewModel
+import com.example.aapremote.ui.components.ErrorMessage
+import com.example.aapremote.ui.components.SearchBar
+import com.example.aapremote.ui.components.SkeletonCard
+import com.example.aapremote.ui.components.pressScale
+import org.koin.compose.viewmodel.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HostsScreen(
+    viewModel: HostsViewModel = koinViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var isRefreshing by remember { mutableStateOf(false) }
+    var selectedHost by remember { mutableStateOf<Host?>(null) }
+
+    LaunchedEffect(uiState) {
+        if (uiState !is HostsUiState.Loading) {
+            isRefreshing = false
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        when (val state = uiState) {
+            is HostsUiState.Loading -> {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(5) { SkeletonCard() }
+                }
+            }
+            is HostsUiState.Error -> {
+                ErrorMessage(
+                    error = state.error,
+                    onRetry = { viewModel.loadHosts() },
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+            is HostsUiState.Empty -> {
+                PullToRefreshBox(
+                    isRefreshing = isRefreshing,
+                    onRefresh = {
+                        isRefreshing = true
+                        viewModel.refresh()
+                    },
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = state.message,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+            is HostsUiState.Success -> {
+                PullToRefreshBox(
+                    isRefreshing = isRefreshing,
+                    onRefresh = {
+                        isRefreshing = true
+                        viewModel.refresh()
+                    },
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    val listState = rememberLazyListState()
+
+                    val shouldLoadMore by remember {
+                        derivedStateOf {
+                            val lastVisibleItem =
+                                listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                            lastVisibleItem >= state.hosts.size - 3
+                        }
+                    }
+
+                    LaunchedEffect(shouldLoadMore) {
+                        snapshotFlow { shouldLoadMore }
+                            .collect { if (it) viewModel.loadMore() }
+                    }
+
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        item {
+                            SearchBar(
+                                onSearch = viewModel::search,
+                                placeholder = "Search hosts..."
+                            )
+                        }
+
+                        items(
+                            items = state.hosts,
+                            key = { it.id }
+                        ) { host ->
+                            HostItem(
+                                host = host,
+                                onClick = { selectedHost = host }
+                            )
+                        }
+
+                        if (state.isLoadingMore) {
+                            item {
+                                LinearProgressIndicator(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(16.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    selectedHost?.let { host ->
+        HostDetailSheet(
+            host = host,
+            onDismiss = { selectedHost = null }
+        )
+    }
+}
+
+@Composable
+private fun HostItem(
+    host: Host,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Card(
+        onClick = onClick,
+        interactionSource = interactionSource,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .pressScale(interactionSource)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = host.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (host.description.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = host.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                host.summaryFields.inventory?.let { inventory ->
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = "Inventory: ${inventory.name}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/ui/inventory/InventoriesScreen.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/inventory/InventoriesScreen.kt
@@ -1,0 +1,227 @@
+package com.example.aapremote.ui.inventory
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.aapremote.model.Inventory
+import com.example.aapremote.presentation.inventory.InventoriesUiState
+import com.example.aapremote.presentation.inventory.InventoriesViewModel
+import com.example.aapremote.ui.components.ErrorMessage
+import com.example.aapremote.ui.components.SkeletonCard
+import com.example.aapremote.ui.components.pressScale
+import org.koin.compose.viewmodel.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InventoriesScreen(
+    viewModel: InventoriesViewModel = koinViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var isRefreshing by remember { mutableStateOf(false) }
+    var selectedInventory by remember { mutableStateOf<Inventory?>(null) }
+
+    LaunchedEffect(uiState) {
+        if (uiState !is InventoriesUiState.Loading) {
+            isRefreshing = false
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        when (val state = uiState) {
+            is InventoriesUiState.Loading -> {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(5) { SkeletonCard() }
+                }
+            }
+            is InventoriesUiState.Error -> {
+                ErrorMessage(
+                    error = state.error,
+                    onRetry = { viewModel.loadInventories() },
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+            is InventoriesUiState.Empty -> {
+                PullToRefreshBox(
+                    isRefreshing = isRefreshing,
+                    onRefresh = {
+                        isRefreshing = true
+                        viewModel.refresh()
+                    },
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = state.message,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+            is InventoriesUiState.Success -> {
+                PullToRefreshBox(
+                    isRefreshing = isRefreshing,
+                    onRefresh = {
+                        isRefreshing = true
+                        viewModel.refresh()
+                    },
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    val listState = rememberLazyListState()
+
+                    val shouldLoadMore by remember {
+                        derivedStateOf {
+                            val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                            lastVisibleItem >= state.inventories.size - 3
+                        }
+                    }
+
+                    LaunchedEffect(shouldLoadMore) {
+                        snapshotFlow { shouldLoadMore }
+                            .collect { if (it) viewModel.loadMore() }
+                    }
+
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        items(
+                            items = state.inventories,
+                            key = { it.id }
+                        ) { inventory ->
+                            InventoryItem(
+                                inventory = inventory,
+                                onClick = { selectedInventory = inventory }
+                            )
+                        }
+
+                        if (state.isLoadingMore) {
+                            item {
+                                LinearProgressIndicator(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(16.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    selectedInventory?.let { inventory ->
+        InventoryDetailSheet(
+            inventory = inventory,
+            onDismiss = { selectedInventory = null }
+        )
+    }
+}
+
+@Composable
+private fun InventoryItem(
+    inventory: Inventory,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Card(
+        onClick = onClick,
+        interactionSource = interactionSource,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .pressScale(interactionSource)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = inventory.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (inventory.description.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = inventory.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    AssistChip(
+                        onClick = {},
+                        label = {
+                            Text(
+                                text = inventory.displayKind,
+                                style = MaterialTheme.typography.labelSmall
+                            )
+                        }
+                    )
+                    inventory.summaryFields.organization?.let { org ->
+                        Text(
+                            text = org.name,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = "${inventory.totalHosts} hosts",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/ui/inventory/InventoryDetailSheet.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/inventory/InventoryDetailSheet.kt
@@ -1,0 +1,355 @@
+package com.example.aapremote.ui.inventory
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.OpenInFull
+import androidx.compose.material.icons.filled.RemoveCircle
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.launch
+import com.example.aapremote.model.Host
+import com.example.aapremote.model.Inventory
+import com.example.aapremote.presentation.hosts.InventoryHostsUiState
+import com.example.aapremote.presentation.hosts.InventoryHostsViewModel
+import com.example.aapremote.ui.components.ErrorMessage
+import com.example.aapremote.ui.components.SearchBar
+import com.example.aapremote.ui.components.SkeletonCard
+import com.example.aapremote.ui.components.pressScale
+import com.example.aapremote.ui.hosts.HostDetailSheet
+import org.koin.compose.viewmodel.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InventoryDetailSheet(
+    inventory: Inventory,
+    onDismiss: () -> Unit
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = isExpanded)
+
+    val scope = rememberCoroutineScope()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        if (isExpanded) {
+            InventoryHostsFullScreen(
+                inventory = inventory,
+                onClose = onDismiss
+            )
+        } else {
+            InventoryDetailCompact(
+                inventory = inventory,
+                onExpand = {
+                    isExpanded = true
+                    scope.launch { sheetState.expand() }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun InventoryDetailCompact(
+    inventory: Inventory,
+    onExpand: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 32.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = inventory.name,
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.weight(1f),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            IconButton(onClick = onExpand) {
+                Icon(Icons.Default.OpenInFull, contentDescription = "Expand to full screen")
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        HorizontalDivider()
+        Spacer(modifier = Modifier.height(16.dp))
+
+        DetailRow(label = "Type", value = inventory.displayKind)
+
+        inventory.summaryFields.organization?.let {
+            DetailRow(label = "Organization", value = it.name)
+        }
+
+        DetailRow(label = "Total Hosts", value = inventory.totalHosts.toString())
+        DetailRow(label = "Total Groups", value = inventory.totalGroups.toString())
+        DetailRow(label = "Created", value = inventory.created)
+        DetailRow(label = "Modified", value = inventory.modified)
+
+        if (inventory.variables.isNotBlank() && inventory.variables != "{}") {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Variables",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = inventory.variables,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun InventoryHostsFullScreen(
+    inventory: Inventory,
+    onClose: () -> Unit
+) {
+    val viewModel: InventoryHostsViewModel = koinViewModel()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var selectedHost by remember { mutableStateOf<Host?>(null) }
+
+    LaunchedEffect(inventory.id) {
+        viewModel.loadHosts(inventory.id)
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = {
+                Text(
+                    text = inventory.name,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            },
+            navigationIcon = {
+                IconButton(onClick = onClose) {
+                    Icon(Icons.Default.Close, contentDescription = "Close")
+                }
+            }
+        )
+
+        SearchBar(
+            onSearch = { viewModel.search(it) },
+            placeholder = "Search hosts..."
+        )
+
+        when (val state = uiState) {
+            is InventoryHostsUiState.Loading -> {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(5) { SkeletonCard() }
+                }
+            }
+            is InventoryHostsUiState.Error -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    ErrorMessage(
+                        error = state.error,
+                        onRetry = { viewModel.loadHosts(inventory.id) }
+                    )
+                }
+            }
+            is InventoryHostsUiState.Empty -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = state.message,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            is InventoryHostsUiState.Success -> {
+                val listState = rememberLazyListState()
+
+                val shouldLoadMore by remember {
+                    derivedStateOf {
+                        val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                        lastVisibleItem >= state.hosts.size - 3
+                    }
+                }
+
+                LaunchedEffect(shouldLoadMore) {
+                    snapshotFlow { shouldLoadMore }
+                        .collect { if (it) viewModel.loadMore() }
+                }
+
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+                ) {
+                    items(
+                        items = state.hosts,
+                        key = { it.id }
+                    ) { host ->
+                        HostItem(
+                            host = host,
+                            onClick = { selectedHost = host }
+                        )
+                    }
+
+                    if (state.isLoadingMore) {
+                        item {
+                            LinearProgressIndicator(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp)
+                            )
+                        }
+                    }
+
+                    item { Spacer(modifier = Modifier.height(32.dp)) }
+                }
+            }
+        }
+    }
+
+    selectedHost?.let { host ->
+        HostDetailSheet(
+            host = host,
+            onDismiss = { selectedHost = null }
+        )
+    }
+}
+
+@Composable
+private fun HostItem(
+    host: Host,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val groups = host.summaryFields.groups?.results.orEmpty()
+
+    Card(
+        onClick = onClick,
+        interactionSource = interactionSource,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .pressScale(interactionSource)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = if (host.enabled) Icons.Default.CheckCircle else Icons.Default.RemoveCircle,
+                contentDescription = if (host.enabled) "Enabled" else "Disabled",
+                tint = if (host.enabled) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = host.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (groups.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        AssistChip(
+                            onClick = {},
+                            label = {
+                                Text(
+                                    text = groups.first().name,
+                                    style = MaterialTheme.typography.labelSmall
+                                )
+                            }
+                        )
+                        if (groups.size > 1) {
+                            Text(
+                                text = "+${groups.size - 1} more",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.padding(vertical = 4.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/ui/main/TabDefinitions.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/main/TabDefinitions.kt
@@ -39,9 +39,8 @@ sealed class TopLevelTab(
         icon = Icons.Outlined.Dns,
         selectedIcon = Icons.Filled.Dns,
         segments = listOf(
-            Segment(label = "Inventories", isDefault = true),
-            Segment(label = "Hosts"),
-            Segment(label = "Projects")
+            Segment(label = "Inventories", isDefault = true, isImplemented = true),
+            Segment(label = "Hosts", isImplemented = true)
         )
     )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.3"
+agp = "8.13.2"
 kotlin = "2.1.0"
 compose-bom = "2024.12.01"
 activity-compose = "1.9.3"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/specs/008-infrastructure-section/checklists/requirements.md
+++ b/specs/008-infrastructure-section/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Infrastructure Section
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- API endpoint paths are mentioned in Assumptions section as they are part of the AAP platform contract, not implementation details.

--- a/specs/008-infrastructure-section/data-model.md
+++ b/specs/008-infrastructure-section/data-model.md
@@ -1,0 +1,117 @@
+# Data Model: Infrastructure Section
+
+**Feature**: 008-infrastructure-section | **Date**: 2026-04-03
+
+## Entities
+
+### Inventory
+
+```
+Inventory
+├── id: Int                    # Unique identifier
+├── name: String               # Inventory name
+├── description: String        # Optional description (default: "")
+├── kind: String               # "" (regular), "smart", "constructed"
+├── total_hosts: Int           # Number of hosts in inventory
+├── total_groups: Int          # Number of groups in inventory
+├── has_inventory_sources: Boolean  # Whether inventory has external sources
+├── variables: String          # JSON string of inventory variables (default: "")
+├── created: String            # ISO timestamp of creation
+├── modified: String           # ISO timestamp of last modification
+└── summary_fields: InventorySummaryFields
+    └── organization: OrganizationSummary?
+        ├── id: Int
+        └── name: String
+```
+
+**Serialization**: `@Serializable` with `@SerialName` for snake_case fields.
+
+**Bottom sheet fields**: name, kind (type), organization (from summary_fields), total_hosts, created, modified, variables.
+
+### Host
+
+```
+Host
+├── id: Int                    # Unique identifier
+├── name: String               # Hostname
+├── description: String        # Optional description (default: "")
+├── enabled: Boolean           # Whether host is enabled (default: true)
+├── variables: String          # JSON string of host variables (default: "")
+├── has_active_failures: Boolean  # Whether host has failing jobs
+├── inventory: Int             # Parent inventory ID
+├── created: String            # ISO timestamp of creation
+├── modified: String           # ISO timestamp of last modification
+├── last_job: Int?             # ID of last job run on this host
+├── last_job_host_summary: LastJobHostSummary?
+│   └── failed: Boolean        # Whether last job failed
+└── summary_fields: HostSummaryFields
+    ├── inventory: InventorySummary?
+    │   ├── id: Int
+    │   └── name: String
+    └── groups: GroupsSummary?
+        └── results: List<GroupSummary>
+            ├── id: Int
+            └── name: String
+```
+
+**Standalone hosts list**: Shows name, description, and inventory label (from summary_fields.inventory.name).
+**Inventory hosts list**: Shows name, enabled status, and group badge (from summary_fields.groups.results).
+**Bottom sheet fields**: name, last successful run (from summary_fields or last_job), inventory (from summary_fields.inventory.name), created, modified, variables.
+**Expanded full screen**: facts (from ansible_facts endpoint), groups (from summary_fields.groups), jobs run (from job_host_summaries endpoint).
+
+### HostFacts (fetched on demand for expanded view)
+
+```
+HostFacts
+└── ansible_facts: Map<String, JsonElement>   # Arbitrary key-value facts gathered by Ansible
+```
+
+Fetched from: `GET /api/v2/hosts/{id}/ansible_facts/`
+
+### JobHostSummary (fetched on demand for expanded view)
+
+```
+JobHostSummary
+├── id: Int
+├── job: Int                    # Job ID
+├── host: Int                   # Host ID
+├── failed: Boolean
+├── ok: Int                     # Number of OK tasks
+├── changed: Int                # Number of changed tasks
+├── failures: Int               # Number of failed tasks
+├── skipped: Int                # Number of skipped tasks
+├── created: String             # ISO timestamp
+└── summary_fields: JobHostSummaryFields
+    └── job: JobSummaryRef
+        ├── id: Int
+        ├── name: String
+        └── status: String
+```
+
+Fetched from: `GET /api/v2/hosts/{id}/job_host_summaries/`
+
+## Result Wrappers (Repository Layer)
+
+Following existing pattern (e.g., `TemplateListResult`, `RecentJobsResult`):
+
+```
+InventoryListResult
+├── inventories: List<Inventory>
+├── hasMore: Boolean
+└── totalCount: Int
+
+HostListResult
+├── hosts: List<Host>
+├── hasMore: Boolean
+└── totalCount: Int
+```
+
+## Relationships
+
+```
+Inventory (1) ──── (N) Host
+    │                    │
+    │                    └── belongs to groups (via summary_fields)
+    │
+    └── belongs to Organization (via summary_fields)
+```

--- a/specs/008-infrastructure-section/plan.md
+++ b/specs/008-infrastructure-section/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Infrastructure Section (Inventories and Hosts)
+
+**Branch**: `008-infrastructure-section` | **Date**: 2026-04-03 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/008-infrastructure-section/spec.md`
+
+## Summary
+
+Add two functional screens plus detail bottom sheets to the existing Infrastructure tab (which currently shows placeholders): Inventories and Hosts. This follows the same MVVM + Compose patterns used by Templates and Activity sections. The feature adds new API endpoints to `AapApiService`, two data models, two repositories, three ViewModels, two screen composables, and two bottom sheet composables.
+
+Projects have been descoped to a separate dedicated tab (Controller + EDA projects).
+
+## Technical Context
+
+**Language/Version**: Kotlin (JVM 17), compileSdk 35, minSdk 31
+**Primary Dependencies**: Jetpack Compose (Material 3 BOM), Navigation Compose, Retrofit + Kotlin Serialization, Koin
+**Storage**: N/A (no new local storage — all data fetched from API)
+**Testing**: Manual testing against AAP 2.5+ instance
+**Target Platform**: Android (minSdk 31)
+**Project Type**: Mobile app (Android)
+**Performance Goals**: First page load < 3 seconds on typical mobile connection
+**Constraints**: All API calls through AAP Gateway, HTTPS only, Bearer token auth
+**Scale/Scope**: 2 new screens, 2 bottom sheets, ~14 new files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Kotlin-Only | PASS | All new code is Kotlin |
+| II. Compose-First UI | PASS | All new screens use Jetpack Compose + Material 3 |
+| III. MVVM + UDF | PASS | ViewModels with StateFlow, sealed UiState interfaces |
+| IV. Security-First | PASS | No new credential handling; uses existing auth interceptor |
+| V. Lean Dependencies | PASS | No new dependencies required |
+| VI. API-Driven Design | PASS | New endpoints added to existing AapApiService |
+
+All gates pass. No violations to justify.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-infrastructure-section/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (N/A — internal app, no external contracts)
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+app/src/main/kotlin/com/example/aapremote/
+├── model/
+│   ├── Inventory.kt              # NEW — API response model
+│   ├── Host.kt                   # NEW — API response model (includes HostFacts, JobHostSummary)
+├── network/
+│   └── AapApiService.kt          # MODIFY — add inventory and host endpoints (including ansible_facts, job_host_summaries)
+├── data/
+│   ├── InventoryRepository.kt    # NEW — inventory data access
+│   └── HostRepository.kt         # NEW — host data access (all hosts + inventory hosts + facts + job summaries)
+├── presentation/
+│   ├── inventory/
+│   │   ├── InventoriesViewModel.kt    # NEW — inventory list
+│   │   └── InventoriesUiState.kt      # NEW — sealed state interface
+│   └── hosts/
+│       ├── HostsViewModel.kt          # NEW — all hosts list + search
+│       ├── HostsUiState.kt            # NEW — sealed state interface
+│       ├── InventoryHostsViewModel.kt # NEW — hosts within inventory (for expanded view)
+│       └── InventoryHostsUiState.kt   # NEW — sealed state interface
+├── ui/
+│   ├── inventory/
+│   │   ├── InventoriesScreen.kt       # NEW — inventory list
+│   │   └── InventoryDetailSheet.kt    # NEW — bottom sheet with inventory details + expand to hosts
+│   └── hosts/
+│       ├── HostsScreen.kt            # NEW — standalone all-hosts list with search
+│       └── HostDetailSheet.kt         # NEW — bottom sheet with host details + expand
+├── ui/main/
+│   └── TabDefinitions.kt             # MODIFY — mark Inventories and Hosts as isImplemented = true, remove Projects segment
+├── navigation/
+│   └── MainNavigation.kt             # MODIFY — route Infrastructure segments to screens
+└── di/
+    ├── DataModule.kt                  # MODIFY — register new repositories
+    └── PresentationModule.kt          # MODIFY — register new ViewModels
+```
+
+**Structure Decision**: Feature-based packaging within existing architecture layers. Inventory and Host each get their own repository. HostRepository handles both the standalone all-hosts list and hosts-within-inventory queries. InventoryHostsViewModel is used for the expanded inventory detail view showing that inventory's hosts.
+
+## Complexity Tracking
+
+No constitution violations. Table not needed.

--- a/specs/008-infrastructure-section/quickstart.md
+++ b/specs/008-infrastructure-section/quickstart.md
@@ -1,0 +1,71 @@
+# Quickstart: Infrastructure Section
+
+**Feature**: 008-infrastructure-section | **Date**: 2026-04-03
+
+## Prerequisites
+
+- Android Studio with Kotlin plugin
+- AAP 2.5+ instance with Gateway access
+- Valid AAP credentials (for testing)
+
+## Implementation Order
+
+Build in this sequence to enable incremental testing:
+
+### Phase 1: Data Layer (API + Models + Repositories)
+
+1. **Add data models**: `Inventory.kt`, `Host.kt` in `model/`
+   - Follow existing pattern: `@Serializable` data classes with `@SerialName` for snake_case
+   - Include summary field nested classes
+   - Inventory needs: created, modified, variables fields for bottom sheet
+
+2. **Add API endpoints** to `AapApiService.kt`:
+   - `getInventories()` — GET `inventories/`
+   - `getInventory()` — GET `inventories/{id}/` (for detail if needed)
+   - `getInventoryHosts()` — GET `inventories/{id}/hosts/`
+   - `getHosts()` — GET `hosts/` (all hosts with search)
+
+3. **Add repositories**: `InventoryRepository.kt`, `HostRepository.kt`
+   - Follow `TemplateRepository` pattern: `Result<T>` returns, pagination wrappers
+   - HostRepository handles both all-hosts and inventory-scoped hosts
+
+4. **Register in Koin**: Add repositories to `DataModule`, ViewModels to `PresentationModule`
+
+### Phase 2: Inventories (US1)
+
+5. **InventoriesViewModel**: List inventories with pagination and refresh
+6. **InventoriesScreen**: LazyColumn with inventory cards
+7. **InventoryDetailSheet**: Bottom sheet with inventory fields, expandable to full screen with hosts list
+8. **Wire navigation**: Mark Inventories segment as implemented, route in TabContent
+
+### Phase 3: Hosts (US2)
+
+9. **HostsViewModel**: List all hosts with search (debounced) and pagination
+10. **HostsScreen**: LazyColumn with host cards showing description + inventory label
+11. **HostDetailSheet**: Bottom sheet with host details, expandable to full screen
+12. **Wire navigation**: Mark Hosts segment as implemented, route in TabContent
+
+### Phase 4: Cleanup
+
+13. **Remove Projects segment** from TabDefinitions (descoped to separate tab)
+14. **Verify** no PlaceholderScreen remains for Infrastructure segments
+
+## Key Patterns to Follow
+
+- **ViewModel state**: Copy `EdaAuditViewModel` pattern for simple lists
+- **Screen composable**: Copy `EdaAuditScreen` pattern (LazyColumn + PullToRefreshBox + skeleton)
+- **Bottom sheet**: Copy `EdaAuditDetailSheet` pattern, add expand-to-full-screen
+- **Tab wiring**: Set `isImplemented = true` in `TabDefinitions.kt`, add cases to `TabContent()` in `MainNavigation.kt`
+- **Search with debounce**: Copy `TemplatesViewModel.search()` pattern (300ms delay)
+
+## Testing
+
+Test against a real AAP 2.5+ instance:
+1. Verify inventory list loads and paginates
+2. Tap inventory → verify bottom sheet shows name, type, org, total hosts, created, modified, variables
+3. Expand inventory detail → verify hosts load with group badges
+4. Switch to Hosts segment → verify all hosts load with descriptions and inventory labels
+5. Search hosts → verify server-side filtering works
+6. Tap host → verify bottom sheet shows details → expand to full screen
+7. Test empty states, error states, pull-to-refresh on all screens
+8. Verify Projects segment is removed from Infrastructure tab

--- a/specs/008-infrastructure-section/research.md
+++ b/specs/008-infrastructure-section/research.md
@@ -1,0 +1,71 @@
+# Research: Infrastructure Section
+
+**Feature**: 008-infrastructure-section | **Date**: 2026-04-03
+
+## AAP Controller API Endpoints
+
+### Inventories
+
+- **List inventories**: `GET /api/v2/inventories/`
+  - Query params: `page`, `page_size`, `search`, `order_by` (default: `-modified`)
+  - Response: `PaginatedResponse<Inventory>` with `count`, `next`, `previous`, `results`
+  - Key fields: `id`, `name`, `description`, `kind` (empty string = regular, "smart", "constructed"), `total_hosts`, `total_groups`, `has_inventory_sources`, `variables`, `created`, `modified`, `summary_fields`
+
+- **Get inventory detail**: `GET /api/v2/inventories/{id}/`
+  - Returns full inventory object with variables and summary fields
+  - Used for bottom sheet detail view (list response may have sufficient data)
+
+- **List hosts in inventory**: `GET /api/v2/inventories/{id}/hosts/`
+  - Query params: `page`, `page_size`, `search`, `order_by`
+  - Response: `PaginatedResponse<Host>`
+  - Key fields: `id`, `name`, `description`, `enabled`, `variables` (JSON string), `has_active_failures`, `summary_fields` (with `groups` containing group names)
+
+### Hosts
+
+- **List all hosts**: `GET /api/v2/hosts/`
+  - Query params: `page`, `page_size`, `search`, `order_by`
+  - Returns hosts across all inventories; `summary_fields.inventory` contains parent inventory info
+  - Same response model as inventory hosts
+
+- **Host detail**: `GET /api/v2/hosts/{id}/`
+  - Returns full host object with variables and summary fields
+  - Used for bottom sheet detail view if needed
+
+- **Host facts**: `GET /api/v2/hosts/{id}/ansible_facts/`
+  - Returns gathered Ansible facts as a JSON object
+  - Fetched on demand when user expands host detail to full screen
+
+- **Host job summaries**: `GET /api/v2/hosts/{id}/job_host_summaries/`
+  - Query params: `page`, `page_size`, `order_by` (default: `-created`)
+  - Returns paginated list of job runs on this host with task counts (ok, changed, failures, skipped)
+  - Includes summary_fields.job with job name and status
+
+## Design Decisions
+
+### Decision: Separate InventoryRepository and HostRepository
+- **Rationale**: The Hosts segment is a standalone screen browsing all hosts independently of inventories. A dedicated HostRepository handles both `getAllHosts()` (for the Hosts screen) and `getInventoryHosts()` (for the expanded inventory detail). InventoryRepository focuses on inventory list and detail.
+- **Alternatives considered**: Single shared repository — rejected because hosts now have their own standalone section with independent concerns.
+
+### Decision: No extra API call for host detail in standalone list
+- **Rationale**: The host list endpoint returns sufficient data (name, description, enabled, variables, inventory via summary_fields) for the bottom sheet. Only fetch individual host if variables are truncated.
+- **Alternatives considered**: Always fetch `/api/v2/hosts/{id}/` on tap — adds latency with no benefit for typical hosts.
+
+### Decision: Inventory bottom sheet with expandable detail
+- **Rationale**: Tapping an inventory shows a ModalBottomSheet with key fields (name, type, organization, total hosts, created, modified, variables). Expanding to full screen adds a host list for that inventory with group badges. This keeps the inventory list clean while providing drill-down.
+- **Alternatives considered**: Navigate to a separate screen — rejected to stay consistent with the bottom sheet pattern used elsewhere in the app.
+
+### Decision: Host group display as badge (inventory hosts view)
+- **Rationale**: In the expanded inventory detail, host list includes `summary_fields.groups.results[]` with group names. Display the first group name as a chip/badge. If host belongs to multiple groups, show first group + "+N more" indicator.
+- **Alternatives considered**: Show all groups inline — too cluttered for a mobile list.
+
+### Decision: Host detail bottom sheet + expanded full screen
+- **Rationale**: Bottom sheet shows quick-reference fields (name, last successful run, inventory, created, modified, variables). Expanding to full screen loads additional data on demand: ansible facts (from `/api/v2/hosts/{id}/ansible_facts/`), groups (already in summary_fields), and jobs run (from `/api/v2/hosts/{id}/job_host_summaries/`). Facts and job summaries are fetched lazily to avoid unnecessary API calls.
+- **Alternatives considered**: Load everything in bottom sheet — rejected because facts can be very large and job history is paginated, both unsuitable for a compact bottom sheet.
+
+### Decision: Inventory label on standalone hosts list
+- **Rationale**: In the standalone Hosts screen, each host item shows `summary_fields.inventory.name` as a label/chip so the user knows which inventory the host belongs to.
+- **Alternatives considered**: No inventory label — rejected because without it, the standalone host list lacks crucial context.
+
+### Decision: Projects descoped to separate tab
+- **Rationale**: Projects (Controller + EDA) will be implemented as a dedicated tab in a future feature, not as part of the Infrastructure tab. This simplifies the Infrastructure section and allows a more comprehensive Projects implementation covering both Controller and EDA projects.
+- **Alternatives considered**: Include in Infrastructure tab — rejected per user direction to create a separate Projects tab.

--- a/specs/008-infrastructure-section/spec.md
+++ b/specs/008-infrastructure-section/spec.md
@@ -1,0 +1,110 @@
+# Feature Specification: Infrastructure Section (Inventories and Hosts)
+
+**Feature Branch**: `008-infrastructure-section`  
+**Created**: 2026-04-03  
+**Status**: Draft  
+**Input**: User description: "Add Infrastructure section (Inventories, Hosts) - GitHub issue #5"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Browse Inventories (Priority: P1)
+
+As an AAP operator, I want to browse my inventories and inspect their details so I can see what infrastructure is managed by my AAP instance.
+
+**Why this priority**: Inventories are the foundational object in the Infrastructure section. They group hosts and are the starting point for understanding managed infrastructure.
+
+**Independent Test**: Can be fully tested by navigating to the Infrastructure tab, selecting "Inventories", verifying the list loads with inventory names and host counts, tapping an inventory to see its details in a bottom sheet, and expanding to full screen to see its hosts.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am authenticated and on the main screen, **When** I tap the Infrastructure tab and select "Inventories", **Then** I see a paginated list of inventories showing name, description, and host count.
+2. **Given** I am viewing the inventories list, **When** I pull down to refresh, **Then** the list reloads with current data from AAP.
+3. **Given** I am viewing the inventories list, **When** I scroll to the bottom, **Then** additional inventories load automatically (infinite scroll).
+4. **Given** I am viewing the inventories list, **When** I tap on an inventory, **Then** a bottom sheet appears showing inventory details: name, type, organization, total hosts, created date, last modified date, and variables.
+5. **Given** I am viewing an inventory bottom sheet, **When** I expand to full screen, **Then** I see the full inventory details plus a list of hosts belonging to that inventory, with group badges on each host.
+6. **Given** I am viewing hosts in the expanded inventory detail, **When** I tap on a host, **Then** the host detail bottom sheet appears (same as the Hosts segment detail view).
+
+---
+
+### User Story 2 - Browse and Search All Hosts (Priority: P1)
+
+As an AAP operator, I want to browse all hosts across my AAP instance so I can quickly find and inspect any managed host regardless of which inventory it belongs to.
+
+**Why this priority**: A standalone hosts list provides the fastest path to finding a specific host. Operators frequently need to check host status without knowing which inventory it's in.
+
+**Independent Test**: Can be tested by navigating to Infrastructure > Hosts, verifying the full host list loads with descriptions and inventory labels, using search to filter by hostname, and tapping a host to view details.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am on the Infrastructure tab, **When** I select "Hosts", **Then** I see a paginated list of all hosts showing hostname, description, and an inventory label indicating which inventory each host belongs to.
+2. **Given** I am viewing the hosts list, **When** I type in the search bar, **Then** the host list filters to show only hosts matching my search query (server-side search).
+3. **Given** I am viewing the hosts list, **When** I tap on a host, **Then** a bottom sheet appears showing: name, last successful run, inventory, created date, last modified date, and variables section, with an option to expand to full screen.
+4. **Given** I am viewing a host bottom sheet, **When** I expand to full screen, **Then** I see the full host details plus additional sections: facts, groups, and jobs run.
+5. **Given** I am viewing the hosts list, **When** the list contains no hosts, **Then** I see an empty state message.
+6. **Given** I am viewing the hosts list, **When** I pull down to refresh, **Then** the list reloads with current data.
+
+---
+
+### Edge Cases
+
+- What happens when the AAP instance has no inventories? Display an appropriate empty state message.
+- What happens when the user lacks permissions to view certain inventories or hosts? AAP API returns only permitted resources; no special handling needed beyond showing what the API returns.
+- What happens when the user has a very large inventory (thousands of hosts)? Pagination and search handle this — host list uses infinite scroll with server-side search.
+- What happens when network connectivity is lost while browsing? Show the standard error state with a retry option, consistent with existing app behavior.
+- What happens when an inventory has no hosts? Show an empty state in the expanded inventory detail view.
+- What happens when host variables are very large? The bottom sheet can be expanded to full screen for lengthy content.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST display a paginated list of inventories from the AAP API, showing inventory name, description, and total host count.
+- **FR-002**: System MUST support infinite scroll pagination for inventory and host lists, loading more items as the user scrolls near the bottom.
+- **FR-003**: System MUST display inventory details in a bottom sheet when an inventory is tapped, showing: name, type, organization, total hosts, created date, last modified date, and variables.
+- **FR-004**: System MUST allow the inventory detail bottom sheet to expand to full screen, showing the full inventory details plus a list of hosts within that inventory with group badges. Tapping a host in the expanded view MUST open the host detail bottom sheet.
+- **FR-005**: System MUST display a standalone paginated list of all hosts across all inventories, showing hostname, description, and an inventory label for each host.
+- **FR-006**: System MUST provide a search bar on the Hosts screen to filter hosts by name (server-side search).
+- **FR-007**: System MUST present host details in a bottom sheet showing: name, last successful run, inventory, created date, last modified date, and variables.
+- **FR-007a**: System MUST allow the host detail bottom sheet to expand to full screen, showing additional sections: facts (from `/api/v2/hosts/{id}/ansible_facts/`), groups, and jobs run on this host.
+- **FR-008**: System MUST support pull-to-refresh on all list screens (inventories, hosts, inventory detail hosts).
+- **FR-009**: System MUST show loading skeletons while data is being fetched, consistent with existing app screens.
+- **FR-010**: System MUST show appropriate empty state messages when no items exist in a list.
+- **FR-011**: System MUST show error states with retry options when API requests fail, consistent with existing app behavior.
+- **FR-012**: System MUST replace the current placeholder screens in the Infrastructure tab for Inventories and Hosts segments with the implemented screens.
+
+### Key Entities
+
+- **Inventory**: Represents a collection of managed hosts. Key attributes: name, description, type, organization, total host count, total group count, created date, last modified date, variables.
+- **Host**: Represents a managed node within an inventory. Key attributes: hostname, description, enabled status, variables, last successful run, inventory (parent), created date, last modified date. Extended detail: ansible facts, group memberships, jobs run.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can browse inventories and inspect inventory details within 5 seconds of opening the Infrastructure tab.
+- **SC-002**: Users can locate a specific host using the Hosts screen search within 15 seconds.
+- **SC-003**: All list screens load their first page of data within 3 seconds on a typical mobile connection.
+- **SC-004**: The Infrastructure section follows the same visual patterns and interaction behaviors as the existing Templates and Activity sections, providing a consistent user experience.
+
+## Clarifications
+
+### Session 2026-04-03
+
+- Q: Should the app show inventory groups as an intermediate navigation level? → A: Show flat host list but include a "Group" label/badge on each host item.
+- Q: How should host detail view be presented? → A: Bottom sheet initially for quick inspection, with an option to expand to full screen when more detail is needed (e.g., lengthy variables).
+- Q: What is the scope of host search? → A: Within-inventory search is available in the expanded inventory detail view. Global cross-inventory host search is on the standalone Hosts segment.
+- Q: What should the Hosts segment show? → A: A standalone list of ALL hosts across all inventories, with hostname, description, and inventory label. This is a separate section from the inventory drill-down.
+- Q: What does tapping an inventory show? → A: A bottom sheet with inventory details (name, type, organization, total hosts, created, last modified, variables). Expanding to full screen shows the inventory's hosts.
+- Q: Should Projects be in the Infrastructure tab? → A: No. Projects (Controller + EDA) will be moved to a separate dedicated tab in a future feature.
+- Q: What fields does the host detail bottom sheet show? → A: Name, last successful run, inventory, created, last modified, and variables section. Expanding to full screen adds: facts, groups, and jobs run.
+
+## Assumptions
+
+- The AAP instance is version 2.5+ with Gateway, and all API calls go through the Gateway as defined in the project requirements.
+- The user is already authenticated with a valid Bearer token before accessing the Infrastructure section.
+- The Infrastructure tab already exists in the bottom navigation with placeholder screens; this feature replaces the Inventories and Hosts placeholders.
+- Inventory and host APIs follow the same pagination pattern as existing endpoints (page/page_size query parameters, paginated response with count/next/previous/results).
+- Host variables are displayed as read-only text; editing host variables from the app is out of scope.
+- Smart inventories and constructed inventories are displayed the same as regular inventories in the list view.
+- The host detail view shows variables in a readable format but does not support editing or copying individual values.
+- Projects have been descoped from this feature and will be implemented as a separate tab with both Controller and EDA projects.

--- a/specs/008-infrastructure-section/tasks.md
+++ b/specs/008-infrastructure-section/tasks.md
@@ -1,0 +1,187 @@
+# Tasks: Infrastructure Section (Inventories and Hosts)
+
+**Input**: Design documents from `/specs/008-infrastructure-section/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Tests**: Not requested in feature specification. No test tasks included.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No project setup needed — the project already exists. This phase is intentionally empty.
+
+---
+
+## Phase 2: Foundational (Data Layer — Models, API, Repositories, DI)
+
+**Purpose**: All data models, API endpoints, repositories, and DI wiring that MUST be complete before any UI work begins.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T001 [P] Create Inventory data model with InventorySummaryFields, OrganizationSummary (include created, modified, variables fields for bottom sheet) in `app/src/main/kotlin/com/example/aapremote/model/Inventory.kt`
+- [X] T002 [P] Create Host data model with HostSummaryFields, InventorySummary, GroupsSummary, GroupSummary, HostFacts, JobHostSummary, JobHostSummaryFields (include created, modified, last_job fields) in `app/src/main/kotlin/com/example/aapremote/model/Host.kt`
+- [X] T003 Add inventory and host API endpoints to `app/src/main/kotlin/com/example/aapremote/network/AapApiService.kt`: getInventories(), getInventory(), getInventoryHosts(), getHosts(), getHostFacts(), getHostJobSummaries()
+- [X] T004 [P] Create InventoryRepository with getInventories() and getInventory() in `app/src/main/kotlin/com/example/aapremote/data/InventoryRepository.kt`
+- [X] T005 [P] Create HostRepository with getAllHosts(), getInventoryHosts(), searchHosts(), getHostFacts(), getHostJobSummaries() in `app/src/main/kotlin/com/example/aapremote/data/HostRepository.kt`
+- [X] T006 Register InventoryRepository, HostRepository in `app/src/main/kotlin/com/example/aapremote/di/DataModule.kt`
+- [X] T007 Create HostDetailSheet composable with ModalBottomSheet showing host name, last successful run, inventory, created, last modified, and variables; expand-to-full-screen loads and displays facts (ansible_facts), groups, and jobs run in `app/src/main/kotlin/com/example/aapremote/ui/hosts/HostDetailSheet.kt` (shared by US1 and US2)
+
+**Checkpoint**: Data layer and shared components complete — user story work can begin.
+
+---
+
+## Phase 3: User Story 1 — Browse Inventories (Priority: P1) MVP
+
+**Goal**: Users can navigate to Infrastructure > Inventories, see a paginated list of inventories, tap an inventory to see details in a bottom sheet, and expand to full screen to see the inventory's hosts with group badges.
+
+**Independent Test**: Navigate to Infrastructure tab, select Inventories, verify list loads with pagination and pull-to-refresh. Tap an inventory to see bottom sheet with name, type, organization, total hosts, created, modified, variables. Expand to see hosts with group badges.
+
+### Implementation for User Story 1
+
+- [X] T008 [P] [US1] Create InventoriesUiState sealed interface (Loading, Success, Error, Empty) in `app/src/main/kotlin/com/example/aapremote/presentation/inventory/InventoriesUiState.kt`
+- [X] T009 [P] [US1] Create InventoryHostsUiState sealed interface (Loading, Success, Error, Empty) for the expanded inventory hosts view in `app/src/main/kotlin/com/example/aapremote/presentation/hosts/InventoryHostsUiState.kt`
+- [X] T010 [US1] Create InventoriesViewModel with inventory list, pagination, and refresh in `app/src/main/kotlin/com/example/aapremote/presentation/inventory/InventoriesViewModel.kt`
+- [X] T011 [US1] Create InventoryHostsViewModel with hosts-within-inventory list, pagination, and search (debounced) for the expanded view in `app/src/main/kotlin/com/example/aapremote/presentation/hosts/InventoryHostsViewModel.kt`
+- [X] T012 [US1] Register InventoriesViewModel and InventoryHostsViewModel in `app/src/main/kotlin/com/example/aapremote/di/PresentationModule.kt`
+- [X] T013 [US1] Create InventoriesScreen composable with LazyColumn, pull-to-refresh, infinite scroll, and skeleton loading in `app/src/main/kotlin/com/example/aapremote/ui/inventory/InventoriesScreen.kt`
+- [X] T014 [US1] Create InventoryDetailSheet composable with ModalBottomSheet showing inventory details (name, type, organization, total hosts, created, modified, variables) and expand-to-full-screen with hosts list showing group badges; tapping a host opens shared HostDetailSheet (T007) in `app/src/main/kotlin/com/example/aapremote/ui/inventory/InventoryDetailSheet.kt`
+- [X] T015 [US1] Mark Inventories segment as isImplemented=true in `app/src/main/kotlin/com/example/aapremote/ui/main/TabDefinitions.kt`
+- [X] T016 [US1] Wire InventoriesScreen into TabContent for Infrastructure > Inventories in `app/src/main/kotlin/com/example/aapremote/navigation/MainNavigation.kt`
+
+**Checkpoint**: Inventories list is functional. Users can browse inventories, view details in bottom sheet, and expand to see hosts. MVP complete.
+
+---
+
+## Phase 4: User Story 2 — Browse and Search All Hosts (Priority: P1)
+
+**Goal**: Users can navigate to Infrastructure > Hosts and see a standalone list of ALL hosts across all inventories, with hostname, description, and inventory label. Search filters the list. Tapping a host shows details in a bottom sheet.
+
+**Independent Test**: Navigate to Infrastructure > Hosts, verify all hosts load with descriptions and inventory labels. Search for a host by name. Tap a host to see bottom sheet with details. Expand to full screen.
+
+### Implementation for User Story 2
+
+- [X] T017 [P] [US2] Create HostsUiState sealed interface (Loading, Success, Error, Empty) in `app/src/main/kotlin/com/example/aapremote/presentation/hosts/HostsUiState.kt`
+- [X] T018 [US2] Create HostsViewModel with all-hosts list, pagination, search (debounced), and refresh in `app/src/main/kotlin/com/example/aapremote/presentation/hosts/HostsViewModel.kt`
+- [X] T019 [US2] Register HostsViewModel in `app/src/main/kotlin/com/example/aapremote/di/PresentationModule.kt`
+- [X] T020 [US2] Create HostsScreen composable with LazyColumn, search bar, host cards showing hostname/description/inventory label, pull-to-refresh, infinite scroll, and skeleton loading; tapping a host opens shared HostDetailSheet (T007) in `app/src/main/kotlin/com/example/aapremote/ui/hosts/HostsScreen.kt`
+- [X] T021 [US2] Mark Hosts segment as isImplemented=true in `app/src/main/kotlin/com/example/aapremote/ui/main/TabDefinitions.kt`
+- [X] T022 [US2] Wire HostsScreen into TabContent for Infrastructure > Hosts in `app/src/main/kotlin/com/example/aapremote/navigation/MainNavigation.kt`
+
+**Checkpoint**: Standalone Hosts screen is functional. Users can browse all hosts, search, and view details.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final integration checks, cleanup, and descoping.
+
+- [X] T023 Remove Projects segment from Infrastructure tab in `app/src/main/kotlin/com/example/aapremote/ui/main/TabDefinitions.kt` (descoped to separate future tab)
+- [X] T024 Verify all Infrastructure placeholder screens are replaced — confirm no PlaceholderScreen remains for Inventories and Hosts segments in `app/src/main/kotlin/com/example/aapremote/navigation/MainNavigation.kt`
+- [ ] T025 Run quickstart.md validation scenarios (requires live AAP instance — manual testing) end-to-end against a live AAP 2.5+ instance
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Empty — project already exists
+- **Foundational (Phase 2)**: No dependencies — can start immediately. BLOCKS all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational (Phase 2)
+- **User Story 2 (Phase 4)**: Depends on Foundational (Phase 2) — independent of US1, can run in parallel
+- **Polish (Phase 5)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (Browse Inventories)**: Can start after Phase 2 — No story dependencies. Uses shared HostDetailSheet (T007).
+- **US2 (Browse/Search Hosts)**: Can start after Phase 2 — Independent of US1, can run in parallel. Uses shared HostDetailSheet (T007).
+
+### Within Each User Story
+
+- UiState before ViewModel
+- ViewModel before Screen composable
+- DI registration before Screen can use ViewModel
+- Screen before navigation wiring
+
+### Parallel Opportunities
+
+- T001, T002 (both data models) can run in parallel
+- T004, T005 (both repositories) can run in parallel (after T003)
+- T008, T009, T017 (all UiState files) can run in parallel
+- US1 and US2 can be implemented in parallel (both depend only on Phase 2)
+
+## Parallel Example: Foundational Phase
+
+```bash
+# Launch both data models together:
+Task: "Create Inventory model in model/Inventory.kt"
+Task: "Create Host model in model/Host.kt"
+
+# Then launch both repositories together:
+Task: "Create InventoryRepository in data/InventoryRepository.kt"
+Task: "Create HostRepository in data/HostRepository.kt"
+```
+
+## Parallel Example: User Stories 1 + 2
+
+```bash
+# After Phase 2, launch US1 and US2 in parallel:
+# Agent A: User Story 1 (Inventories)
+Task: "Create InventoriesUiState in presentation/inventory/InventoriesUiState.kt"
+Task: "Create InventoriesViewModel in presentation/inventory/InventoriesViewModel.kt"
+Task: "Create InventoriesScreen in ui/inventory/InventoriesScreen.kt"
+Task: "Create InventoryDetailSheet in ui/inventory/InventoryDetailSheet.kt"
+
+# Agent B: User Story 2 (Hosts) — HostDetailSheet already built in Phase 2
+Task: "Create HostsUiState in presentation/hosts/HostsUiState.kt"
+Task: "Create HostsViewModel in presentation/hosts/HostsViewModel.kt"
+Task: "Create HostsScreen in ui/hosts/HostsScreen.kt"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: Foundational (data layer)
+2. Complete Phase 3: User Story 1 (Inventories)
+3. **STOP and VALIDATE**: Test inventory browsing and detail view independently
+4. Demo if ready
+
+### Incremental Delivery
+
+1. Complete Foundational → Data layer ready
+2. Add US1 (Inventories + detail + hosts drill-down) → Test → Demo (MVP!)
+3. Add US2 (Standalone Hosts) → Test → Demo
+4. Each story adds value without breaking previous stories
+
+### Parallel Strategy
+
+With multiple agents/developers:
+
+1. Complete Foundational phase together
+2. Once Foundational is done:
+   - Agent A: US1 (Inventories + InventoryDetailSheet)
+   - Agent B: US2 (Hosts — uses shared HostDetailSheet from Phase 2)
+3. Stories integrate independently
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Projects have been descoped — a separate GitHub issue should be created for the Projects tab (Controller + EDA projects)


### PR DESCRIPTION
## Summary
- **Inventories screen**: Paginated list with detail bottom sheet showing name, type, organization, total hosts/groups, created/modified, variables. Expand to full-screen view with searchable host list and group badges.
- **Hosts screen**: Standalone all-hosts list with server-side search, inventory labels, and detail bottom sheet. Expand to full-screen with ansible facts, groups, and job run history.
- **Data layer**: Inventory and Host models, 6 new API endpoints in AapApiService, InventoryRepository and HostRepository, Koin DI wiring.
- **Cleanup**: Removed descoped Projects segment from Infrastructure tab.

## Test plan
- [ ] Navigate to Infrastructure > Inventories, verify list loads with pagination and pull-to-refresh
- [ ] Tap an inventory to see bottom sheet with details, expand to full screen to see hosts with group badges
- [ ] Navigate to Infrastructure > Hosts, verify all hosts load with descriptions and inventory labels
- [ ] Search for a host by name, verify server-side filtering
- [ ] Tap a host to see detail bottom sheet, expand to full screen for facts/groups/jobs
- [ ] Verify Projects segment is no longer visible in Infrastructure tab
- [ ] Test error states and empty states on both screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)