### PR TITLE
Enable R8 minification — APK 52MB to 8.2MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A lightweight Android app for remotely controlling [Ansible Automation Platform (AAP)](https://www.redhat.com/en/technologies/management/ansible). Authenticate with your AAP instance, browse job templates, launch playbooks, and monitor job status from your phone.
 
 > **Disclaimer:** This project is not affiliated with or endorsed by Red Hat or the Ansible project.
+>
+> This is a vibe-coded, spec-driven, AI-assisted developed application. It comes with **no warranties of any kind** — use at your own risk. This project exists purely for research and investigation purposes.
 
 ## Features
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "com.example.aapremote"
         minSdk = 31
         targetSdk = 36
-        versionCode = 2605012
-        versionName = "1.1.1"
+        versionCode = 2605013
+        versionName = "1.1.2"
     }
 
     signingConfigs {
@@ -30,7 +30,12 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
             signingConfig = if (System.getenv("KEYSTORE_FILE") != null)
                 signingConfigs.getByName("release")
             else signingConfigs.getByName("debug")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -51,7 +51,7 @@
 
 # ── Koin ─────────────────────────────────────────────────────────────
 -keep class org.koin.** { *; }
--keepclassmembers class * {
+-keepclassmembers class com.example.aapremote.** {
     public <init>(...);
 }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,64 @@
+# ── Kotlin Serialization ──────────────────────────────────────────────
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault
+
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+
+-if @kotlinx.serialization.Serializable class ** {
+    static **$Companion Companion;
+}
+-keepclassmembers class <2>$Companion {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static ** INSTANCE;
+}
+
+-keepclassmembers class kotlinx.serialization.json.** { *; }
+-keep,includedescriptorclasses class com.example.aapremote.model.**$$serializer { *; }
+-keepclassmembers class com.example.aapremote.model.** {
+    *** Companion;
+}
+
+# ── Retrofit ─────────────────────────────────────────────────────────
+-keepattributes Signature,Exceptions,InnerClasses,EnclosingMethod
+-keepattributes *Annotation*
+
+-keepclasseswithmembers class * {
+    @retrofit2.http.* <methods>;
+}
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# ── OkHttp ───────────────────────────────────────────────────────────
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**
+
+# ── Tink ─────────────────────────────────────────────────────────────
+-keep class com.google.crypto.tink.** { *; }
+-keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
+-dontwarn com.google.errorprone.annotations.**
+-dontwarn javax.annotation.**
+
+# ── Koin ─────────────────────────────────────────────────────────────
+-keep class org.koin.** { *; }
+-keepclassmembers class * {
+    public <init>(...);
+}
+
+# ── Markdown Renderer ────────────────────────────────────────────────
+-keep class com.mikepenz.markdown.** { *; }
+
+# ── App models (Retrofit response types need full generic info) ──────
+-keep class com.example.aapremote.model.** { *; }
+-keep class com.example.aapremote.network.** { *; }
+-keep class com.example.aapremote.assistant.llm.** { *; }


### PR DESCRIPTION
## Summary
- Enable R8 minification and resource shrinking for release builds
- Add ProGuard rules for Kotlin Serialization, Retrofit, OkHttp, Tink, Koin, and markdown-renderer
- Release APK drops from **52MB → 8.2MB** (84% reduction)
- Add vibe-coded / no-warranty disclaimer to README
- Bump version to 1.1.2

## Test plan
- [x] `./gradlew assembleRelease` builds successfully
- [x] `./gradlew testDebugUnitTest` — all 103 tests pass
- [ ] CI build passes
- [ ] Verify release APK installs and runs on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)