### PR TITLE
Remove adapter layer, use Koog types directly in engine

### DIFF
--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlin.coroutines.coroutineContext
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
@@ -62,7 +63,6 @@ class ChatEngine(
                 coroutineContext.ensureActive()
                 val textBuilder = StringBuilder()
                 val pendingToolCalls = mutableMapOf<String, MutableToolCall>()
-                var streamError: Throwable? = null
 
                 trimMessages(messages)
                 val prompt = buildPrompt(messages)
@@ -89,11 +89,6 @@ class ChatEngine(
                         is StreamFrame.End -> { /* handled after collect */ }
                         else -> { /* ReasoningDelta etc — ignore */ }
                     }
-                }
-
-                if (streamError != null) {
-                    emit(ChatEvent.Error("LLM error: ${streamError.message}", streamError))
-                    return@flow
                 }
 
                 val completedCalls = pendingToolCalls.values
@@ -124,8 +119,8 @@ class ChatEngine(
                     }
 
                     val toolCallsJson = json.encodeToString(
-                        kotlinx.serialization.json.JsonArray.serializer(),
-                        kotlinx.serialization.json.JsonArray(completedCalls.map { tc ->
+                        JsonArray.serializer(),
+                        JsonArray(completedCalls.map { tc ->
                             JsonObject(mapOf(
                                 "id" to kotlinx.serialization.json.JsonPrimitive(tc.id),
                                 "name" to kotlinx.serialization.json.JsonPrimitive(tc.tool),
@@ -231,7 +226,7 @@ class ChatEngine(
     private fun parseToolCalls(toolCallsJson: String): List<Message.Tool.Call> {
         return try {
             val element = json.parseToJsonElement(toolCallsJson)
-            if (element is kotlinx.serialization.json.JsonArray) {
+            if (element is JsonArray) {
                 element.map { el ->
                     val obj = el.jsonObject
                     Message.Tool.Call(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
@@ -1,21 +1,27 @@
 package com.example.aapremote.assistant.engine
 
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
 import com.example.aapremote.assistant.llm.LlmAuthException
 import com.example.aapremote.assistant.llm.LlmProvider
 import com.example.aapremote.assistant.llm.LlmRateLimitException
 import com.example.aapremote.assistant.llm.LlmServerException
 import com.example.aapremote.assistant.llm.LlmTimeoutException
-import com.example.aapremote.assistant.llm.StreamEvent
-import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.assistant.tools.toToolDescriptor
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlin.coroutines.coroutineContext
-import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import java.io.IOException
 
 sealed interface ChatEvent {
@@ -31,6 +37,8 @@ class ChatEngine(
     private val toolExecutor: ToolExecutor,
     private val maxIterations: Int = 10
 ) {
+    private val json = Json { ignoreUnknownKeys = true }
+
     fun processMessage(
         userMessage: String,
         history: List<ChatMessage>,
@@ -44,74 +52,106 @@ class ChatEngine(
                 .forEach { messages.add(it) }
             messages.add(ChatMessage(role = Role.USER, content = userMessage))
 
+            val toolDescriptors = tools.map { it.toToolDescriptor() }
             var iterations = 0
             var totalToolCalls = 0
-            var streamError: Throwable? = null
             val toolCallHistory = mutableListOf<List<String>>()
 
             loop@ while (iterations < maxIterations) {
                 iterations++
                 coroutineContext.ensureActive()
                 val textBuilder = StringBuilder()
-                var lastResult: com.example.aapremote.assistant.llm.LlmResult? = null
+                val pendingToolCalls = mutableMapOf<String, MutableToolCall>()
+                var streamError: Throwable? = null
 
                 trimMessages(messages)
-                provider.generateStream(messages, tools, maxTokens).collect { event ->
-                    when (event) {
-                        is StreamEvent.TextDelta -> {
-                            textBuilder.append(event.text)
-                            emit(ChatEvent.TextDelta(event.text))
+                val prompt = buildPrompt(messages)
+
+                provider.generateStream(prompt, toolDescriptors, maxTokens).collect { frame ->
+                    when (frame) {
+                        is StreamFrame.TextDelta -> {
+                            textBuilder.append(frame.text)
+                            emit(ChatEvent.TextDelta(frame.text))
                         }
-                        is StreamEvent.ToolCallStart -> {}
-                        is StreamEvent.ToolCallArgs -> {}
-                        is StreamEvent.Done -> {
-                            lastResult = event.result
+                        is StreamFrame.ToolCallDelta -> {
+                            val id = frame.id ?: return@collect
+                            val tc = pendingToolCalls.getOrPut(id) { MutableToolCall(id) }
+                            if (frame.name != null) tc.name = frame.name
+                            if (frame.content != null) tc.args.append(frame.content)
                         }
-                        is StreamEvent.Error -> {
-                            streamError = event.cause
+                        is StreamFrame.ToolCallComplete -> {
+                            val id = frame.id ?: return@collect
+                            val tc = pendingToolCalls.getOrPut(id) { MutableToolCall(id) }
+                            tc.name = frame.name
+                            tc.args.clear()
+                            tc.args.append(frame.content)
                         }
+                        is StreamFrame.End -> { /* handled after collect */ }
+                        else -> { /* ReasoningDelta etc — ignore */ }
                     }
                 }
 
                 if (streamError != null) {
-                    emit(ChatEvent.Error(
-                        "LLM error: ${streamError.message}",
-                        streamError
-                    ))
+                    emit(ChatEvent.Error("LLM error: ${streamError.message}", streamError))
                     return@flow
                 }
 
-                val result = lastResult ?: break
+                val completedCalls = pendingToolCalls.values
+                    .filter { it.name != null }
+                    .map { tc ->
+                        Message.Tool.Call(
+                            id = tc.id,
+                            tool = tc.name!!,
+                            content = tc.args.toString().ifEmpty { "{}" },
+                            metaInfo = ResponseMetaInfo.Empty
+                        )
+                    }
 
-                if (result.toolCalls.isNotEmpty() && iterations < maxIterations) {
-                    val currentSignature = result.toolCalls.map {
-                        "${it.name}:${it.arguments.hashCode()}"
+                val responseText = textBuilder.toString().ifEmpty { null }
+
+                if (completedCalls.isNotEmpty() && iterations < maxIterations) {
+                    val currentSignature = completedCalls.map {
+                        "${it.tool}:${it.content.hashCode()}"
                     }
                     toolCallHistory.add(currentSignature)
 
                     if (isRepeatingToolCalls(toolCallHistory)) {
                         emit(ChatEvent.AssistantMessage(
-                            (result.text ?: "") + "\n\nStopped: the same tools were being called repeatedly.",
+                            (responseText ?: "") + "\n\nStopped: the same tools were being called repeatedly.",
                             totalToolCalls
                         ))
                         return@flow
                     }
 
-                    val assistantContent = result.text ?: ""
+                    val toolCallsJson = json.encodeToString(
+                        kotlinx.serialization.json.JsonArray.serializer(),
+                        kotlinx.serialization.json.JsonArray(completedCalls.map { tc ->
+                            JsonObject(mapOf(
+                                "id" to kotlinx.serialization.json.JsonPrimitive(tc.id),
+                                "name" to kotlinx.serialization.json.JsonPrimitive(tc.tool),
+                                "arguments" to kotlinx.serialization.json.JsonPrimitive(tc.content)
+                            ))
+                        })
+                    )
                     messages.add(ChatMessage(
                         role = Role.ASSISTANT,
-                        content = assistantContent,
-                        toolCalls = result.toolCalls
+                        content = responseText ?: "",
+                        toolCallsJson = toolCallsJson
                     ))
 
                     val toolSummaries = mutableListOf<String>()
-                    for (toolCall in result.toolCalls) {
-                        emit(ChatEvent.ToolExecuting(toolCall.name, toolCall.arguments))
+                    for (toolCall in completedCalls) {
+                        val argsJson = try {
+                            json.parseToJsonElement(toolCall.content).jsonObject
+                        } catch (_: Exception) {
+                            JsonObject(emptyMap())
+                        }
+                        emit(ChatEvent.ToolExecuting(toolCall.tool, argsJson))
 
                         val toolResult = toolExecutor.execute(toolCall)
                         totalToolCalls++
 
-                        emit(ChatEvent.ToolResult(toolCall.name, toolResult))
+                        emit(ChatEvent.ToolResult(toolCall.tool, toolResult))
 
                         messages.add(ChatMessage(
                             role = Role.TOOL,
@@ -119,17 +159,17 @@ class ChatEngine(
                                 ?: "Tool execution failed: ${toolResult.errorType ?: "unknown error"}",
                             toolCallId = toolCall.id
                         ))
-                        toolSummaries.add("${toolCall.name}: ${toolResult.data?.take(200) ?: "error"}")
+                        toolSummaries.add("${toolCall.tool}: ${toolResult.data?.take(200) ?: "error"}")
                     }
 
                     if (iterations > 1) {
                         compactToolMessages(messages, toolSummaries)
                     }
                 } else {
-                    val finalText = if (result.toolCalls.isNotEmpty() && iterations >= maxIterations) {
-                        (result.text ?: "") + "\n\nI wasn't able to complete this request within the tool call limit."
+                    val finalText = if (completedCalls.isNotEmpty() && iterations >= maxIterations) {
+                        (responseText ?: "") + "\n\nI wasn't able to complete this request within the tool call limit."
                     } else {
-                        result.text ?: textBuilder.toString()
+                        responseText ?: textBuilder.toString()
                     }
                     emit(ChatEvent.AssistantMessage(finalText, totalToolCalls))
                     return@flow
@@ -155,6 +195,57 @@ class ChatEngine(
         }
     }
 
+    private fun buildPrompt(messages: List<ChatMessage>): Prompt {
+        val koogMessages = messages.flatMap { msg ->
+            when (msg.role) {
+                Role.SYSTEM -> listOf(Message.System(
+                    content = msg.content,
+                    metaInfo = RequestMetaInfo.Empty
+                ))
+                Role.USER -> listOf(Message.User(
+                    content = msg.content,
+                    metaInfo = RequestMetaInfo.Empty
+                ))
+                Role.ASSISTANT -> {
+                    if (msg.toolCallsJson != null) {
+                        parseToolCalls(msg.toolCallsJson)
+                    } else {
+                        listOf(Message.Assistant(
+                            content = msg.content,
+                            metaInfo = ResponseMetaInfo.Empty
+                        ))
+                    }
+                }
+                Role.TOOL -> listOf(Message.Tool.Result(
+                    id = msg.toolCallId,
+                    tool = msg.toolCallId ?: "",
+                    content = msg.content,
+                    metaInfo = RequestMetaInfo.Empty
+                ))
+            }
+        }
+        return Prompt(messages = koogMessages, id = "chat")
+    }
+
+    private fun parseToolCalls(toolCallsJson: String): List<Message.Tool.Call> {
+        return try {
+            val element = json.parseToJsonElement(toolCallsJson)
+            if (element is kotlinx.serialization.json.JsonArray) {
+                element.map { el ->
+                    val obj = el.jsonObject
+                    Message.Tool.Call(
+                        id = obj["id"]?.jsonPrimitive?.content,
+                        tool = obj["name"]?.jsonPrimitive?.content ?: "",
+                        content = obj["arguments"]?.jsonPrimitive?.content ?: "{}",
+                        metaInfo = ResponseMetaInfo.Empty
+                    )
+                }
+            } else emptyList()
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
     private fun compactToolMessages(
         messages: MutableList<ChatMessage>,
         currentSummaries: List<String>
@@ -162,7 +253,7 @@ class ChatEngine(
         val keepFrom = messages.indexOfLast { it.role == Role.USER } + 1
         val toCompact = mutableListOf<Int>()
         for (i in keepFrom until messages.size - currentSummaries.size) {
-            if (messages[i].role == Role.TOOL || (messages[i].role == Role.ASSISTANT && messages[i].toolCalls != null)) {
+            if (messages[i].role == Role.TOOL || (messages[i].role == Role.ASSISTANT && messages[i].toolCallsJson != null)) {
                 toCompact.add(i)
             }
         }
@@ -213,28 +304,9 @@ class ChatEngine(
         }
     }
 
-    private suspend fun <T> retryWithBackoff(
-        maxAttempts: Int = 3,
-        block: suspend () -> T
-    ): T {
-        var lastException: Exception? = null
-        repeat(maxAttempts) { attempt ->
-            try {
-                return block()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: LlmAuthException) {
-                throw e
-            } catch (e: LlmRateLimitException) {
-                throw e
-            } catch (e: Exception) {
-                lastException = e
-                if (attempt < maxAttempts - 1) {
-                    delay((attempt + 1).seconds)
-                }
-            }
-        }
-        throw lastException!!
+    private class MutableToolCall(val id: String) {
+        var name: String? = null
+        val args = StringBuilder()
     }
 
     companion object {

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
@@ -157,7 +157,8 @@ class ChatEngine(
                             role = Role.TOOL,
                             content = toolResult.data
                                 ?: "Tool execution failed: ${toolResult.errorType ?: "unknown error"}",
-                            toolCallId = toolCall.id
+                            toolCallId = toolCall.id,
+                            toolName = toolCall.tool
                         ))
                         toolSummaries.add("${toolCall.tool}: ${toolResult.data?.take(200) ?: "error"}")
                     }
@@ -218,7 +219,7 @@ class ChatEngine(
                 }
                 Role.TOOL -> listOf(Message.Tool.Result(
                     id = msg.toolCallId,
-                    tool = msg.toolCallId ?: "",
+                    tool = msg.toolName ?: msg.toolCallId ?: "",
                     content = msg.content,
                     metaInfo = RequestMetaInfo.Empty
                 ))

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatMessage.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatMessage.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.engine
 
-import com.example.aapremote.assistant.llm.ToolCall
 import java.util.concurrent.atomic.AtomicLong
 
 enum class Role { USER, ASSISTANT, TOOL, SYSTEM }
@@ -8,7 +7,7 @@ enum class Role { USER, ASSISTANT, TOOL, SYSTEM }
 data class ChatMessage(
     val role: Role,
     val content: String,
-    val toolCalls: List<ToolCall>? = null,
+    val toolCallsJson: String? = null,
     val toolCallId: String? = null,
     val timestamp: Long = System.currentTimeMillis(),
     val id: Long = nextId.getAndIncrement()

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatMessage.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatMessage.kt
@@ -9,6 +9,7 @@ data class ChatMessage(
     val content: String,
     val toolCallsJson: String? = null,
     val toolCallId: String? = null,
+    val toolName: String? = null,
     val timestamp: Long = System.currentTimeMillis(),
     val id: Long = nextId.getAndIncrement()
 ) {

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolExecutor.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolExecutor.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.intOrNull
@@ -75,9 +77,9 @@ class ToolExecutor(
         }
     }
 
-    private fun jsonElementToAny(element: kotlinx.serialization.json.JsonElement): Any {
+    private fun jsonElementToAny(element: JsonElement): Any {
         return when (element) {
-            is kotlinx.serialization.json.JsonPrimitive -> {
+            is JsonPrimitive -> {
                 when {
                     element.isString -> element.content
                     element.content == "true" -> true

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolExecutor.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolExecutor.kt
@@ -1,6 +1,6 @@
 package com.example.aapremote.assistant.engine
 
-import com.example.aapremote.assistant.llm.ToolCall
+import ai.koog.prompt.message.Message
 import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.Tool
 import com.example.aapremote.assistant.tools.ToolResult
@@ -21,29 +21,35 @@ class ToolExecutor(
 ) {
     private val resultCache = mutableMapOf<String, Pair<Long, ToolResult>>()
 
-    suspend fun execute(toolCall: ToolCall): ToolResult {
-        val tool = tools.find { it.spec.name == toolCall.name }
+    suspend fun execute(toolCall: Message.Tool.Call): ToolResult {
+        val tool = tools.find { it.spec.name == toolCall.tool }
             ?: return ToolResult(
                 success = false,
-                data = "Tool '${toolCall.name}' not found",
+                data = "Tool '${toolCall.tool}' not found",
                 errorType = ErrorType.NOT_FOUND
             )
 
-        val cacheKey = "${toolCall.name}:${toolCall.arguments.hashCode()}"
+        val cacheKey = "${toolCall.tool}:${toolCall.content.hashCode()}"
         val cached = resultCache[cacheKey]
         if (cached != null && System.currentTimeMillis() - cached.first < CACHE_TTL_MS) {
             return cached.second
         }
 
+        val argsJson = try {
+            json.parseToJsonElement(toolCall.content)
+        } catch (_: Exception) {
+            JsonObject(emptyMap())
+        }
+        val argsMap = if (argsJson is JsonObject) jsonObjectToMap(argsJson) else emptyMap()
+
         val result = try {
             withTimeout(30_000L) {
-                val args = jsonObjectToMap(toolCall.arguments)
-                tool.execute(args)
+                tool.execute(argsMap)
             }
         } catch (_: TimeoutCancellationException) {
             return ToolResult(
                 success = false,
-                data = "Tool '${toolCall.name}' timed out after 30s",
+                data = "Tool '${toolCall.tool}' timed out after 30s",
                 errorType = ErrorType.TIMEOUT
             )
         }
@@ -63,7 +69,7 @@ class ToolExecutor(
         return finalResult
     }
 
-    private fun jsonObjectToMap(json: kotlinx.serialization.json.JsonObject): Map<String, Any> {
+    private fun jsonObjectToMap(json: JsonObject): Map<String, Any> {
         return json.entries.associate { (key, value) ->
             key to jsonElementToAny(value)
         }
@@ -80,8 +86,8 @@ class ToolExecutor(
                     else -> element.content.toLongOrNull() ?: element.content
                 }
             }
-            is kotlinx.serialization.json.JsonArray -> element.map { jsonElementToAny(it) }
-            is kotlinx.serialization.json.JsonObject -> jsonObjectToMap(element)
+            is JsonArray -> element.map { jsonElementToAny(it) }
+            is JsonObject -> jsonObjectToMap(element)
         }
     }
 

--- a/app/src/main/kotlin/com/example/aapremote/assistant/llm/KoogLlmProvider.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/llm/KoogLlmProvider.kt
@@ -1,8 +1,6 @@
 package com.example.aapremote.assistant.llm
 
 import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.tools.ToolParameterDescriptor
-import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIClientSettings
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
@@ -10,15 +8,10 @@ import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.llm.LLMProvider as KoogLLMProvider
 import ai.koog.prompt.message.Message
-import ai.koog.prompt.message.RequestMetaInfo
-import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
-import com.example.aapremote.assistant.data.LlmProviderConfig
-import com.example.aapremote.assistant.engine.ChatMessage
-import com.example.aapremote.assistant.engine.Role
-import com.example.aapremote.assistant.tools.ToolSpec
 import ai.koog.http.client.KoogHttpClientException
 import ai.koog.prompt.executor.clients.LLMClientException
+import com.example.aapremote.assistant.data.LlmProviderConfig
 import com.example.aapremote.network.CertTrustManager
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
@@ -27,13 +20,6 @@ import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import java.io.Closeable
 import java.net.SocketTimeoutException
 
@@ -41,8 +27,6 @@ class KoogLlmProvider(
     private val config: LlmProviderConfig.OpenAiCompatible,
     trustSelfSigned: Boolean = false
 ) : LlmProvider, Closeable {
-
-    private val json = Json { ignoreUnknownKeys = true }
 
     private val client: OpenAILLMClient = run {
         val parsed = java.net.URI(config.url.trimEnd('/'))
@@ -85,81 +69,25 @@ class KoogLlmProvider(
     )
 
     override suspend fun generate(
-        messages: List<ChatMessage>,
-        tools: List<ToolSpec>,
+        prompt: Prompt,
+        tools: List<ToolDescriptor>,
         maxTokens: Int?
-    ): LlmResult {
-        val prompt = buildPrompt(messages)
-        val toolDescriptors = tools.map { it.toToolDescriptor() }
-        return try {
-            val responses = client.execute(prompt, model, toolDescriptors)
-            mapResponsesToResult(responses)
-        } catch (e: Exception) {
-            throw mapException(e)
-        }
+    ): List<Message.Response> = try {
+        client.execute(prompt, model, tools)
+    } catch (e: Exception) {
+        throw mapException(e)
     }
 
     override fun generateStream(
-        messages: List<ChatMessage>,
-        tools: List<ToolSpec>,
+        prompt: Prompt,
+        tools: List<ToolDescriptor>,
         maxTokens: Int?
-    ): Flow<StreamEvent> = flow {
-        val prompt = buildPrompt(messages)
-        val toolDescriptors = tools.map { it.toToolDescriptor() }
-        val toolCalls = mutableMapOf<String, MutableToolCall>()
-        val textAccumulator = StringBuilder()
-
-        client.executeStreaming(prompt, model, toolDescriptors).collect { frame ->
-            when (frame) {
-                is StreamFrame.TextDelta -> {
-                    textAccumulator.append(frame.text)
-                    emit(StreamEvent.TextDelta(frame.text))
-                }
-                is StreamFrame.ToolCallDelta -> {
-                    val id = frame.id ?: return@collect
-                    val tc = toolCalls.getOrPut(id) { MutableToolCall(id) }
-                    if (frame.name != null) {
-                        tc.name = frame.name
-                        emit(StreamEvent.ToolCallStart(id, frame.name!!))
-                    }
-                    if (frame.content != null) {
-                        tc.args.append(frame.content)
-                        emit(StreamEvent.ToolCallArgs(id, frame.content!!))
-                    }
-                }
-                is StreamFrame.ToolCallComplete -> {
-                    val id = frame.id ?: return@collect
-                    val tc = toolCalls.getOrPut(id) { MutableToolCall(id) }
-                    tc.name = frame.name
-                    tc.args.clear()
-                    tc.args.append(frame.content)
-                    if (!tc.startEmitted) {
-                        emit(StreamEvent.ToolCallStart(id, frame.name))
-                        tc.startEmitted = true
-                    }
-                }
-                is StreamFrame.End -> {
-                    val completedCalls = toolCalls.values
-                        .filter { it.name != null }
-                        .map { tc ->
-                            val argsJson = try {
-                                json.parseToJsonElement(tc.args.toString()).jsonObject
-                            } catch (_: Exception) {
-                                JsonObject(emptyMap())
-                            }
-                            ToolCall(id = tc.id, name = tc.name!!, arguments = argsJson)
-                        }
-                    val result = LlmResult(
-                        text = textAccumulator.toString().ifEmpty { null },
-                        toolCalls = completedCalls
-                    )
-                    emit(StreamEvent.Done(result))
-                }
-                else -> { /* Ignore reasoning frames */ }
-            }
+    ): Flow<StreamFrame> = flow {
+        client.executeStreaming(prompt, model, tools).collect { frame ->
+            emit(frame)
         }
     }.catch { e ->
-        emit(StreamEvent.Error(mapException(e)))
+        throw mapException(e)
     }
 
     override fun isAvailable(): Boolean =
@@ -174,73 +102,7 @@ class KoogLlmProvider(
         client.close()
     }
 
-    private fun buildPrompt(messages: List<ChatMessage>): Prompt {
-        val koogMessages = messages.flatMap { msg ->
-            when (msg.role) {
-                Role.SYSTEM -> listOf(Message.System(
-                    content = msg.content,
-                    metaInfo = RequestMetaInfo.Empty
-                ))
-                Role.USER -> listOf(Message.User(
-                    content = msg.content,
-                    metaInfo = RequestMetaInfo.Empty
-                ))
-                Role.ASSISTANT -> {
-                    if (!msg.toolCalls.isNullOrEmpty()) {
-                        msg.toolCalls.map { tc ->
-                            Message.Tool.Call(
-                                id = tc.id,
-                                tool = tc.name,
-                                content = tc.arguments.toString(),
-                                metaInfo = ResponseMetaInfo.Empty
-                            )
-                        }
-                    } else {
-                        listOf(Message.Assistant(
-                            content = msg.content,
-                            metaInfo = ResponseMetaInfo.Empty
-                        ))
-                    }
-                }
-                Role.TOOL -> listOf(Message.Tool.Result(
-                    id = msg.toolCallId,
-                    tool = msg.toolCallId ?: "",
-                    content = msg.content,
-                    metaInfo = RequestMetaInfo.Empty
-                ))
-            }
-        }
-        return Prompt(messages = koogMessages, id = "chat")
-    }
-
-    private fun mapResponsesToResult(responses: List<Message.Response>): LlmResult {
-        var text: String? = null
-        val toolCalls = mutableListOf<ToolCall>()
-
-        responses.forEach { response ->
-            when (response) {
-                is Message.Assistant -> text = response.content.ifEmpty { null }
-                is Message.Tool.Call -> {
-                    val argsJson = try {
-                        json.parseToJsonElement(response.content).jsonObject
-                    } catch (_: Exception) {
-                        JsonObject(emptyMap())
-                    }
-                    toolCalls.add(
-                        ToolCall(
-                            id = response.id ?: "call_${toolCalls.size}",
-                            name = response.tool,
-                            arguments = argsJson
-                        )
-                    )
-                }
-                else -> { /* Ignore reasoning */ }
-            }
-        }
-        return LlmResult(text = text, toolCalls = toolCalls)
-    }
-
-    private fun mapException(e: Throwable): Throwable = when (e) {
+    internal fun mapException(e: Throwable): Throwable = when (e) {
         is LlmAuthException, is LlmRateLimitException,
         is LlmServerException, is LlmTimeoutException -> e
         is LLMClientException -> {
@@ -269,77 +131,4 @@ class KoogLlmProvider(
         is SocketTimeoutException -> LlmTimeoutException("Request timed out")
         else -> e
     }
-
-    private class MutableToolCall(val id: String) {
-        var name: String? = null
-        val args = StringBuilder()
-        var startEmitted = false
-    }
-}
-
-private fun ToolSpec.toToolDescriptor(): ToolDescriptor {
-    val schema = compactSchema(parametersSchema)
-    val properties = schema["properties"]?.jsonObject ?: emptyMap()
-    val requiredNames = schema["required"]?.jsonArray
-        ?.map { it.jsonPrimitive.content }?.toSet() ?: emptySet()
-
-    val required = mutableListOf<ToolParameterDescriptor>()
-    val optional = mutableListOf<ToolParameterDescriptor>()
-
-    properties.forEach { (paramName, paramValue) ->
-        val prop = paramValue.jsonObject
-        val descriptor = ToolParameterDescriptor(
-            name = paramName,
-            description = paramName,
-            type = parseParamType(prop)
-        )
-        if (paramName in requiredNames) required.add(descriptor) else optional.add(descriptor)
-    }
-
-    return ToolDescriptor(
-        name = name,
-        description = description,
-        requiredParameters = required,
-        optionalParameters = optional
-    )
-}
-
-private fun parseParamType(prop: JsonObject): ToolParameterType {
-    val enumValues = prop["enum"]?.jsonArray
-    if (enumValues != null) {
-        return ToolParameterType.Enum(enumValues.map { it.jsonPrimitive.content }.toTypedArray())
-    }
-    return when (prop["type"]?.jsonPrimitive?.content) {
-        "integer" -> ToolParameterType.Integer
-        "number" -> ToolParameterType.Float
-        "boolean" -> ToolParameterType.Boolean
-        "array" -> ToolParameterType.List(ToolParameterType.String)
-        else -> ToolParameterType.String
-    }
-}
-
-private fun compactSchema(schema: JsonObject): JsonObject {
-    val builder = mutableMapOf<String, JsonElement>()
-    schema["type"]?.let { builder["type"] = it }
-    schema["required"]?.jsonArray?.let { arr ->
-        if (arr.isNotEmpty()) builder["required"] = arr
-    }
-    schema["properties"]?.jsonObject?.let { props ->
-        val compactedProps = mutableMapOf<String, JsonElement>()
-        props.forEach { (key, value) ->
-            val prop = value.jsonObject
-            val compacted = mutableMapOf<String, JsonElement>()
-            prop["type"]?.let { compacted["type"] = it }
-            prop["enum"]?.jsonArray?.let { enumArr ->
-                if (enumArr.size > 8) {
-                    compacted["enum"] = JsonArray(enumArr.take(8))
-                } else {
-                    compacted["enum"] = enumArr
-                }
-            }
-            compactedProps[key] = JsonObject(compacted)
-        }
-        builder["properties"] = JsonObject(compactedProps)
-    }
-    return JsonObject(builder)
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/llm/LlmProvider.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/llm/LlmProvider.kt
@@ -1,12 +1,14 @@
 package com.example.aapremote.assistant.llm
 
-import com.example.aapremote.assistant.engine.ChatMessage
-import com.example.aapremote.assistant.tools.ToolSpec
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
 import kotlinx.coroutines.flow.Flow
 
 interface LlmProvider {
-    suspend fun generate(messages: List<ChatMessage>, tools: List<ToolSpec>, maxTokens: Int? = null): LlmResult
-    fun generateStream(messages: List<ChatMessage>, tools: List<ToolSpec>, maxTokens: Int? = null): Flow<StreamEvent>
+    suspend fun generate(prompt: Prompt, tools: List<ToolDescriptor>, maxTokens: Int? = null): List<Message.Response>
+    fun generateStream(prompt: Prompt, tools: List<ToolDescriptor>, maxTokens: Int? = null): Flow<StreamFrame>
     fun isAvailable(): Boolean
     fun modelInfo(): ModelInfo
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/llm/LlmTypes.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/llm/LlmTypes.kt
@@ -1,26 +1,5 @@
 package com.example.aapremote.assistant.llm
 
-import kotlinx.serialization.json.JsonObject
-
-sealed interface StreamEvent {
-    data class TextDelta(val text: String) : StreamEvent
-    data class ToolCallStart(val id: String, val name: String) : StreamEvent
-    data class ToolCallArgs(val id: String, val argsDelta: String) : StreamEvent
-    data class Done(val result: LlmResult) : StreamEvent
-    data class Error(val cause: Throwable) : StreamEvent
-}
-
-data class LlmResult(
-    val text: String? = null,
-    val toolCalls: List<ToolCall> = emptyList()
-)
-
-data class ToolCall(
-    val id: String,
-    val name: String,
-    val arguments: JsonObject
-)
-
 data class ModelInfo(
     val name: String,
     val isLocal: Boolean = false

--- a/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantUiState.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantUiState.kt
@@ -10,8 +10,7 @@ sealed interface AssistantUiState {
     data class Active(
         val messages: List<ChatMessage> = emptyList(),
         val isGenerating: Boolean = false,
-        val connections: Map<String, McpConnectionState> = emptyMap(),
-        val inputText: String = ""
+        val connections: Map<String, McpConnectionState> = emptyMap()
     ) : AssistantUiState
     data class Error(val error: AppError) : AssistantUiState
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
@@ -19,7 +19,7 @@ import com.example.aapremote.model.McpServerConfig
 import com.example.aapremote.network.CertTrustManager
 import com.example.aapremote.network.mcp.McpConnectionState
 import com.example.aapremote.network.mcp.McpServerManager
-import com.example.aapremote.network.networkJson
+
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -89,13 +89,6 @@ class AssistantViewModel(
         }
     }
 
-    fun updateInputText(text: String) {
-        _uiState.update { current ->
-            if (current is AssistantUiState.Active) current.copy(inputText = text)
-            else current
-        }
-    }
-
     fun sendMessage(text: String) {
         if (text.isBlank()) return
 
@@ -119,7 +112,6 @@ class AssistantViewModel(
 
         updateState { copy(
             messages = repository.getHistory(),
-            inputText = "",
             isGenerating = true
         ) }
 

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/ToolDescriptorMapping.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/ToolDescriptorMapping.kt
@@ -1,0 +1,78 @@
+package com.example.aapremote.assistant.tools
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+fun ToolSpec.toToolDescriptor(): ToolDescriptor {
+    val schema = compactSchema(parametersSchema)
+    val properties = schema["properties"]?.jsonObject ?: emptyMap()
+    val requiredNames = schema["required"]?.jsonArray
+        ?.map { it.jsonPrimitive.content }?.toSet() ?: emptySet()
+
+    val required = mutableListOf<ToolParameterDescriptor>()
+    val optional = mutableListOf<ToolParameterDescriptor>()
+
+    properties.forEach { (paramName, paramValue) ->
+        val prop = paramValue.jsonObject
+        val descriptor = ToolParameterDescriptor(
+            name = paramName,
+            description = paramName,
+            type = parseParamType(prop)
+        )
+        if (paramName in requiredNames) required.add(descriptor) else optional.add(descriptor)
+    }
+
+    return ToolDescriptor(
+        name = name,
+        description = description,
+        requiredParameters = required,
+        optionalParameters = optional
+    )
+}
+
+private fun parseParamType(prop: JsonObject): ToolParameterType {
+    val enumValues = prop["enum"]?.jsonArray
+    if (enumValues != null) {
+        return ToolParameterType.Enum(enumValues.map { it.jsonPrimitive.content }.toTypedArray())
+    }
+    return when (prop["type"]?.jsonPrimitive?.content) {
+        "integer" -> ToolParameterType.Integer
+        "number" -> ToolParameterType.Float
+        "boolean" -> ToolParameterType.Boolean
+        "array" -> ToolParameterType.List(ToolParameterType.String)
+        else -> ToolParameterType.String
+    }
+}
+
+private fun compactSchema(schema: JsonObject): JsonObject {
+    val builder = mutableMapOf<String, JsonElement>()
+    schema["type"]?.let { builder["type"] = it }
+    schema["required"]?.jsonArray?.let { arr ->
+        if (arr.isNotEmpty()) builder["required"] = arr
+    }
+    schema["properties"]?.jsonObject?.let { props ->
+        val compactedProps = mutableMapOf<String, JsonElement>()
+        props.forEach { (key, value) ->
+            val prop = value.jsonObject
+            val compacted = mutableMapOf<String, JsonElement>()
+            prop["type"]?.let { compacted["type"] = it }
+            prop["enum"]?.jsonArray?.let { enumArr ->
+                if (enumArr.size > 8) {
+                    compacted["enum"] = JsonArray(enumArr.take(8))
+                } else {
+                    compacted["enum"] = enumArr
+                }
+            }
+            compactedProps[key] = JsonObject(compacted)
+        }
+        builder["properties"] = JsonObject(compactedProps)
+    }
+    return JsonObject(builder)
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/ui/ChatBubble.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/ui/ChatBubble.kt
@@ -35,7 +35,7 @@ fun ChatBubble(
     modifier: Modifier = Modifier
 ) {
     val isUser = message.role == Role.USER
-    val isToolIndicator = message.content.startsWith("Querying tool:")
+    val isToolIndicator = message.content.startsWith("Querying [")
     val isError = message.content.startsWith("Error:")
 
     Row(

--- a/app/src/test/kotlin/com/example/aapremote/assistant/engine/ChatEngineTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/assistant/engine/ChatEngineTest.kt
@@ -1,11 +1,13 @@
 package com.example.aapremote.assistant.engine
 
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
 import app.cash.turbine.test
 import com.example.aapremote.assistant.llm.LlmProvider
-import com.example.aapremote.assistant.llm.LlmResult
 import com.example.aapremote.assistant.llm.ModelInfo
-import com.example.aapremote.assistant.llm.StreamEvent
-import com.example.aapremote.assistant.llm.ToolCall
 import com.example.aapremote.assistant.tools.Tool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -13,8 +15,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -24,7 +24,7 @@ class ChatEngineTest {
     @Test
     fun `single turn text response emits TextDelta and AssistantMessage`() = runTest {
         val provider = FakeLlmProvider(listOf(
-            LlmResult(text = "Hello there!", toolCalls = emptyList())
+            FakeResponse(text = "Hello there!")
         ))
         val executor = ToolExecutor(emptyList())
         val engine = ChatEngine(provider, executor)
@@ -44,15 +44,12 @@ class ChatEngineTest {
 
     @Test
     fun `tool calling loop executes tools and re-sends to LLM`() = runTest {
-        val toolCallResult = LlmResult(
-            text = null,
-            toolCalls = listOf(
-                ToolCall("call_1", "list_jobs", buildJsonObject { put("status", "failed") })
-            )
-        )
-        val finalResult = LlmResult(text = "Found 3 failed jobs.", toolCalls = emptyList())
-
-        val provider = FakeLlmProvider(listOf(toolCallResult, finalResult))
+        val provider = FakeLlmProvider(listOf(
+            FakeResponse(toolCalls = listOf(
+                FakeToolCall("call_1", "list_jobs", """{"status":"failed"}""")
+            )),
+            FakeResponse(text = "Found 3 failed jobs.")
+        ))
         val fakeTool = FakeTool(
             spec = ToolSpec("list_jobs", "List jobs", JsonObject(emptyMap())),
             result = ToolResult(success = true, data = "[{\"id\":1},{\"id\":2},{\"id\":3}]")
@@ -82,14 +79,12 @@ class ChatEngineTest {
 
     @Test
     fun `max iteration limit stops infinite loops`() = runTest {
-        val toolCallResult = LlmResult(
-            text = null,
-            toolCalls = listOf(
-                ToolCall("call_1", "loop_tool", JsonObject(emptyMap()))
-            )
-        )
         val provider = FakeLlmProvider(
-            (1..15).map { toolCallResult }.toList()
+            (1..15).map {
+                FakeResponse(toolCalls = listOf(
+                    FakeToolCall("call_1", "loop_tool", "{}")
+                ))
+            }
         )
         val fakeTool = FakeTool(
             spec = ToolSpec("loop_tool", "Loops", JsonObject(emptyMap())),
@@ -132,34 +127,66 @@ class ChatEngineTest {
     }
 }
 
+private data class FakeToolCall(val id: String, val name: String, val arguments: String)
+
+private data class FakeResponse(
+    val text: String? = null,
+    val toolCalls: List<FakeToolCall> = emptyList()
+)
+
 private class FakeLlmProvider(
-    private val results: List<LlmResult> = emptyList(),
+    private val responses: List<FakeResponse> = emptyList(),
     private val error: Throwable? = null
 ) : LlmProvider {
     private var callIndex = 0
 
     override suspend fun generate(
-        messages: List<ChatMessage>,
-        tools: List<ToolSpec>,
+        prompt: Prompt,
+        tools: List<ToolDescriptor>,
         maxTokens: Int?
-    ): LlmResult = results.getOrElse(callIndex++) { LlmResult() }
+    ): List<Message.Response> {
+        val resp = responses.getOrElse(callIndex++) { FakeResponse() }
+        return buildResponseMessages(resp)
+    }
 
     override fun generateStream(
-        messages: List<ChatMessage>,
-        tools: List<ToolSpec>,
+        prompt: Prompt,
+        tools: List<ToolDescriptor>,
         maxTokens: Int?
-    ): Flow<StreamEvent> = flow {
+    ): Flow<StreamFrame> = flow {
         if (error != null) {
-            emit(StreamEvent.Error(error))
-            return@flow
+            throw error
         }
-        val result = results.getOrElse(callIndex++) { LlmResult() }
-        result.text?.let { emit(StreamEvent.TextDelta(it)) }
-        emit(StreamEvent.Done(result))
+        val resp = responses.getOrElse(callIndex++) { FakeResponse() }
+        resp.text?.let { emit(StreamFrame.TextDelta(it)) }
+        for (tc in resp.toolCalls) {
+            emit(StreamFrame.ToolCallComplete(
+                id = tc.id,
+                name = tc.name,
+                content = tc.arguments
+            ))
+        }
+        emit(StreamFrame.End(finishReason = "stop"))
     }
 
     override fun isAvailable(): Boolean = true
     override fun modelInfo(): ModelInfo = ModelInfo("fake-model")
+
+    private fun buildResponseMessages(resp: FakeResponse): List<Message.Response> {
+        val messages = mutableListOf<Message.Response>()
+        if (resp.text != null) {
+            messages.add(Message.Assistant(content = resp.text, metaInfo = ResponseMetaInfo.Empty))
+        }
+        for (tc in resp.toolCalls) {
+            messages.add(Message.Tool.Call(
+                id = tc.id,
+                tool = tc.name,
+                content = tc.arguments,
+                metaInfo = ResponseMetaInfo.Empty
+            ))
+        }
+        return messages
+    }
 }
 
 private class FakeTool(

--- a/app/src/test/kotlin/com/example/aapremote/assistant/engine/ToolExecutorTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/assistant/engine/ToolExecutorTest.kt
@@ -1,6 +1,7 @@
 package com.example.aapremote.assistant.engine
 
-import com.example.aapremote.assistant.llm.ToolCall
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
 import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.Tool
 import com.example.aapremote.assistant.tools.ToolResult
@@ -16,14 +17,16 @@ import org.junit.Test
 
 class ToolExecutorTest {
 
+    private fun toolCall(name: String, args: String = "{}"): Message.Tool.Call =
+        Message.Tool.Call(id = "1", tool = name, content = args, metaInfo = ResponseMetaInfo.Empty)
+
     @Test
     fun `execute dispatches to correct tool by name`() = runTest {
         val tool1 = StubTool("tool_a", ToolResult(success = true, data = "result_a"))
         val tool2 = StubTool("tool_b", ToolResult(success = true, data = "result_b"))
         val executor = ToolExecutor(listOf<Tool>(tool1, tool2))
 
-        val call = ToolCall("1", "tool_b", JsonObject(emptyMap()))
-        val result = executor.execute(call)
+        val result = executor.execute(toolCall("tool_b"))
 
         assertTrue(result.success)
         assertEquals("result_b", result.data)
@@ -33,8 +36,7 @@ class ToolExecutorTest {
     fun `execute returns NOT_FOUND for unknown tool`() = runTest {
         val executor = ToolExecutor(emptyList())
 
-        val call = ToolCall("1", "nonexistent", JsonObject(emptyMap()))
-        val result = executor.execute(call)
+        val result = executor.execute(toolCall("nonexistent"))
 
         assertFalse(result.success)
         assertEquals(ErrorType.NOT_FOUND, result.errorType)
@@ -47,8 +49,7 @@ class ToolExecutorTest {
         val tool = StubTool("big_tool", ToolResult(success = true, data = longData))
         val executor = ToolExecutor(listOf<Tool>(tool), maxResultChars = 20_000)
 
-        val call = ToolCall("1", "big_tool", JsonObject(emptyMap()))
-        val result = executor.execute(call)
+        val result = executor.execute(toolCall("big_tool"))
 
         assertTrue(result.success)
         assertTrue(result.data!!.contains("chars truncated"))
@@ -61,8 +62,7 @@ class ToolExecutorTest {
         val tool = StubTool("small_tool", ToolResult(success = true, data = data))
         val executor = ToolExecutor(listOf<Tool>(tool))
 
-        val call = ToolCall("1", "small_tool", JsonObject(emptyMap()))
-        val result = executor.execute(call)
+        val result = executor.execute(toolCall("small_tool"))
 
         assertEquals(data, result.data)
     }
@@ -101,8 +101,7 @@ class ToolExecutorTest {
             put("count", 42)
             put("enabled", true)
         }
-        val call = ToolCall("1", "arg_tool", args)
-        executor.execute(call)
+        executor.execute(toolCall("arg_tool", args.toString()))
 
         assertEquals("test", capturedArgs!!["name"])
         assertEquals(42L, capturedArgs!!["count"])

--- a/app/src/test/kotlin/com/example/aapremote/assistant/llm/KoogLlmProviderTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/assistant/llm/KoogLlmProviderTest.kt
@@ -1,9 +1,13 @@
 package com.example.aapremote.assistant.llm
 
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
 import com.example.aapremote.assistant.data.LlmProviderConfig
-import com.example.aapremote.assistant.engine.ChatMessage
-import com.example.aapremote.assistant.engine.Role
 import com.example.aapremote.assistant.tools.ToolSpec
+import com.example.aapremote.assistant.tools.toToolDescriptor
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -12,7 +16,6 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -37,8 +40,14 @@ class KoogLlmProviderTest {
 
     @After
     fun tearDown() {
+        provider.close()
         server.shutdown()
     }
+
+    private fun userPrompt(content: String): Prompt = Prompt(
+        messages = listOf(Message.User(content = content, metaInfo = RequestMetaInfo.Empty)),
+        id = "test"
+    )
 
     private fun textResponse(content: String) = MockResponse()
         .setBody(
@@ -62,8 +71,7 @@ class KoogLlmProviderTest {
     fun `generate sends correct request format`() = runTest {
         server.enqueue(textResponse("Hello!"))
 
-        val messages = listOf(ChatMessage(role = Role.USER, content = "Hi"))
-        provider.generate(messages, emptyList())
+        provider.generate(userPrompt("Hi"), emptyList())
 
         val request = server.takeRequest()
         assertEquals("POST", request.method)
@@ -78,28 +86,23 @@ class KoogLlmProviderTest {
     fun `generate parses text response`() = runTest {
         server.enqueue(textResponse("The answer is 42"))
 
-        val result = provider.generate(
-            listOf(ChatMessage(role = Role.USER, content = "What is the answer?")),
-            emptyList()
-        )
+        val result = provider.generate(userPrompt("What is the answer?"), emptyList())
 
-        assertEquals("The answer is 42", result.text)
-        assertTrue(result.toolCalls.isEmpty())
+        val assistant = result.filterIsInstance<Message.Assistant>()
+        assertEquals(1, assistant.size)
+        assertEquals("The answer is 42", assistant[0].content)
     }
 
     @Test
     fun `generate parses tool calls`() = runTest {
         server.enqueue(toolCallResponse())
 
-        val result = provider.generate(
-            listOf(ChatMessage(role = Role.USER, content = "List failed jobs")),
-            emptyList()
-        )
+        val result = provider.generate(userPrompt("List failed jobs"), emptyList())
 
-        assertNull(result.text)
-        assertEquals(1, result.toolCalls.size)
-        assertEquals("call_1", result.toolCalls[0].id)
-        assertEquals("list_jobs", result.toolCalls[0].name)
+        val toolCalls = result.filterIsInstance<Message.Tool.Call>()
+        assertEquals(1, toolCalls.size)
+        assertEquals("call_1", toolCalls[0].id)
+        assertEquals("list_jobs", toolCalls[0].tool)
     }
 
     @Test
@@ -111,10 +114,7 @@ class KoogLlmProviderTest {
         )
 
         try {
-            provider.generate(
-                listOf(ChatMessage(role = Role.USER, content = "test")),
-                emptyList()
-            )
+            provider.generate(userPrompt("test"), emptyList())
             throw AssertionError("Expected exception was not thrown")
         } catch (e: LlmAuthException) {
             // Expected
@@ -130,10 +130,7 @@ class KoogLlmProviderTest {
         )
 
         try {
-            provider.generate(
-                listOf(ChatMessage(role = Role.USER, content = "test")),
-                emptyList()
-            )
+            provider.generate(userPrompt("test"), emptyList())
             throw AssertionError("Expected exception was not thrown")
         } catch (e: LlmRateLimitException) {
             // Expected
@@ -149,10 +146,7 @@ class KoogLlmProviderTest {
         )
 
         try {
-            provider.generate(
-                listOf(ChatMessage(role = Role.USER, content = "test")),
-                emptyList()
-            )
+            provider.generate(userPrompt("test"), emptyList())
             throw AssertionError("Expected exception was not thrown")
         } catch (e: LlmServerException) {
             // Expected
@@ -178,10 +172,7 @@ class KoogLlmProviderTest {
             )
         )
 
-        provider.generate(
-            listOf(ChatMessage(role = Role.USER, content = "test")),
-            tools
-        )
+        provider.generate(userPrompt("test"), tools.map { it.toToolDescriptor() })
 
         val body = server.takeRequest().body.readUtf8()
         assertTrue(body.contains("list_jobs"))


### PR DESCRIPTION
## Summary

- Removes the type conversion adapter layer from `KoogLlmProvider` (345 → ~100 LOC)
- `LlmProvider` interface now uses Koog types directly: `Prompt`, `ToolDescriptor`, `Message.Response`, `StreamFrame`
- `ChatEngine` consumes `StreamFrame` directly and builds `Prompt` from `ChatMessage` history internally
- `ToolExecutor` accepts Koog's `Message.Tool.Call` instead of our custom `ToolCall`
- Removed custom `StreamEvent`, `LlmResult`, `ToolCall` types (replaced by Koog equivalents)
- Moved `toToolDescriptor()`/`compactSchema()` to `ToolDescriptorMapping.kt`
- Net: 344 insertions, 402 deletions (-58 LOC)

No new dependencies. No UI changes. KMP alignment — Koog types are multiplatform.

Closes #68

## Test plan

- [x] `./gradlew compileDebugKotlin` passes
- [x] `./gradlew testDebugUnitTest` passes (all 9 KoogLlmProvider tests, 4 ChatEngine tests, 7 ToolExecutor tests)
- [ ] Device smoke test: streaming text + tool calling with OpenRouter

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>