### PR TITLE
Add Phase 2 local tools and fix token budget (#54)

### DIFF
--- a/app/src/main/kotlin/com/example/aapremote/assistant/LocalToolsModule.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/LocalToolsModule.kt
@@ -7,13 +7,25 @@ import com.example.aapremote.assistant.tools.local.GetJobStdoutLocalTool
 import com.example.aapremote.assistant.tools.local.GetWorkflowJobLocalTool
 import com.example.aapremote.assistant.tools.local.LaunchJobLocalTool
 import com.example.aapremote.assistant.tools.local.LaunchWorkflowLocalTool
+import com.example.aapremote.assistant.tools.local.GetCredentialLocalTool
+import com.example.aapremote.assistant.tools.local.GetEdaActivationLocalTool
+import com.example.aapremote.assistant.tools.local.GetInstanceLocalTool
+import com.example.aapremote.assistant.tools.local.GetMeshTopologyLocalTool
+import com.example.aapremote.assistant.tools.local.GetProjectLocalTool
+import com.example.aapremote.assistant.tools.local.ListCredentialsLocalTool
+import com.example.aapremote.assistant.tools.local.ListEdaActivationsLocalTool
 import com.example.aapremote.assistant.tools.local.ListEdaAuditRulesLocalTool
+import com.example.aapremote.assistant.tools.local.ListExecutionEnvironmentsLocalTool
 import com.example.aapremote.assistant.tools.local.ListHostsLocalTool
+import com.example.aapremote.assistant.tools.local.ListInstanceGroupsLocalTool
+import com.example.aapremote.assistant.tools.local.ListInstancesLocalTool
 import com.example.aapremote.assistant.tools.local.ListInventoriesLocalTool
 import com.example.aapremote.assistant.tools.local.ListJobTemplatesLocalTool
 import com.example.aapremote.assistant.tools.local.ListJobsLocalTool
+import com.example.aapremote.assistant.tools.local.ListProjectsLocalTool
 import com.example.aapremote.assistant.tools.local.ListSchedulesLocalTool
 import com.example.aapremote.assistant.tools.local.ListWorkflowTemplatesLocalTool
+import com.example.aapremote.assistant.tools.local.PingLocalTool
 import com.example.aapremote.assistant.tools.local.ToggleScheduleLocalTool
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -33,4 +45,16 @@ val localToolsModule = module {
     single { ListSchedulesLocalTool(get()) } bind LocalTool::class
     single { ToggleScheduleLocalTool(get()) } bind LocalTool::class
     single { ListEdaAuditRulesLocalTool(get()) } bind LocalTool::class
+    single { ListInstancesLocalTool(get()) } bind LocalTool::class
+    single { GetInstanceLocalTool(get()) } bind LocalTool::class
+    single { ListInstanceGroupsLocalTool(get()) } bind LocalTool::class
+    single { PingLocalTool(get()) } bind LocalTool::class
+    single { GetMeshTopologyLocalTool(get()) } bind LocalTool::class
+    single { ListCredentialsLocalTool(get()) } bind LocalTool::class
+    single { GetCredentialLocalTool(get()) } bind LocalTool::class
+    single { ListProjectsLocalTool(get()) } bind LocalTool::class
+    single { GetProjectLocalTool(get()) } bind LocalTool::class
+    single { ListExecutionEnvironmentsLocalTool(get()) } bind LocalTool::class
+    single { ListEdaActivationsLocalTool(get()) } bind LocalTool::class
+    single { GetEdaActivationLocalTool(get()) } bind LocalTool::class
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolRouter.kt
@@ -165,7 +165,21 @@ class ToolRouter {
             matchesCategory && isEnabled && passesReadOnly
         }
 
-        return filteredLocal + filteredMcp
+        return rankTools(filteredLocal, queryWords) + filteredMcp
+    }
+
+    private fun rankTools(tools: List<Tool>, queryWords: Set<String>): List<Tool> {
+        return tools.sortedByDescending { tool ->
+            val name = tool.spec.name
+            var score = 0
+            if (name.startsWith("list_")) score += 10
+            if (name.startsWith("ping")) score += 10
+            if (name.startsWith("get_")) score += 5
+            if (tool is LocalTool && tool.destructive) score -= 5
+            val nameWords = name.split("_").toSet()
+            score += (nameWords intersect queryWords).size * 3
+            score
+        }
     }
 
     fun getAllRegisteredTools(): List<Pair<Tool, ToolSource>> {

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolRouter.kt
@@ -36,9 +36,9 @@ class ToolRouter {
             )
         ),
         MONITORING(
-            keywords = setOf("health", "status", "monitor", "metrics", "log", "logs", "dashboard", "analytics", "instance", "instances"),
-            resourcePrefixes = setOf("dashboard", "ping", "config", "instances", "instance_groups", "metrics"),
-            localToolNames = emptySet()
+            keywords = setOf("health", "status", "monitor", "metrics", "log", "logs", "dashboard", "analytics", "instance", "instances", "mesh", "topology", "ping", "cluster", "capacity", "node"),
+            resourcePrefixes = setOf("dashboard", "ping", "config", "instances", "instance_groups", "metrics", "mesh_visualizer"),
+            localToolNames = setOf("list_instances", "get_instance", "list_instance_groups", "ping", "get_mesh_topology")
         ),
         USERS(
             keywords = setOf("user", "users", "team", "teams", "organization", "organizations", "org", "role", "roles", "permission", "permissions", "member"),
@@ -48,17 +48,17 @@ class ToolRouter {
         SECURITY(
             keywords = setOf("credential", "credentials", "secret", "secrets", "audit", "security", "compliance", "policy", "certificate"),
             resourcePrefixes = setOf("credentials", "credential_types", "credential_input_sources"),
-            localToolNames = emptySet()
+            localToolNames = setOf("list_credentials", "get_credential")
         ),
         CONFIGURATION(
-            keywords = setOf("setting", "settings", "configure", "configuration", "notification", "notifications", "label", "labels", "project", "projects"),
+            keywords = setOf("setting", "settings", "configure", "configuration", "notification", "notifications", "label", "labels", "project", "projects", "execution", "environment", "environments"),
             resourcePrefixes = setOf("settings", "notification_templates", "notifications", "labels", "execution_environments", "projects"),
-            localToolNames = emptySet()
+            localToolNames = setOf("list_projects", "get_project", "list_execution_environments")
         ),
         EDA(
             keywords = setOf("eda", "rulebook", "activation", "event", "audit"),
             resourcePrefixes = setOf("audit_rules", "activations", "decision_environments", "rulebooks", "event_streams"),
-            localToolNames = setOf("list_eda_audit_rules")
+            localToolNames = setOf("list_eda_audit_rules", "list_eda_activations", "get_eda_activation")
         )
     }
 
@@ -78,6 +78,18 @@ class ToolRouter {
             "list_schedules" to setOf("controller.schedules_list"),
             "toggle_schedule" to setOf("controller.schedules_partial_update", "controller.schedules_update"),
             "list_eda_audit_rules" to setOf("eda.audit_rules_list"),
+            "list_instances" to setOf("controller.instances_list"),
+            "get_instance" to setOf("controller.instances_read"),
+            "list_instance_groups" to setOf("controller.instance_groups_list"),
+            "ping" to setOf("controller.ping_read"),
+            "get_mesh_topology" to setOf("controller.mesh_visualizer_read"),
+            "list_credentials" to setOf("controller.credentials_list"),
+            "get_credential" to setOf("controller.credentials_read"),
+            "list_projects" to setOf("controller.projects_list"),
+            "get_project" to setOf("controller.projects_read"),
+            "list_execution_environments" to setOf("controller.execution_environments_list"),
+            "list_eda_activations" to setOf("eda.activations_list"),
+            "get_eda_activation" to setOf("eda.activations_read"),
         )
 
         private val MCP_TOOLS_WITH_LOCAL_OVERLAP: Set<String> =

--- a/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
@@ -157,8 +157,8 @@ class AssistantViewModel(
 
         val maxToolsForMode = when (mode) {
             TokenSavingMode.STANDARD -> Int.MAX_VALUE
-            TokenSavingMode.TOKEN_SAVER -> 5
-            TokenSavingMode.MINIMAL -> 3
+            TokenSavingMode.TOKEN_SAVER -> 8
+            TokenSavingMode.MINIMAL -> 5
         }
         val budgetedTools = if (noToolMatch) emptyList() else tools.take(maxToolsForMode)
         val toolSpecs = budgetedTools.map { it.spec }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
@@ -155,12 +155,14 @@ class AssistantViewModel(
             return
         }
 
-        val maxToolsForMode = when (mode) {
+        val mcpToolLimit = when (mode) {
             TokenSavingMode.STANDARD -> Int.MAX_VALUE
-            TokenSavingMode.TOKEN_SAVER -> 8
-            TokenSavingMode.MINIMAL -> 5
+            TokenSavingMode.TOKEN_SAVER -> 5
+            TokenSavingMode.MINIMAL -> 3
         }
-        val budgetedTools = if (noToolMatch) emptyList() else tools.take(maxToolsForMode)
+        val matchedLocal = tools.filterIsInstance<LocalTool>()
+        val matchedMcp = tools.filter { it !is LocalTool }.take(mcpToolLimit)
+        val budgetedTools = if (noToolMatch) emptyList() else matchedLocal + matchedMcp
         val toolSpecs = budgetedTools.map { it.spec }
         val toolExecutor = ToolExecutor(budgetedTools)
         val engine = ChatEngine(provider, toolExecutor)

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetCredentialLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetCredentialLocalTool.kt
@@ -1,0 +1,33 @@
+package com.example.aapremote.assistant.tools.local
+
+import com.example.aapremote.assistant.tools.ErrorType
+import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.ToolResult
+import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.data.CredentialRepository
+import com.example.aapremote.network.networkJson
+import kotlinx.serialization.encodeToString
+
+class GetCredentialLocalTool(
+    private val repository: CredentialRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "get_credential",
+        description = "Get details of a specific credential by ID (type, organization — no secrets exposed)",
+        parametersSchema = buildToolSchema(
+            Triple("credential_id", "integer", "ID of the credential"),
+            required = listOf("credential_id")
+        )
+    )
+) {
+    override suspend fun execute(args: Map<String, Any>): ToolResult {
+        return try {
+            val credentialId = (args["credential_id"] as? Number)?.toInt()
+                ?: return ToolResult(success = false, data = "credential_id is required", errorType = ErrorType.NOT_FOUND)
+            val credential = repository.getCredential(credentialId).getOrThrow()
+            ToolResult(success = true, data = networkJson.encodeToString(credential))
+        } catch (e: Exception) {
+            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetEdaActivationLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetEdaActivationLocalTool.kt
@@ -1,0 +1,33 @@
+package com.example.aapremote.assistant.tools.local
+
+import com.example.aapremote.assistant.tools.ErrorType
+import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.ToolResult
+import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.data.EdaActivationRepository
+import com.example.aapremote.network.networkJson
+import kotlinx.serialization.encodeToString
+
+class GetEdaActivationLocalTool(
+    private val repository: EdaActivationRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "get_eda_activation",
+        description = "Get details of a specific EDA rulebook activation by ID — status, restart policy, decision environment",
+        parametersSchema = buildToolSchema(
+            Triple("activation_id", "integer", "ID of the EDA activation"),
+            required = listOf("activation_id")
+        )
+    )
+) {
+    override suspend fun execute(args: Map<String, Any>): ToolResult {
+        return try {
+            val activationId = (args["activation_id"] as? Number)?.toInt()
+                ?: return ToolResult(success = false, data = "activation_id is required", errorType = ErrorType.NOT_FOUND)
+            val activation = repository.getActivation(activationId).getOrThrow()
+            ToolResult(success = true, data = networkJson.encodeToString(activation))
+        } catch (e: Exception) {
+            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetInstanceLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetInstanceLocalTool.kt
@@ -1,0 +1,33 @@
+package com.example.aapremote.assistant.tools.local
+
+import com.example.aapremote.assistant.tools.ErrorType
+import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.ToolResult
+import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.data.InfrastructureRepository
+import com.example.aapremote.network.networkJson
+import kotlinx.serialization.encodeToString
+
+class GetInstanceLocalTool(
+    private val repository: InfrastructureRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "get_instance",
+        description = "Get details of a specific AAP instance by ID, including capacity and health",
+        parametersSchema = buildToolSchema(
+            Triple("instance_id", "integer", "ID of the instance"),
+            required = listOf("instance_id")
+        )
+    )
+) {
+    override suspend fun execute(args: Map<String, Any>): ToolResult {
+        return try {
+            val instanceId = (args["instance_id"] as? Number)?.toInt()
+                ?: return ToolResult(success = false, data = "instance_id is required", errorType = ErrorType.NOT_FOUND)
+            val instance = repository.getInstance(instanceId).getOrThrow()
+            ToolResult(success = true, data = networkJson.encodeToString(instance))
+        } catch (e: Exception) {
+            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetMeshTopologyLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetMeshTopologyLocalTool.kt
@@ -1,0 +1,26 @@
+package com.example.aapremote.assistant.tools.local
+
+import com.example.aapremote.assistant.tools.ErrorType
+import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.ToolResult
+import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.data.InfrastructureRepository
+
+class GetMeshTopologyLocalTool(
+    private val repository: InfrastructureRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "get_mesh_topology",
+        description = "Get the automation mesh topology — nodes, connections, and link status",
+        parametersSchema = buildToolSchema()
+    )
+) {
+    override suspend fun execute(args: Map<String, Any>): ToolResult {
+        return try {
+            val topology = repository.getMeshTopology().getOrThrow()
+            ToolResult(success = true, data = topology.toString())
+        } catch (e: Exception) {
+            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetProjectLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetProjectLocalTool.kt
@@ -1,0 +1,33 @@
+package com.example.aapremote.assistant.tools.local
+
+import com.example.aapremote.assistant.tools.ErrorType
+import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.ToolResult
+import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.data.ProjectRepository
+import com.example.aapremote.network.networkJson
+import kotlinx.serialization.encodeToString
+
+class GetProjectLocalTool(
+    private val repository: ProjectRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "get_project",
+        description = "Get details of a specific project by ID — SCM URL, branch, last sync status",
+        parametersSchema = buildToolSchema(
+            Triple("project_id", "integer", "ID of the project"),
+            required = listOf("project_id")
+        )
+    )
+) {
+    override suspend fun execute(args: Map<String, Any>): ToolResult {
+        return try {
+            val projectId = (args["project_id"] as? Number)?.toInt()
+                ?: return ToolResult(success = false, data = "project_id is required", errorType = ErrorType.NOT_FOUND)
+            val project = repository.getProject(projectId).getOrThrow()
+            ToolResult(success = true, data = networkJson.encodeToString(project))
+        } catch (e: Exception) {
+            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListCredentialsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListCredentialsLocalTool.kt
@@ -1,0 +1,43 @@
+package com.example.aapremote.assistant.tools.local
+
+import com.example.aapremote.assistant.tools.ErrorType
+import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.ToolResult
+import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.data.CredentialRepository
+import com.example.aapremote.network.networkJson
+import kotlinx.serialization.encodeToString
+
+class ListCredentialsLocalTool(
+    private val repository: CredentialRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_credentials",
+        description = "List credentials with optional search (no secrets exposed, only metadata)",
+        parametersSchema = buildToolSchema(
+            Triple("search", "string", "Search term to filter credentials by name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: Map<String, Any>): ToolResult {
+        return try {
+            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+            val result = repository.getCredentials(
+                page = (args["page"] as? Number)?.toInt() ?: 1,
+                pageSize = pageSize,
+                search = args["search"] as? String
+            ).getOrThrow()
+            ToolResult(
+                success = true,
+                data = networkJson.encodeToString(mapOf(
+                    "count" to result.totalCount.toString(),
+                    "credentials" to networkJson.encodeToString(result.credentials)
+                ))
+            )
+        } catch (e: Exception) {
+            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaActivationsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaActivationsLocalTool.kt
@@ -1,0 +1,41 @@
+package com.example.aapremote.assistant.tools.local
+
+import com.example.aapremote.assistant.tools.ErrorType
+import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.ToolResult
+import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.data.EdaActivationRepository
+import com.example.aapremote.network.networkJson
+import kotlinx.serialization.encodeToString
+
+class ListEdaActivationsLocalTool(
+    private val repository: EdaActivationRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_eda_activations",
+        description = "List EDA rulebook activations with status, restart policy, and rulebook info",
+        parametersSchema = buildToolSchema(
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 20, max 20)"),
+        )
+    )
+) {
+    override suspend fun execute(args: Map<String, Any>): ToolResult {
+        return try {
+            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 20) ?: 20
+            val result = repository.getActivations(
+                page = (args["page"] as? Number)?.toInt() ?: 1,
+                pageSize = pageSize
+            ).getOrThrow()
+            ToolResult(
+                success = true,
+                data = networkJson.encodeToString(mapOf(
+                    "count" to result.totalCount.toString(),
+                    "activations" to networkJson.encodeToString(result.activations)
+                ))
+            )
+        } catch (e: Exception) {
+            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListExecutionEnvironmentsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListExecutionEnvironmentsLocalTool.kt
@@ -1,0 +1,41 @@
+package com.example.aapremote.assistant.tools.local
+
+import com.example.aapremote.assistant.tools.ErrorType
+import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.ToolResult
+import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.data.ProjectRepository
+import com.example.aapremote.network.networkJson
+import kotlinx.serialization.encodeToString
+
+class ListExecutionEnvironmentsLocalTool(
+    private val repository: ProjectRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_execution_environments",
+        description = "List execution environments with image and organization info",
+        parametersSchema = buildToolSchema(
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: Map<String, Any>): ToolResult {
+        return try {
+            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+            val result = repository.getExecutionEnvironments(
+                page = (args["page"] as? Number)?.toInt() ?: 1,
+                pageSize = pageSize
+            ).getOrThrow()
+            ToolResult(
+                success = true,
+                data = networkJson.encodeToString(mapOf(
+                    "count" to result.totalCount.toString(),
+                    "execution_environments" to networkJson.encodeToString(result.executionEnvironments)
+                ))
+            )
+        } catch (e: Exception) {
+            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstanceGroupsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstanceGroupsLocalTool.kt
@@ -1,0 +1,41 @@
+package com.example.aapremote.assistant.tools.local
+
+import com.example.aapremote.assistant.tools.ErrorType
+import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.ToolResult
+import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.data.InfrastructureRepository
+import com.example.aapremote.network.networkJson
+import kotlinx.serialization.encodeToString
+
+class ListInstanceGroupsLocalTool(
+    private val repository: InfrastructureRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_instance_groups",
+        description = "List instance groups with capacity and container group info",
+        parametersSchema = buildToolSchema(
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: Map<String, Any>): ToolResult {
+        return try {
+            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+            val result = repository.getInstanceGroups(
+                page = (args["page"] as? Number)?.toInt() ?: 1,
+                pageSize = pageSize
+            ).getOrThrow()
+            ToolResult(
+                success = true,
+                data = networkJson.encodeToString(mapOf(
+                    "count" to result.totalCount.toString(),
+                    "instance_groups" to networkJson.encodeToString(result.instanceGroups)
+                ))
+            )
+        } catch (e: Exception) {
+            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstancesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstancesLocalTool.kt
@@ -1,0 +1,41 @@
+package com.example.aapremote.assistant.tools.local
+
+import com.example.aapremote.assistant.tools.ErrorType
+import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.ToolResult
+import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.data.InfrastructureRepository
+import com.example.aapremote.network.networkJson
+import kotlinx.serialization.encodeToString
+
+class ListInstancesLocalTool(
+    private val repository: InfrastructureRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_instances",
+        description = "List AAP cluster instances with node type, capacity, and health status",
+        parametersSchema = buildToolSchema(
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: Map<String, Any>): ToolResult {
+        return try {
+            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+            val result = repository.getInstances(
+                page = (args["page"] as? Number)?.toInt() ?: 1,
+                pageSize = pageSize
+            ).getOrThrow()
+            ToolResult(
+                success = true,
+                data = networkJson.encodeToString(mapOf(
+                    "count" to result.totalCount.toString(),
+                    "instances" to networkJson.encodeToString(result.instances)
+                ))
+            )
+        } catch (e: Exception) {
+            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListProjectsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListProjectsLocalTool.kt
@@ -1,0 +1,43 @@
+package com.example.aapremote.assistant.tools.local
+
+import com.example.aapremote.assistant.tools.ErrorType
+import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.ToolResult
+import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.data.ProjectRepository
+import com.example.aapremote.network.networkJson
+import kotlinx.serialization.encodeToString
+
+class ListProjectsLocalTool(
+    private val repository: ProjectRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_projects",
+        description = "List projects with SCM type, URL, branch, and sync status",
+        parametersSchema = buildToolSchema(
+            Triple("search", "string", "Search term to filter projects by name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: Map<String, Any>): ToolResult {
+        return try {
+            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+            val result = repository.getProjects(
+                page = (args["page"] as? Number)?.toInt() ?: 1,
+                pageSize = pageSize,
+                search = args["search"] as? String
+            ).getOrThrow()
+            ToolResult(
+                success = true,
+                data = networkJson.encodeToString(mapOf(
+                    "count" to result.totalCount.toString(),
+                    "projects" to networkJson.encodeToString(result.projects)
+                ))
+            )
+        } catch (e: Exception) {
+            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/PingLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/PingLocalTool.kt
@@ -1,0 +1,28 @@
+package com.example.aapremote.assistant.tools.local
+
+import com.example.aapremote.assistant.tools.ErrorType
+import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.ToolResult
+import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.data.InfrastructureRepository
+import com.example.aapremote.network.networkJson
+import kotlinx.serialization.encodeToString
+
+class PingLocalTool(
+    private val repository: InfrastructureRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "ping",
+        description = "Quick health check of the AAP cluster — returns version, HA status, and node info",
+        parametersSchema = buildToolSchema()
+    )
+) {
+    override suspend fun execute(args: Map<String, Any>): ToolResult {
+        return try {
+            val ping = repository.ping().getOrThrow()
+            ToolResult(success = true, data = networkJson.encodeToString(ping))
+        } catch (e: Exception) {
+            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/ui/AssistantScreen.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/ui/AssistantScreen.kt
@@ -30,6 +30,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -234,7 +240,15 @@ private fun ActiveChatContent(
                 onValueChange = { inputText = it },
                 modifier = Modifier
                     .weight(1f)
-                    .focusRequester(focusRequester),
+                    .focusRequester(focusRequester)
+                    .onPreviewKeyEvent { event ->
+                        if (event.key == Key.Enter && event.type == KeyEventType.KeyDown && !event.isShiftPressed) {
+                            submit()
+                            true
+                        } else {
+                            false
+                        }
+                    },
                 placeholder = { Text("Ask a question...") },
                 maxLines = 3,
             )

--- a/app/src/main/kotlin/com/example/aapremote/data/CredentialRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/CredentialRepository.kt
@@ -1,0 +1,44 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.Credential
+import com.example.aapremote.network.AapApiProvider
+
+class CredentialRepository(private val apiProvider: AapApiProvider) {
+
+    suspend fun getCredentials(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<CredentialListResult> {
+        return try {
+            val response = apiProvider.getApiService().getCredentials(
+                page = page,
+                pageSize = pageSize,
+                search = search
+            )
+            Result.success(
+                CredentialListResult(
+                    credentials = response.results,
+                    hasMore = response.next != null,
+                    totalCount = response.count
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getCredential(id: Int): Result<Credential> {
+        return try {
+            Result.success(apiProvider.getApiService().getCredential(id))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}
+
+data class CredentialListResult(
+    val credentials: List<Credential>,
+    val hasMore: Boolean,
+    val totalCount: Int
+)

--- a/app/src/main/kotlin/com/example/aapremote/data/DataModule.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/DataModule.kt
@@ -14,4 +14,8 @@ val dataModule = module {
     single { EdaAuditRepository(get<com.example.aapremote.network.AapApiProvider>()) }
     single { InventoryRepository(get<com.example.aapremote.network.AapApiProvider>()) }
     single { HostRepository(get<com.example.aapremote.network.AapApiProvider>()) }
+    single { InfrastructureRepository(get<com.example.aapremote.network.AapApiProvider>()) }
+    single { CredentialRepository(get<com.example.aapremote.network.AapApiProvider>()) }
+    single { ProjectRepository(get<com.example.aapremote.network.AapApiProvider>()) }
+    single { EdaActivationRepository(get<com.example.aapremote.network.AapApiProvider>()) }
 }

--- a/app/src/main/kotlin/com/example/aapremote/data/EdaActivationRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/EdaActivationRepository.kt
@@ -1,0 +1,42 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.EdaActivation
+import com.example.aapremote.network.AapApiProvider
+
+class EdaActivationRepository(private val apiProvider: AapApiProvider) {
+
+    suspend fun getActivations(
+        page: Int = 1,
+        pageSize: Int = 20
+    ): Result<EdaActivationListResult> {
+        return try {
+            val response = apiProvider.getEdaApiService().getActivations(
+                page = page,
+                pageSize = pageSize
+            )
+            Result.success(
+                EdaActivationListResult(
+                    activations = response.results,
+                    hasMore = response.next != null,
+                    totalCount = response.count
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getActivation(id: Int): Result<EdaActivation> {
+        return try {
+            Result.success(apiProvider.getEdaApiService().getActivation(id))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}
+
+data class EdaActivationListResult(
+    val activations: List<EdaActivation>,
+    val hasMore: Boolean,
+    val totalCount: Int
+)

--- a/app/src/main/kotlin/com/example/aapremote/data/InfrastructureRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/InfrastructureRepository.kt
@@ -1,0 +1,88 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.Instance
+import com.example.aapremote.model.InstanceGroup
+import com.example.aapremote.model.PingResponse
+import com.example.aapremote.network.AapApiProvider
+import kotlinx.serialization.json.JsonElement
+
+class InfrastructureRepository(private val apiProvider: AapApiProvider) {
+
+    suspend fun getInstances(
+        page: Int = 1,
+        pageSize: Int = 25
+    ): Result<InstanceListResult> {
+        return try {
+            val response = apiProvider.getApiService().getInstances(
+                page = page,
+                pageSize = pageSize
+            )
+            Result.success(
+                InstanceListResult(
+                    instances = response.results,
+                    hasMore = response.next != null,
+                    totalCount = response.count
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getInstance(id: Int): Result<Instance> {
+        return try {
+            Result.success(apiProvider.getApiService().getInstance(id))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getInstanceGroups(
+        page: Int = 1,
+        pageSize: Int = 25
+    ): Result<InstanceGroupListResult> {
+        return try {
+            val response = apiProvider.getApiService().getInstanceGroups(
+                page = page,
+                pageSize = pageSize
+            )
+            Result.success(
+                InstanceGroupListResult(
+                    instanceGroups = response.results,
+                    hasMore = response.next != null,
+                    totalCount = response.count
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun ping(): Result<PingResponse> {
+        return try {
+            Result.success(apiProvider.getApiService().ping())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getMeshTopology(): Result<JsonElement> {
+        return try {
+            Result.success(apiProvider.getApiService().getMeshTopology())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}
+
+data class InstanceListResult(
+    val instances: List<Instance>,
+    val hasMore: Boolean,
+    val totalCount: Int
+)
+
+data class InstanceGroupListResult(
+    val instanceGroups: List<InstanceGroup>,
+    val hasMore: Boolean,
+    val totalCount: Int
+)

--- a/app/src/main/kotlin/com/example/aapremote/data/ProjectRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/ProjectRepository.kt
@@ -1,0 +1,72 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.ExecutionEnvironment
+import com.example.aapremote.model.Project
+import com.example.aapremote.network.AapApiProvider
+
+class ProjectRepository(private val apiProvider: AapApiProvider) {
+
+    suspend fun getProjects(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<ProjectListResult> {
+        return try {
+            val response = apiProvider.getApiService().getProjects(
+                page = page,
+                pageSize = pageSize,
+                search = search
+            )
+            Result.success(
+                ProjectListResult(
+                    projects = response.results,
+                    hasMore = response.next != null,
+                    totalCount = response.count
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getProject(id: Int): Result<Project> {
+        return try {
+            Result.success(apiProvider.getApiService().getProject(id))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getExecutionEnvironments(
+        page: Int = 1,
+        pageSize: Int = 25
+    ): Result<ExecutionEnvironmentListResult> {
+        return try {
+            val response = apiProvider.getApiService().getExecutionEnvironments(
+                page = page,
+                pageSize = pageSize
+            )
+            Result.success(
+                ExecutionEnvironmentListResult(
+                    executionEnvironments = response.results,
+                    hasMore = response.next != null,
+                    totalCount = response.count
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}
+
+data class ProjectListResult(
+    val projects: List<Project>,
+    val hasMore: Boolean,
+    val totalCount: Int
+)
+
+data class ExecutionEnvironmentListResult(
+    val executionEnvironments: List<ExecutionEnvironment>,
+    val hasMore: Boolean,
+    val totalCount: Int
+)

--- a/app/src/main/kotlin/com/example/aapremote/model/Credential.kt
+++ b/app/src/main/kotlin/com/example/aapremote/model/Credential.kt
@@ -1,0 +1,38 @@
+package com.example.aapremote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Credential(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    @SerialName("credential_type") val credentialType: Int = 0,
+    @SerialName("summary_fields") val summaryFields: CredentialSummaryFields = CredentialSummaryFields(),
+    val managed: Boolean = false
+) {
+    val credentialTypeName: String
+        get() = summaryFields.credentialType?.name ?: ""
+
+    val organizationName: String
+        get() = summaryFields.organization?.name ?: ""
+}
+
+@Serializable
+data class CredentialSummaryFields(
+    @SerialName("credential_type") val credentialType: CredentialTypeRef? = null,
+    val organization: OrganizationRef? = null
+)
+
+@Serializable
+data class CredentialTypeRef(
+    val id: Int,
+    val name: String = ""
+)
+
+@Serializable
+data class OrganizationRef(
+    val id: Int,
+    val name: String = ""
+)

--- a/app/src/main/kotlin/com/example/aapremote/model/EdaActivation.kt
+++ b/app/src/main/kotlin/com/example/aapremote/model/EdaActivation.kt
@@ -1,0 +1,19 @@
+package com.example.aapremote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EdaActivation(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    val status: String = "",
+    @SerialName("is_enabled") val isEnabled: Boolean = false,
+    @SerialName("restart_policy") val restartPolicy: String = "",
+    @SerialName("rulebook_name") val rulebookName: String? = null,
+    @SerialName("decision_environment_name") val decisionEnvironmentName: String? = null,
+    @SerialName("project_name") val projectName: String? = null,
+    @SerialName("organization_name") val organizationName: String? = null,
+    @SerialName("created_at") val createdAt: String? = null
+)

--- a/app/src/main/kotlin/com/example/aapremote/model/Instance.kt
+++ b/app/src/main/kotlin/com/example/aapremote/model/Instance.kt
@@ -1,0 +1,45 @@
+package com.example.aapremote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Instance(
+    val id: Int,
+    val hostname: String = "",
+    @SerialName("node_type") val nodeType: String = "",
+    val enabled: Boolean = true,
+    val capacity: Int = 0,
+    @SerialName("consumed_capacity") val consumedCapacity: Float = 0f,
+    @SerialName("percent_capacity_remaining") val percentCapacityRemaining: Float = 100f,
+    val errors: String = "",
+    val version: String = ""
+)
+
+@Serializable
+data class InstanceGroup(
+    val id: Int,
+    val name: String = "",
+    val instances: Int = 0,
+    @SerialName("consumed_capacity") val consumedCapacity: Float = 0f,
+    @SerialName("percent_capacity_remaining") val percentCapacityRemaining: Float = 100f,
+    @SerialName("is_container_group") val isContainerGroup: Boolean = false
+)
+
+@Serializable
+data class PingResponse(
+    val ha: Boolean = false,
+    val version: String = "",
+    @SerialName("active_node") val activeNode: String = "",
+    @SerialName("install_uuid") val installUuid: String = "",
+    val instances: List<PingInstance> = emptyList()
+)
+
+@Serializable
+data class PingInstance(
+    val node: String = "",
+    @SerialName("node_type") val nodeType: String = "",
+    val capacity: Int = 0,
+    val version: String = "",
+    val errors: String = ""
+)

--- a/app/src/main/kotlin/com/example/aapremote/model/Project.kt
+++ b/app/src/main/kotlin/com/example/aapremote/model/Project.kt
@@ -1,0 +1,27 @@
+package com.example.aapremote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Project(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    @SerialName("scm_type") val scmType: String = "",
+    @SerialName("scm_url") val scmUrl: String = "",
+    @SerialName("scm_branch") val scmBranch: String = "",
+    val status: String = "",
+    @SerialName("last_job_run") val lastJobRun: String? = null,
+    val organization: Int? = null
+)
+
+@Serializable
+data class ExecutionEnvironment(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    val image: String = "",
+    val organization: Int? = null,
+    val managed: Boolean = false
+)

--- a/app/src/main/kotlin/com/example/aapremote/network/AapApiService.kt
+++ b/app/src/main/kotlin/com/example/aapremote/network/AapApiService.kt
@@ -121,4 +121,54 @@ interface AapApiService {
         @Query("page_size") pageSize: Int = 20,
         @Query("order_by") orderBy: String = "-created"
     ): PaginatedResponse<JobHostSummary>
+
+    @GET("instances/")
+    suspend fun getInstances(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("order_by") orderBy: String = "hostname"
+    ): PaginatedResponse<Instance>
+
+    @GET("instances/{id}/")
+    suspend fun getInstance(@Path("id") id: Int): Instance
+
+    @GET("instance_groups/")
+    suspend fun getInstanceGroups(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25
+    ): PaginatedResponse<InstanceGroup>
+
+    @GET("ping/")
+    suspend fun ping(): PingResponse
+
+    @GET("mesh_visualizer/")
+    suspend fun getMeshTopology(): kotlinx.serialization.json.JsonElement
+
+    @GET("credentials/")
+    suspend fun getCredentials(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "name"
+    ): PaginatedResponse<Credential>
+
+    @GET("credentials/{id}/")
+    suspend fun getCredential(@Path("id") id: Int): Credential
+
+    @GET("projects/")
+    suspend fun getProjects(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "-modified"
+    ): PaginatedResponse<Project>
+
+    @GET("projects/{id}/")
+    suspend fun getProject(@Path("id") id: Int): Project
+
+    @GET("execution_environments/")
+    suspend fun getExecutionEnvironments(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25
+    ): PaginatedResponse<ExecutionEnvironment>
 }

--- a/app/src/main/kotlin/com/example/aapremote/network/EdaApiService.kt
+++ b/app/src/main/kotlin/com/example/aapremote/network/EdaApiService.kt
@@ -1,5 +1,6 @@
 package com.example.aapremote.network
 
+import com.example.aapremote.model.EdaActivation
 import com.example.aapremote.model.EdaRuleAudit
 import com.example.aapremote.model.PaginatedResponse
 import retrofit2.http.GET
@@ -16,4 +17,13 @@ interface EdaApiService {
 
     @GET("audit-rules/{id}/")
     suspend fun getAuditRule(@Path("id") id: Int): EdaRuleAudit
+
+    @GET("activations/")
+    suspend fun getActivations(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 20
+    ): PaginatedResponse<EdaActivation>
+
+    @GET("activations/{id}/")
+    suspend fun getActivation(@Path("id") id: Int): EdaActivation
 }

--- a/app/src/main/kotlin/com/example/aapremote/ui/main/MainScreen.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/main/MainScreen.kt
@@ -6,9 +6,12 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.union
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Settings
@@ -17,6 +20,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
@@ -106,7 +110,9 @@ fun MainScreen(
             )
         },
         bottomBar = {
-            NavigationBar {
+            NavigationBar(
+                windowInsets = NavigationBarDefaults.windowInsets.union(WindowInsets.ime)
+            ) {
                 tabs.forEachIndexed { index, tab ->
                     NavigationBarItem(
                         selected = selectedTabIndex == index,

--- a/app/src/test/kotlin/com/example/aapremote/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/assistant/engine/ToolRouterTest.kt
@@ -600,6 +600,49 @@ class ToolRouterTest {
     }
 
     @Test
+    fun `SHOULD rank list tools above write tools for budget cuts`() {
+        val tools = listOf(
+            localTool("launch_job", destructive = true),
+            localTool("get_job_stdout"),
+            localTool("list_job_templates"),
+            localTool("get_job"),
+            localTool("list_jobs"),
+            localTool("list_workflow_templates"),
+            localTool("launch_workflow", destructive = true),
+            localTool("get_workflow_job"),
+            localTool("list_schedules"),
+            localTool("toggle_schedule", destructive = true)
+        )
+        router.registerLocalTools(tools)
+        val result = router.getToolsForQuery("what job templates are available")
+
+        assertTrue(result.size >= 5)
+        val top5 = result.take(5).map { it.spec.name }
+        assertTrue("list_job_templates" in top5)
+        assertTrue("list_jobs" in top5)
+        assertTrue("list_workflow_templates" in top5)
+        assertFalse("launch_job" in top5)
+        assertFalse("toggle_schedule" in top5)
+    }
+
+    @Test
+    fun `SHOULD boost query-matching tools in ranking`() {
+        val tools = listOf(
+            localTool("list_schedules"),
+            localTool("toggle_schedule", destructive = true),
+            localTool("list_job_templates"),
+            localTool("launch_job", destructive = true),
+            localTool("get_job"),
+            localTool("list_jobs")
+        )
+        router.registerLocalTools(tools)
+        val result = router.getToolsForQuery("show my schedules")
+        val names = result.map { it.spec.name }
+
+        assertEquals("list_schedules", names[0])
+    }
+
+    @Test
     fun `SHOULD select monitoring tools WHEN query mentions mesh topology`() {
         val tools = listOf(
             localTool("get_mesh_topology"),

--- a/app/src/test/kotlin/com/example/aapremote/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/assistant/engine/ToolRouterTest.kt
@@ -487,4 +487,131 @@ class ToolRouterTest {
         assertTrue("list_hosts" in names)
         assertTrue("controller.users_list" in names)
     }
+
+    // --- Phase 2 local tool tests ---
+
+    @Test
+    fun `SHOULD select monitoring tools WHEN query mentions instances`() {
+        val tools = listOf(
+            localTool("list_instances"),
+            localTool("get_instance"),
+            localTool("list_instance_groups"),
+            localTool("ping"),
+            localTool("get_mesh_topology"),
+            localTool("list_hosts")
+        )
+        router.registerLocalTools(tools)
+        val result = router.getToolsForQuery("show cluster instances")
+        val names = result.map { it.spec.name }
+
+        assertTrue("list_instances" in names)
+        assertTrue("get_instance" in names)
+        assertTrue("list_instance_groups" in names)
+        assertTrue("ping" in names)
+        assertTrue("get_mesh_topology" in names)
+        assertFalse("list_hosts" in names)
+    }
+
+    @Test
+    fun `SHOULD select monitoring tools WHEN query mentions health`() {
+        val tools = listOf(
+            localTool("list_instances"),
+            localTool("ping"),
+            localTool("list_hosts")
+        )
+        router.registerLocalTools(tools)
+        val result = router.getToolsForQuery("check system health")
+        val names = result.map { it.spec.name }
+
+        assertTrue("list_instances" in names)
+        assertTrue("ping" in names)
+        assertFalse("list_hosts" in names)
+    }
+
+    @Test
+    fun `SHOULD select credential tools WHEN query mentions credentials`() {
+        val tools = listOf(
+            localTool("list_credentials"),
+            localTool("get_credential"),
+            localTool("list_hosts")
+        )
+        router.registerLocalTools(tools)
+        val result = router.getToolsForQuery("show my credentials")
+        val names = result.map { it.spec.name }
+
+        assertTrue("list_credentials" in names)
+        assertTrue("get_credential" in names)
+        assertFalse("list_hosts" in names)
+    }
+
+    @Test
+    fun `SHOULD select project tools WHEN query mentions projects`() {
+        val tools = listOf(
+            localTool("list_projects"),
+            localTool("get_project"),
+            localTool("list_execution_environments"),
+            localTool("list_hosts")
+        )
+        router.registerLocalTools(tools)
+        val result = router.getToolsForQuery("list projects")
+        val names = result.map { it.spec.name }
+
+        assertTrue("list_projects" in names)
+        assertTrue("get_project" in names)
+        assertTrue("list_execution_environments" in names)
+        assertFalse("list_hosts" in names)
+    }
+
+    @Test
+    fun `SHOULD select EDA activation tools WHEN query mentions activations`() {
+        val tools = listOf(
+            localTool("list_eda_activations"),
+            localTool("get_eda_activation"),
+            localTool("list_eda_audit_rules"),
+            localTool("list_hosts")
+        )
+        router.registerLocalTools(tools)
+        val result = router.getToolsForQuery("show eda activations")
+        val names = result.map { it.spec.name }
+
+        assertTrue("list_eda_activations" in names)
+        assertTrue("get_eda_activation" in names)
+        assertTrue("list_eda_audit_rules" in names)
+        assertFalse("list_hosts" in names)
+    }
+
+    @Test
+    fun `SHOULD auto-disable Phase 2 MCP overlaps WHEN local tools registered`() {
+        val localTools = listOf(
+            localTool("list_instances"),
+            localTool("ping"),
+            localTool("list_credentials"),
+            localTool("list_projects"),
+            localTool("list_eda_activations")
+        )
+        router.registerLocalTools(localTools)
+
+        assertFalse(router.isToolEnabled("controller.instances_list", ToolSource.MCP))
+        assertFalse(router.isToolEnabled("controller.ping_read", ToolSource.MCP))
+        assertFalse(router.isToolEnabled("controller.credentials_list", ToolSource.MCP))
+        assertFalse(router.isToolEnabled("controller.projects_list", ToolSource.MCP))
+        assertFalse(router.isToolEnabled("eda.activations_list", ToolSource.MCP))
+        assertTrue(router.isToolEnabled("controller.users_list", ToolSource.MCP))
+    }
+
+    @Test
+    fun `SHOULD select monitoring tools WHEN query mentions mesh topology`() {
+        val tools = listOf(
+            localTool("get_mesh_topology"),
+            localTool("list_instances"),
+            localTool("list_hosts")
+        )
+        router.registerLocalTools(tools)
+        val result = router.getToolsForQuery("show mesh topology")
+        val names = result.map { it.spec.name }
+
+        assertTrue("get_mesh_topology" in names)
+        assertTrue("list_instances" in names)
+        assertFalse("list_hosts" in names)
+    }
 }

--- a/docs/specs/koog-evaluation.md
+++ b/docs/specs/koog-evaluation.md
@@ -1,0 +1,433 @@
+# Koog Evaluation — Full Findings
+
+**Date:** 2026-05-09
+**Issue:** [#56](https://github.com/leogallego/aapdroid/issues/56)
+**Framework:** [Koog](https://github.com/JetBrains/koog) by JetBrains (Apache 2.0, 4.1K stars)
+**Version analyzed:** Commit `24f6695` (May 2026)
+
+## Executive Summary
+
+Koog is a viable replacement for ~1,260 lines of custom LLM/MCP/agent code across 4 subsystems. 6 of 8 evaluation questions returned positive results. Two significant risks remain: OkHttp 4→5 version conflict and mandatory Kotlin 2.3.10 upgrade. Recommendation: incremental adoption in 3 phases.
+
+| Aspect | Current Custom Code | Koog Replacement | Verdict |
+|--------|-------------------|------------------|---------|
+| LLM provider | 370 LOC, OpenAI-compat only | 9 providers, lenient serialization | Adopt |
+| MCP client | 570 LOC, custom JSON-RPC + SSE | Official MCP SDK wrapper, `fromSseUrl()` | Adopt |
+| ChatEngine | 210 LOC, tool loop + trim | Agent framework with compression strategies | Adopt |
+| ToolExecutor | 113 LOC, caching + truncation | Tool registry + custom tools | Adopt |
+
+---
+
+## Q1: Can We Use Just the LLM Client Modules?
+
+**Verdict: Partial — works but pulls transitive dependencies.**
+
+Importing `prompt-executor-openai-client` gives you `OpenAILLMClient` with streaming chat completions and tool calling. You do NOT get:
+- `agents-core` (agent state machine)
+- `agents-mcp` (MCP integration)
+- `agents-features-*` (history compression, memory, tracing)
+
+But you DO get transitively:
+- `agents-tools` (tool descriptor definitions)
+- `agents-utils` (internal utilities)
+- `rag-base` (vector/RAG base abstractions)
+- `http-client-ktor` + Ktor client modules
+- `prompt-*` modules (model, llm, structure, markdown, xml)
+- ~15 total modules
+
+These transitive modules are lightweight (interfaces + data classes), not the heavyweight agent machinery.
+
+### Gradle dependency
+
+```kotlin
+// Minimum for OpenAI client only
+implementation("ai.koog.prompt:prompt-executor-openai-client:$koogVersion")
+```
+
+---
+
+## Q2: Does the OpenAI Client Handle Non-Standard Providers?
+
+**Verdict: Yes — lenient serialization is a strong point.**
+
+### JSON Configuration (from `AbstractOpenAILLMClient.kt`)
+
+```kotlin
+private val defaultJson = Json {
+    ignoreUnknownKeys = true  // Handles provider-specific extra fields
+    isLenient = true          // Accepts unquoted strings, trailing commas
+    encodeDefaults = true     // Includes defaults in requests
+    explicitNulls = false     // Omits null fields
+    namingStrategy = JsonNamingStrategy.SnakeCase
+}
+```
+
+### Data model design
+
+Response models use nullable types with defaults:
+```kotlin
+@Serializable
+class OpenAIUsage(
+    val promptTokens: Int? = null,
+    val completionTokens: Int? = null,
+    val totalTokens: Int? = null,
+    // ...
+)
+```
+
+### Custom provider support
+
+```kotlin
+class CustomProvider(apiKey: String, baseUrl: String) : AbstractOpenAILLMClient(
+    apiKey = apiKey,
+    settings = object : OpenAIBaseSettings(
+        baseUrl = baseUrl,
+        chatCompletionsPath = "/chat/completions"
+    ) {}
+)
+```
+
+### Known provider quirks handled
+
+- **OpenRouter**: Empty string arguments → auto-fixed to `{}`
+- **DeepSeek**: Missing `audioTokens` field → fixed via nullable default
+- **Multi-provider clients**: OpenRouter, DeepSeek, Ollama, DashScope all extend the same `AbstractOpenAILLMClient` base
+
+### Comparison with our code
+
+Our custom provider is intentionally lenient for Gemini-via-OpenAI-compat, local models, etc. Koog matches this behavior with `ignoreUnknownKeys` + nullable models. Equivalent or better.
+
+---
+
+## Q3: APK Size Impact
+
+**Verdict: ~2-4 MB after R8 (4-8% of current 52 MB APK).**
+
+### Size breakdown (pre-R8)
+
+| Component | Estimated JAR Size |
+|-----------|--------------------|
+| Ktor client/server modules | ~2.5-3.2 MB |
+| Koog's own modules (30+) | ~2-3.3 MB |
+| Other transitive deps (kotlinx-io, datetime, logging, MCP SDK) | ~0.6 MB |
+| **Total pre-R8** | **~5-7 MB** |
+| **After R8 (40-60% shrink)** | **~2-4 MB** |
+
+### Concerns
+
+1. **`koog-agents` is an umbrella** — includes ALL 9 LLM provider clients and ALL features. No way to select only what you need.
+2. **Ktor server modules** — `agents-core` transitively depends on `ktor-server-sse` + `ktor-server-cio`, which is dead weight on mobile (~1 MB).
+3. **With R8 enabled** (#43), unused provider clients and server modules get stripped. Final impact should be manageable.
+
+### Mitigation
+
+- Enable R8 minification (#43) before adding Koog
+- If using individual modules instead of `koog-agents`, avoid `agents-core` until needed
+
+---
+
+## Q4: Can We Keep Our ToolRouter?
+
+**Verdict: Yes — build filtered ToolRegistry per agent run.**
+
+### What Koog does NOT provide
+- No built-in per-request tool filtering based on message content
+- No "tool interceptor" for selective tool hiding
+- No read-only mode or permission-based blocking
+
+### Integration strategies
+
+**Keyword filtering (ToolRouter's primary function):**
+```kotlin
+val fullRegistry = McpToolRegistryProvider.fromSseUrl(sseUrl)
+val filteredRegistry = ToolRegistry {
+    fullRegistry.tools
+        .filter { tool -> toolRouter.shouldInclude(userMessage, tool.descriptor) }
+        .forEach { tool(it) }
+}
+val agent = AIAgent.builder()
+    .toolRegistry(filteredRegistry)
+    .build()
+```
+
+**Read-only enforcement:**
+```kotlin
+class ReadOnlyEnvironment(
+    private val delegate: AIAgentEnvironment,
+    private val writeToolNames: Set<String>
+) : AIAgentEnvironment {
+    override suspend fun executeTool(toolCall: Message.Tool.Call): ReceivedToolResult {
+        if (toolCall.tool in writeToolNames) {
+            return ReceivedToolResult(
+                content = "Tool '${toolCall.tool}' is blocked in read-only mode",
+                resultKind = ToolResultKind.Failure(SecurityException("Write tool blocked")),
+                // ...
+            )
+        }
+        return delegate.executeTool(toolCall)
+    }
+}
+```
+
+### Key architectural note
+
+Koog binds `ToolRegistry` at agent construction. Our ToolRouter filters per-message. Solution: create a new agent per user message (cheap) with a filtered registry. This maps naturally to our current ChatEngine flow.
+
+---
+
+## Q5: Does Koog's MCP Client Support SSE Transport?
+
+**Verdict: Yes — full SSE support, wraps official MCP Kotlin SDK.**
+
+### Transport types supported
+1. **SSE** — via `SseClientTransport`
+2. **Streamable HTTP** — via `StreamableHttpClientTransport`
+3. **stdio** — via `StdioClientTransport`
+
+### One-liner connection
+
+```kotlin
+val toolRegistry = McpToolRegistryProvider.fromSseUrl(
+    "https://aap-gateway.example.com:8448/mcp/sse"
+)
+```
+
+### Underlying SDK
+
+Koog wraps `io.modelcontextprotocol:kotlin-sdk-client` v0.11.1 (official MCP Kotlin SDK). The MCP module is JVM-only (comment in build.gradle.kts: "Kotlin MCP SDK only supports JVM target for now"). Fine for Android.
+
+### Session management
+
+Handled by the MCP Kotlin SDK internally. `Client.connect(transport)` performs the initialize handshake. No built-in SSE reconnection — if connection drops, create a new client (same as our current approach).
+
+### Platform note
+
+MCP module imports:
+```kotlin
+import io.modelcontextprotocol.kotlin.sdk.client.Client
+import io.modelcontextprotocol.kotlin.sdk.client.SseClientTransport
+```
+
+---
+
+## Q6: Ktor Migration Path
+
+**Verdict: Coexistence works, but OkHttp version conflict is the biggest risk.**
+
+### How ktor-client-okhttp bridges existing setup
+
+```kotlin
+val sharedOkHttpClient = OkHttpClient.Builder()
+    .sslSocketFactory(customSslSocketFactory, customTrustManager)
+    .addInterceptor(authInterceptor)
+    .build()
+
+// Retrofit (unchanged)
+val retrofit = Retrofit.Builder()
+    .client(sharedOkHttpClient)
+    .build()
+
+// Ktor for Koog (shares same OkHttp transport)
+val ktorClient = HttpClient(OkHttp) {
+    engine {
+        preconfigured = sharedOkHttpClient
+    }
+}
+```
+
+The `preconfigured` property calls `okHttpClient.newBuilder()`, preserving SSL config, interceptors, and connection pool.
+
+### OkHttp version conflict (CRITICAL)
+
+| Component | Version |
+|-----------|---------|
+| Our app (Retrofit) | OkHttp **4.12.0** (Okio 2.x) |
+| Koog | OkHttp **5.3.2** (Okio 3.x) |
+
+Gradle resolves to one version. OkHttp 5.x has:
+- Okio 3.x (Kotlin-first API, different from Okio 2.x)
+- Same `okhttp3` package but internal API differences
+- Retrofit 2.11 *should* be compatible, but needs testing
+
+### Impact assessment
+
+| Usage | After Koog |
+|-------|------------|
+| Retrofit + OkHttp for AAP API | Unchanged (keep as-is) |
+| OkHttp for LLM API calls | **Replaced by Koog** |
+| OkHttp for MCP SSE | **Replaced by Koog** |
+
+At the transport level: single OkHttp instance. At the API level: Retrofit (AAP) + Ktor (LLM/MCP). Both are thin wrappers over OkHttp.
+
+### Koog's own OkHttp module (alternative path)
+
+Koog has `http-client-okhttp` with `KoogHttpClient.fromOkHttpClient()` that uses OkHttp directly without Ktor. But it's excluded from `koog-agents` and marked `@Experimental`.
+
+### No need to migrate Retrofit
+
+Retrofit remains fine for AAP REST API calls. Ktor handles LLM/MCP inside Koog. They coexist cleanly.
+
+---
+
+## Q7: History Compression + Chat UI
+
+**Verdict: Fully compatible — compression is LLM-internal only.**
+
+### How compression works
+
+Compression modifies `llmSession.prompt.messages` (what goes to the LLM API). It has zero knowledge of the UI layer. Our LazyColumn display list is completely independent.
+
+```
+UI Layer:  messages in LazyColumn → append-only, full history
+LLM Layer: agent.prompt.messages → compressed by strategy
+```
+
+### Available strategies
+
+| Strategy | How it works | Best for |
+|----------|-------------|----------|
+| **WholeHistory** | Compress everything into one TLDR | Simple conversations |
+| **FromLastNMessages(n)** | Keep last N, discard rest | Recent context only |
+| **Chunked(n)** | Split into chunks, summarize each | **Tool-calling apps (recommended)** |
+| **RetrieveFactsFromHistory** | Extract named concepts | Targeted context extraction |
+
+### Recommendation for AAPdroid
+
+**`Chunked(10)`** — preserves multi-step tool interaction context (e.g., "listed templates → launched job #42 → checked status"). Each chunk gets its own summary, so the LLM retains awareness of the full workflow.
+
+Alternative: **`RetrieveFactsFromHistory`** with domain-specific concepts:
+```kotlin
+Concept("aap_instance", "Which AAP instance the user is connected to", FactType.SINGLE)
+Concept("completed_actions", "Actions already performed", FactType.MULTIPLE)
+```
+
+### Caveat
+
+Each compression triggers an extra LLM API call (`requestLLMWithoutTools()`). On mobile with metered data, trigger compression only when history exceeds a threshold, not on every turn.
+
+---
+
+## Q8: Local Tools Coexistence
+
+**Verdict: Fully supported — same Tool base class, registry merging with priority.**
+
+### Koog's tool abstraction
+
+```kotlin
+abstract class Tool<TArgs, TResult>(
+    val argsType: TypeToken,
+    val resultType: TypeToken,
+    val descriptor: ToolDescriptor,
+) {
+    abstract suspend fun execute(args: TArgs): TResult
+}
+```
+
+MCP tools (`McpTool`) are just `Tool<JSONObject, CallToolResult?>` subclasses — same interface as any custom tool.
+
+### Wrapping Retrofit tools for Koog
+
+```kotlin
+object LaunchJobTool : SimpleTool<LaunchJobTool.Args>(
+    argsType = typeToken<Args>(),
+    name = "launch_job",
+    description = "Launch a job template on AAP by its ID"
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("The ID of the job template to launch")
+        val templateId: Int
+    )
+    override suspend fun execute(args: Args): String {
+        val result = aapApiService.launchJob(args.templateId)
+        return "Job launched. Job ID: ${result.id}"
+    }
+}
+```
+
+### Registry merging with priority
+
+```kotlin
+val localRegistry = ToolRegistry {
+    tool(LaunchJobTool)
+    tool(GetStatusTool)
+}
+val mcpRegistry = McpToolRegistryProvider.fromSseUrl(sseUrl)
+
+// Local tools win on name collisions (distinctBy keeps first)
+val combined = localRegistry + mcpRegistry
+```
+
+The `+` operator uses `distinctBy { it.name }` — first occurrence wins. Placing local registry first ensures local tools take priority over MCP equivalents with the same name.
+
+### Architecture flow
+
+```
+User opens Assistant
+  → Connect MCP → mcpRegistry
+  → Create local tools → localRegistry
+  → Merge: localRegistry + mcpRegistry (local wins)
+  → Create Koog agent with combined registry
+  → User message → agent.run() → LLM sees all tools
+  → Local tool called → Retrofit in-process (no MCP hop)
+  → MCP tool called → routed to MCP server
+```
+
+---
+
+## Risk Assessment
+
+### High Risk
+- **OkHttp 4→5 conflict**: Requires testing Retrofit 2.11 + OkHttp 5.3.2 + Okio 3.x. Custom SSL code (`CertTrustManager`) may need API adjustments.
+- **Kotlin 2.2→2.3 upgrade**: Compose compiler version must match. May introduce breaking changes.
+
+### Medium Risk
+- **APK size**: ~2-4 MB after R8. Mitigated by enabling R8 first (#43).
+- **Ktor server modules**: Dead weight on mobile. No current way to exclude from `koog-agents`.
+
+### Low Risk
+- **ToolRouter integration**: Clear path via per-run filtered ToolRegistry.
+- **MCP compatibility**: Wraps official SDK, SSE fully supported.
+- **History compression**: Orthogonal to UI, well-designed.
+- **Local tools**: Clean coexistence via registry merging.
+
+---
+
+## Migration Plan
+
+### Phase 1: LLM Provider Only (Low Risk)
+
+**Replace:** `OpenAiCompatibleProvider` (370 LOC)
+**With:** Koog's `OpenAILLMClient` via `prompt-executor-openai-client`
+**Keep:** ChatEngine, ToolExecutor, MCP client (unchanged)
+**Validates:** Kotlin upgrade, OkHttp 5 compatibility, Ktor coexistence
+
+### Phase 2: Agent Framework (Medium Risk)
+
+**Replace:** ChatEngine (210 LOC) + ToolExecutor (113 LOC)
+**With:** Koog's agent framework (`agents-core`)
+**Integrate:** ToolRouter builds filtered ToolRegistry per message
+**Benefit:** History compression, repetition detection, built-in caching
+
+### Phase 3: MCP Client (Low Risk, after Phase 2)
+
+**Replace:** Custom MCP client (570 LOC)
+**With:** Koog's MCP module (`agents-mcp`)
+**Use:** `McpToolRegistryProvider.fromSseUrl()` for AAP MCP servers
+**Benefit:** Official MCP SDK, streamable HTTP support, session management
+
+### Prerequisites (before Phase 1)
+
+1. Enable R8 minification (#43)
+2. Upgrade Kotlin 2.2.10 → 2.3.10
+3. Test Retrofit 2.11 + OkHttp 5.3.2 compatibility
+4. Verify Compose BOM compatibility with Kotlin 2.3
+
+---
+
+## Related Issues
+
+- **#48** — MCP SDK migration → superseded by Phase 3
+- **#54** — Local tools layer → independent, coexists with Koog (Q8)
+- **#52** — MCP toolset endpoints → complementary, works with Koog's MCP
+- **#43** — R8 minification → prerequisite for managing APK size


### PR DESCRIPTION
## Summary

- **12 new read-only local tools** for Tier 2 endpoints: cluster instances, instance groups, ping, mesh topology, credentials, projects, execution environments, and EDA rulebook activations
- **New Retrofit endpoints**: 11 in AapApiService + 2 in EdaApiService
- **4 new repositories**: InfrastructureRepository, CredentialRepository, ProjectRepository, EdaActivationRepository
- **4 new model files**: Instance.kt, Credential.kt, Project.kt, EdaActivation.kt
- **ToolRouter updates**: MONITORING, SECURITY, CONFIGURATION, EDA categories now have local tool names + 12 new overlap mappings
- **Bug fix**: Local tools now exempt from token budget limits (only MCP tools are budgeted). Fixes issue where Token Saver mode was dropping `list_job_templates` while keeping less useful tools
- **Tool ranking**: Tools sorted by relevance (list > get > write) before any budget cuts

## What's done (Phase 1 + Phase 2)

- 26 local tools total (14 Tier 1 + 12 Tier 2)
- All read-only operations covered
- ToolRouter category matching, overlap resolution, per-tool enable/disable
- Token budget only applies to MCP tools

## What's remaining (#54 Phase 3+)

- [ ] Tier 2 write operations: cancel_job, relaunch_job, sync_project, toggle_eda_activation
- [ ] Tier 2 P3 read-only: list_organizations, list_labels, list_eda_decision_environments
- [ ] Write confirmation flow (ties into #34)
- [ ] Per-tool enable/disable UI in assistant settings
- [ ] MCP toolset coexistence refinements (#52)

## Test plan

- [x] `./gradlew assembleDebug` compiles
- [x] `./gradlew testDebugUnitTest` — 38 ToolRouter tests pass (0 failures)
- [ ] Manual: verify "what job templates are available?" uses local tool in Token Saver mode
- [ ] Manual: verify "check cluster health" selects monitoring tools

🤖 Generated with [Claude Code](https://claude.ai/code)