### PR TITLE
Add tool result caching and conversation compaction

### DIFF
--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
@@ -104,6 +104,7 @@ class ChatEngine(
                         toolCalls = result.toolCalls
                     ))
 
+                    val toolSummaries = mutableListOf<String>()
                     for (toolCall in result.toolCalls) {
                         emit(ChatEvent.ToolExecuting(toolCall.name, toolCall.arguments))
 
@@ -118,6 +119,11 @@ class ChatEngine(
                                 ?: "Tool execution failed: ${toolResult.errorType ?: "unknown error"}",
                             toolCallId = toolCall.id
                         ))
+                        toolSummaries.add("${toolCall.name}: ${toolResult.data?.take(200) ?: "error"}")
+                    }
+
+                    if (iterations > 1) {
+                        compactToolMessages(messages, toolSummaries)
                     }
                 } else {
                     val finalText = if (result.toolCalls.isNotEmpty() && iterations >= maxIterations) {
@@ -146,6 +152,33 @@ class ChatEngine(
             emit(ChatEvent.Error("Unable to reach LLM server: ${e.message}", e))
         } catch (e: Exception) {
             emit(ChatEvent.Error("Error: ${e.message}", e))
+        }
+    }
+
+    private fun compactToolMessages(
+        messages: MutableList<ChatMessage>,
+        currentSummaries: List<String>
+    ) {
+        val keepFrom = messages.indexOfLast { it.role == Role.USER } + 1
+        val toCompact = mutableListOf<Int>()
+        for (i in keepFrom until messages.size - currentSummaries.size) {
+            if (messages[i].role == Role.TOOL || (messages[i].role == Role.ASSISTANT && messages[i].toolCalls != null)) {
+                toCompact.add(i)
+            }
+        }
+        if (toCompact.isEmpty()) return
+        val summary = toCompact
+            .filter { messages[it].role == Role.TOOL }
+            .joinToString("; ") { i ->
+                val msg = messages[i]
+                val preview = msg.content.take(100).replace("\n", " ")
+                "tool_result: $preview"
+            }
+        for (i in toCompact.reversed()) {
+            messages.removeAt(i)
+        }
+        if (summary.isNotBlank()) {
+            messages.add(keepFrom, ChatMessage(role = Role.ASSISTANT, content = "[Previous tool calls: $summary]"))
         }
     }
 

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolExecutor.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolExecutor.kt
@@ -19,6 +19,8 @@ class ToolExecutor(
     private val tools: List<Tool>,
     private val maxResultChars: Int = 8_000
 ) {
+    private val resultCache = mutableMapOf<String, Pair<Long, ToolResult>>()
+
     suspend fun execute(toolCall: ToolCall): ToolResult {
         val tool = tools.find { it.spec.name == toolCall.name }
             ?: return ToolResult(
@@ -26,6 +28,12 @@ class ToolExecutor(
                 data = "Tool '${toolCall.name}' not found",
                 errorType = ErrorType.NOT_FOUND
             )
+
+        val cacheKey = "${toolCall.name}:${toolCall.arguments.hashCode()}"
+        val cached = resultCache[cacheKey]
+        if (cached != null && System.currentTimeMillis() - cached.first < CACHE_TTL_MS) {
+            return cached.second
+        }
 
         val result = try {
             withTimeout(30_000L) {
@@ -44,11 +52,15 @@ class ToolExecutor(
             result.copy(data = capResultArray(result.data))
         } else result
 
-        return if (capped.data != null && capped.data.length > maxResultChars) {
+        val finalResult = if (capped.data != null && capped.data.length > maxResultChars) {
             capped.copy(data = smartTruncate(capped.data, maxResultChars))
         } else {
             capped
         }
+        if (finalResult.success) {
+            resultCache[cacheKey] = System.currentTimeMillis() to finalResult
+        }
+        return finalResult
     }
 
     private fun jsonObjectToMap(json: kotlinx.serialization.json.JsonObject): Map<String, Any> {
@@ -74,6 +86,7 @@ class ToolExecutor(
     }
 
     companion object {
+        private const val CACHE_TTL_MS = 120_000L
         private const val MAX_ARRAY_ITEMS = 10
         private val json = Json { ignoreUnknownKeys = true }
 


### PR DESCRIPTION
## Summary

- **Tool result caching** — identical tool calls within 2 minutes return cached results instead of re-executing. Prevents duplicate MCP/API calls during agentic loops.
- **Conversation compaction** — after the first tool loop iteration, intermediate ASSISTANT+TOOL messages are collapsed into a single summary line before the next LLM call. Reduces context window usage on multi-turn tool loops.

## Token impact

Multi-tool scenario (3 iterations):
- Caching: prevents ~2K tokens per duplicate tool call avoided
- Compaction: reduces intermediate messages from ~8K chars to ~300 chars per collapsed iteration → saves ~2K tokens per iteration

## Test plan

- [x] All unit tests pass
- [ ] Verify duplicate tool calls return cached results (check logs for skipped API calls)
- [ ] Verify multi-tool conversations don't balloon in context size
- [ ] Verify tool results still refresh after 2-minute TTL expires

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)