### PR TITLE
Fix search query persistence across recomposition

### DIFF
--- a/app/src/main/kotlin/com/example/aapremote/presentation/templates/TemplatesViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/templates/TemplatesViewModel.kt
@@ -26,6 +26,9 @@ class TemplatesViewModel(
     private val _launchState = MutableStateFlow<LaunchState>(LaunchState.Idle)
     val launchState: StateFlow<LaunchState> = _launchState.asStateFlow()
 
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
     private var currentPage = 1
     private var currentSearch: String? = null
     private var currentLabelFilter: String? = null
@@ -75,6 +78,7 @@ class TemplatesViewModel(
     }
 
     fun search(query: String) {
+        _searchQuery.value = query
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
             delay(300)
@@ -97,6 +101,7 @@ class TemplatesViewModel(
     }
 
     fun clearFilters() {
+        _searchQuery.value = ""
         currentSearch = null
         currentLabelFilter = null
         currentPage = 1

--- a/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesViewModel.kt
@@ -26,6 +26,9 @@ class WorkflowTemplatesViewModel(
     private val _launchState = MutableStateFlow<WorkflowLaunchState>(WorkflowLaunchState.Idle)
     val launchState: StateFlow<WorkflowLaunchState> = _launchState.asStateFlow()
 
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
     private var currentPage = 1
     private var currentSearch: String? = null
     private var currentLabelFilter: String? = null
@@ -75,6 +78,7 @@ class WorkflowTemplatesViewModel(
     }
 
     fun search(query: String) {
+        _searchQuery.value = query
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
             delay(300)

--- a/app/src/main/kotlin/com/example/aapremote/ui/components/SearchBar.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/components/SearchBar.kt
@@ -23,9 +23,10 @@ import kotlinx.coroutines.delay
 fun SearchBar(
     onSearch: (String) -> Unit,
     modifier: Modifier = Modifier,
-    placeholder: String = "Search templates..."
+    placeholder: String = "Search templates...",
+    initialQuery: String = ""
 ) {
-    var query by remember { mutableStateOf("") }
+    var query by remember(initialQuery) { mutableStateOf(initialQuery) }
     var hasUserTyped by remember { mutableStateOf(false) }
 
     LaunchedEffect(query) {

--- a/app/src/main/kotlin/com/example/aapremote/ui/templates/TemplateListScreen.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/templates/TemplateListScreen.kt
@@ -47,6 +47,7 @@ fun TemplateListScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val launchState by viewModel.launchState.collectAsStateWithLifecycle()
+    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
     var selectedLabel by remember { mutableStateOf<Label?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
     var isRefreshing by remember { mutableStateOf(false) }
@@ -92,6 +93,11 @@ fun TemplateListScreen(
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
+            SearchBar(
+                onSearch = { viewModel.search(it) },
+                initialQuery = searchQuery
+            )
+
             when (val state = uiState) {
                 is TemplatesUiState.Idle, is TemplatesUiState.Loading -> {
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
@@ -106,8 +112,6 @@ fun TemplateListScreen(
                     )
                 }
                 is TemplatesUiState.Success -> {
-                    SearchBar(onSearch = { viewModel.search(it) })
-
                     LabelChips(
                         labels = state.availableLabels,
                         selectedLabel = selectedLabel,

--- a/app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowTemplateListScreen.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/workflows/WorkflowTemplateListScreen.kt
@@ -47,6 +47,7 @@ fun WorkflowTemplateListScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val launchState by viewModel.launchState.collectAsStateWithLifecycle()
+    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
     var selectedLabel by remember { mutableStateOf<Label?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
     var isRefreshing by remember { mutableStateOf(false) }
@@ -92,6 +93,11 @@ fun WorkflowTemplateListScreen(
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
+            SearchBar(
+                onSearch = { viewModel.search(it) },
+                initialQuery = searchQuery
+            )
+
             when (val state = uiState) {
                 is WorkflowTemplatesUiState.Idle, is WorkflowTemplatesUiState.Loading -> {
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
@@ -106,8 +112,6 @@ fun WorkflowTemplateListScreen(
                     )
                 }
                 is WorkflowTemplatesUiState.Success -> {
-                    SearchBar(onSearch = { viewModel.search(it) })
-
                     LabelChips(
                         labels = state.availableLabels,
                         selectedLabel = selectedLabel,


### PR DESCRIPTION
## Summary
- Move SearchBar above loading state so it's always visible (not hidden during loading/idle)
- Persist search query in ViewModels via StateFlow so it survives tab switches and recomposition
- Apply fix to both Job Templates and Workflow Templates screens

## Test plan
- [ ] Type a search query, switch tabs, switch back — query preserved
- [ ] SearchBar visible during loading state
- [ ] Clear filters resets search field