### PR TITLE
Bump minor dependencies to latest stable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,19 @@
 [versions]
 agp = "9.2.1"
-kotlin = "2.2.10"
-compose-bom = "2026.03.01"
+kotlin = "2.3.21"
+compose-bom = "2026.05.00"
 activity-compose = "1.13.0"
-navigation-compose = "2.9.7"
+navigation-compose = "2.9.8"
 lifecycle = "2.10.0"
-retrofit = "2.11.0"
+retrofit = "2.12.0"
 okhttp = "4.12.0"
-kotlinx-serialization-json = "1.9.0"
-koin = "4.1.1"
+kotlinx-serialization-json = "1.11.0"
+koin = "4.2.1"
 datastore-preferences = "1.2.1"
-tink-android = "1.20.0"
-coroutines = "1.10.2"
+tink-android = "1.21.0"
+coroutines = "1.11.0"
 core-ktx = "1.18.0"
-markdownRenderer = "0.40.2"
+markdownRenderer = "0.41.0"
 
 [libraries]
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }


### PR DESCRIPTION
## Summary

Minor version bumps for 9 dependencies (no major/breaking changes):

| Dependency | From | To |
|---|---|---|
| Kotlin | 2.2.10 | **2.3.21** |
| Compose BOM | 2026.03.01 | **2026.05.00** |
| Navigation Compose | 2.9.7 | **2.9.8** |
| Retrofit | 2.11.0 | **2.12.0** |
| kotlinx-serialization | 1.9.0 | **1.11.0** |
| Koin | 4.1.1 | **4.2.1** |
| Tink | 1.20.0 | **1.21.0** |
| Coroutines | 1.10.2 | **1.11.0** |
| Markdown Renderer | 0.40.2 | **0.41.0** |

Includes the patch bumps from #62 (Kotlin 2.2.21, Nav 2.9.8) — merge this one instead if both are approved, then close #62.

## Notes

- Kotlin 2.3.x brings context parameters, explicit backing fields, and Java 25 support
- Koin 4.2 adds lazy modules, Nav3 support, and Dagger bridge
- Retrofit 2.12.0 is the last 2.x release before 3.0.0 (binary compatible)
- OkHttp stays at 4.12.0 (5.x is a major bump, deferred)

## Test plan

- [ ] Gradle sync succeeds
- [ ] `./gradlew build --dry-run` passes
- [ ] App builds and runs on emulator
- [ ] Unit tests pass
- [ ] AI Assistant chat works (serialization + coroutines changed)

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>