### PR TITLE
Add dev suffix to debug builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,12 @@ android {
     }
 
     buildTypes {
+        debug {
+            val gitSha = providers.exec {
+                commandLine("git", "rev-parse", "--short", "HEAD")
+            }.standardOutput.asText.get().trim()
+            versionNameSuffix = "-dev+$gitSha"
+        }
         release {
             isMinifyEnabled = true
             isShrinkResources = true


### PR DESCRIPTION
## Summary
- Debug builds now show version like `1.1.2-dev+36f5a6f` using git SHA
- Release builds are unchanged
- Makes it easy to identify which commit a debug APK was built from

## Test plan
- [ ] Build debug APK and verify version in Settings shows `-dev+<sha>` suffix
- [ ] Build release APK and verify version shows only `1.1.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)