### PR TITLE
Fix compiler warnings and clean up unused code

### DIFF
--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolRouter.kt
@@ -7,11 +7,6 @@ import com.example.aapremote.model.McpServerConfig
 
 class ToolRouter {
 
-    private val WRITE_ACTIONS = setOf(
-        "_create", "_update", "_delete",
-        "_launch", "_relaunch", "_cancel"
-    )
-
     private val localTools = mutableListOf<LocalTool>()
     private val mcpTools = mutableListOf<Tool>()
     private val disabledTools = mutableSetOf<Pair<String, ToolSource>>()
@@ -94,6 +89,17 @@ class ToolRouter {
 
         private val MCP_TOOLS_WITH_LOCAL_OVERLAP: Set<String> =
             OVERLAP_MAPPING.values.flatten().toSet()
+
+        private val WRITE_ACTIONS = setOf(
+            "_create", "_update", "_delete",
+            "_launch", "_relaunch", "_cancel"
+        )
+
+        private val STOP_WORDS = setOf(
+            "list", "get", "show", "what", "are", "the", "is", "a", "an",
+            "my", "all", "me", "how", "many", "which", "do", "i", "have",
+            "can", "tell", "about", "find", "check", "give"
+        )
     }
 
     fun registerLocalTools(tools: List<LocalTool>) {
@@ -167,12 +173,6 @@ class ToolRouter {
 
         return rankTools(filteredLocal, queryWords) + filteredMcp
     }
-
-    private val STOP_WORDS = setOf(
-        "list", "get", "show", "what", "are", "the", "is", "a", "an",
-        "my", "all", "me", "how", "many", "which", "do", "i", "have",
-        "can", "tell", "about", "find", "check", "give"
-    )
 
     private fun stem(word: String): String {
         return word

--- a/app/src/main/kotlin/com/example/aapremote/assistant/llm/KoogLlmProvider.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/llm/KoogLlmProvider.kt
@@ -7,7 +7,7 @@ import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.llm.LLMProvider as KoogLLMProvider
-import ai.koog.prompt.message.Message
+
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.http.client.KoogHttpClientException
 import ai.koog.prompt.executor.clients.LLMClientException
@@ -67,16 +67,6 @@ class KoogLlmProvider(
             LLMCapability.OpenAIEndpoint.Completions
         )
     )
-
-    override suspend fun generate(
-        prompt: Prompt,
-        tools: List<ToolDescriptor>,
-        maxTokens: Int?
-    ): List<Message.Response> = try {
-        client.execute(prompt, model, tools)
-    } catch (e: Exception) {
-        throw mapException(e)
-    }
 
     override fun generateStream(
         prompt: Prompt,

--- a/app/src/main/kotlin/com/example/aapremote/assistant/llm/LlmProvider.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/llm/LlmProvider.kt
@@ -2,12 +2,10 @@ package com.example.aapremote.assistant.llm
 
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.dsl.Prompt
-import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
 import kotlinx.coroutines.flow.Flow
 
 interface LlmProvider {
-    suspend fun generate(prompt: Prompt, tools: List<ToolDescriptor>, maxTokens: Int? = null): List<Message.Response>
     fun generateStream(prompt: Prompt, tools: List<ToolDescriptor>, maxTokens: Int? = null): Flow<StreamFrame>
     fun isAvailable(): Boolean
     fun modelInfo(): ModelInfo

--- a/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
@@ -116,10 +116,7 @@ class AssistantViewModel(
         ) }
 
         val trustSelfSigned = tokenManager.activeInstance.value?.trustSelfSigned == true
-        val provider = when (config) {
-            is LlmProviderConfig.OpenAiCompatible ->
-                KoogLlmProvider(config, trustSelfSigned)
-        }
+        val provider = KoogLlmProvider(config as LlmProviderConfig.OpenAiCompatible, trustSelfSigned)
 
         mcpServerManager.refreshConnections()
         val serverConfigs = tokenManager.activeInstance.value?.mcpServerUrls ?: emptyList()
@@ -234,7 +231,7 @@ class AssistantViewModel(
                         }
                     }
             } finally {
-                (provider as? KoogLlmProvider)?.close()
+                provider.close()
             }
         }
     }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/LocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/LocalTool.kt
@@ -5,6 +5,4 @@ enum class ToolSource { LOCAL, MCP }
 abstract class LocalTool(
     override val spec: ToolSpec,
     val destructive: Boolean = false
-) : Tool {
-    val source: ToolSource = ToolSource.LOCAL
-}
+) : Tool

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/McpTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/McpTool.kt
@@ -19,8 +19,6 @@ class McpTool(
     private val serverLabel: String
 ) : Tool {
 
-    val source: ToolSource = ToolSource.MCP
-
     companion object {
         const val MAX_PAGE_SIZE = 10
         private const val MAX_DESCRIPTION_CHARS = 120

--- a/app/src/main/kotlin/com/example/aapremote/assistant/ui/AssistantSettingsSheet.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/ui/AssistantSettingsSheet.kt
@@ -90,7 +90,7 @@ fun AssistantSettingsSheet(
 
     var providerState by remember {
         mutableStateOf<Map<KnownProvider, Pair<String, String>>>(
-            if (savedConfig != null) mapOf(initialProvider to ((savedConfig.model ?: "") to (savedConfig.apiKey ?: "")))
+            if (savedConfig != null) mapOf(initialProvider to (savedConfig.model to (savedConfig.apiKey ?: "")))
             else emptyMap()
         )
     }

--- a/app/src/main/kotlin/com/example/aapremote/ui/components/WorkflowNodeItem.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/components/WorkflowNodeItem.kt
@@ -44,7 +44,7 @@ fun WorkflowNodeItem(
             modifier = Modifier
                 .fillMaxWidth()
                 .then(
-                    if (isClickable) Modifier.clickable { onToggleExpand?.invoke() }
+                    if (onToggleExpand != null && job != null) Modifier.clickable { onToggleExpand() }
                     else Modifier
                 )
                 .padding(horizontal = 16.dp, vertical = 8.dp),

--- a/app/src/test/kotlin/com/example/aapremote/assistant/engine/ChatEngineTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/assistant/engine/ChatEngineTest.kt
@@ -2,8 +2,6 @@ package com.example.aapremote.assistant.engine
 
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.dsl.Prompt
-import ai.koog.prompt.message.Message
-import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
 import app.cash.turbine.test
 import com.example.aapremote.assistant.llm.LlmProvider
@@ -140,15 +138,6 @@ private class FakeLlmProvider(
 ) : LlmProvider {
     private var callIndex = 0
 
-    override suspend fun generate(
-        prompt: Prompt,
-        tools: List<ToolDescriptor>,
-        maxTokens: Int?
-    ): List<Message.Response> {
-        val resp = responses.getOrElse(callIndex++) { FakeResponse() }
-        return buildResponseMessages(resp)
-    }
-
     override fun generateStream(
         prompt: Prompt,
         tools: List<ToolDescriptor>,
@@ -171,22 +160,6 @@ private class FakeLlmProvider(
 
     override fun isAvailable(): Boolean = true
     override fun modelInfo(): ModelInfo = ModelInfo("fake-model")
-
-    private fun buildResponseMessages(resp: FakeResponse): List<Message.Response> {
-        val messages = mutableListOf<Message.Response>()
-        if (resp.text != null) {
-            messages.add(Message.Assistant(content = resp.text, metaInfo = ResponseMetaInfo.Empty))
-        }
-        for (tc in resp.toolCalls) {
-            messages.add(Message.Tool.Call(
-                id = tc.id,
-                tool = tc.name,
-                content = tc.arguments,
-                metaInfo = ResponseMetaInfo.Empty
-            ))
-        }
-        return messages
-    }
 }
 
 private class FakeTool(

--- a/app/src/test/kotlin/com/example/aapremote/assistant/llm/KoogLlmProviderTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/assistant/llm/KoogLlmProviderTest.kt
@@ -49,29 +49,33 @@ class KoogLlmProviderTest {
         id = "test"
     )
 
-    private fun textResponse(content: String) = MockResponse()
-        .setBody(
-            """{"id":"chatcmpl-1","object":"chat.completion","created":1700000000,"model":"test-model",""" +
-                """"choices":[{"index":0,"message":{"role":"assistant","content":"$content"},"finish_reason":"stop"}],""" +
-                """"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}"""
-        )
-        .setHeader("Content-Type", "application/json")
+    private fun sseTextResponse(content: String): MockResponse {
+        val chunk = """{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"test-model",""" +
+            """"choices":[{"index":0,"delta":{"role":"assistant","content":"$content"},"finish_reason":null}]}"""
+        val done = """{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"test-model",""" +
+            """"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"""
+        return MockResponse()
+            .setBody("data: $chunk\n\ndata: $done\n\ndata: [DONE]\n\n")
+            .setHeader("Content-Type", "text/event-stream")
+    }
 
-    private fun toolCallResponse() = MockResponse()
-        .setBody(
-            """{"id":"chatcmpl-1","object":"chat.completion","created":1700000000,"model":"test-model",""" +
-                """"choices":[{"index":0,"message":{"role":"assistant","content":null,""" +
-                """"tool_calls":[{"id":"call_1","type":"function","function":{"name":"list_jobs","arguments":"{\"status\":\"failed\"}"}}]},""" +
-                """"finish_reason":"tool_calls"}],""" +
-                """"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}"""
-        )
-        .setHeader("Content-Type", "application/json")
+    private fun sseToolCallResponse(): MockResponse {
+        val chunk1 = """{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"test-model",""" +
+            """"choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"list_jobs","arguments":""}}]},"finish_reason":null}]}"""
+        val chunk2 = """{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"test-model",""" +
+            """"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"status\":\"failed\"}"}}]},"finish_reason":null}]}"""
+        val done = """{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"test-model",""" +
+            """"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"""
+        return MockResponse()
+            .setBody("data: $chunk1\n\ndata: $chunk2\n\ndata: $done\n\ndata: [DONE]\n\n")
+            .setHeader("Content-Type", "text/event-stream")
+    }
 
     @Test
-    fun `generate sends correct request format`() = runTest {
-        server.enqueue(textResponse("Hello!"))
+    fun `generateStream sends correct request format`() = runTest {
+        server.enqueue(sseTextResponse("Hello!"))
 
-        provider.generate(userPrompt("Hi"), emptyList())
+        provider.generateStream(userPrompt("Hi"), emptyList()).toList()
 
         val request = server.takeRequest()
         assertEquals("POST", request.method)
@@ -83,30 +87,31 @@ class KoogLlmProviderTest {
     }
 
     @Test
-    fun `generate parses text response`() = runTest {
-        server.enqueue(textResponse("The answer is 42"))
+    fun `generateStream parses text response`() = runTest {
+        server.enqueue(sseTextResponse("The answer is 42"))
 
-        val result = provider.generate(userPrompt("What is the answer?"), emptyList())
+        val frames = provider.generateStream(userPrompt("What is the answer?"), emptyList()).toList()
 
-        val assistant = result.filterIsInstance<Message.Assistant>()
-        assertEquals(1, assistant.size)
-        assertEquals("The answer is 42", assistant[0].content)
+        val textFrames = frames.filterIsInstance<StreamFrame.TextDelta>()
+        assertTrue(textFrames.isNotEmpty())
+        val fullText = textFrames.joinToString("") { it.text }
+        assertTrue(fullText.contains("The answer is 42"))
     }
 
     @Test
-    fun `generate parses tool calls`() = runTest {
-        server.enqueue(toolCallResponse())
+    fun `generateStream parses tool calls`() = runTest {
+        server.enqueue(sseToolCallResponse())
 
-        val result = provider.generate(userPrompt("List failed jobs"), emptyList())
+        val frames = provider.generateStream(userPrompt("List failed jobs"), emptyList()).toList()
 
-        val toolCalls = result.filterIsInstance<Message.Tool.Call>()
+        val toolCalls = frames.filterIsInstance<StreamFrame.ToolCallComplete>()
         assertEquals(1, toolCalls.size)
         assertEquals("call_1", toolCalls[0].id)
-        assertEquals("list_jobs", toolCalls[0].tool)
+        assertEquals("list_jobs", toolCalls[0].name)
     }
 
     @Test
-    fun `generate throws LlmAuthException on 401`() = runTest {
+    fun `generateStream throws LlmAuthException on 401`() = runTest {
         server.enqueue(
             MockResponse()
                 .setResponseCode(401)
@@ -114,7 +119,7 @@ class KoogLlmProviderTest {
         )
 
         try {
-            provider.generate(userPrompt("test"), emptyList())
+            provider.generateStream(userPrompt("test"), emptyList()).toList()
             throw AssertionError("Expected exception was not thrown")
         } catch (e: LlmAuthException) {
             // Expected
@@ -122,7 +127,7 @@ class KoogLlmProviderTest {
     }
 
     @Test
-    fun `generate throws LlmRateLimitException on 429`() = runTest {
+    fun `generateStream throws LlmRateLimitException on 429`() = runTest {
         server.enqueue(
             MockResponse()
                 .setResponseCode(429)
@@ -130,7 +135,7 @@ class KoogLlmProviderTest {
         )
 
         try {
-            provider.generate(userPrompt("test"), emptyList())
+            provider.generateStream(userPrompt("test"), emptyList()).toList()
             throw AssertionError("Expected exception was not thrown")
         } catch (e: LlmRateLimitException) {
             // Expected
@@ -138,7 +143,7 @@ class KoogLlmProviderTest {
     }
 
     @Test
-    fun `generate throws LlmServerException on 500`() = runTest {
+    fun `generateStream throws LlmServerException on 500`() = runTest {
         server.enqueue(
             MockResponse()
                 .setResponseCode(500)
@@ -146,7 +151,7 @@ class KoogLlmProviderTest {
         )
 
         try {
-            provider.generate(userPrompt("test"), emptyList())
+            provider.generateStream(userPrompt("test"), emptyList()).toList()
             throw AssertionError("Expected exception was not thrown")
         } catch (e: LlmServerException) {
             // Expected
@@ -154,8 +159,8 @@ class KoogLlmProviderTest {
     }
 
     @Test
-    fun `generate includes tools in request when provided`() = runTest {
-        server.enqueue(textResponse("ok"))
+    fun `generateStream includes tools in request when provided`() = runTest {
+        server.enqueue(sseTextResponse("ok"))
 
         val tools = listOf(
             ToolSpec(
@@ -172,7 +177,7 @@ class KoogLlmProviderTest {
             )
         )
 
-        provider.generate(userPrompt("test"), tools.map { it.toToolDescriptor() })
+        provider.generateStream(userPrompt("test"), tools.map { it.toToolDescriptor() }).toList()
 
         val body = server.takeRequest().body.readUtf8()
         assertTrue(body.contains("list_jobs"))


### PR DESCRIPTION
## Summary

- Fix all 3 compiler warnings (unnecessary cast, elvis operator, safe call)
- Remove unused `generate()` (non-streaming) from `LlmProvider` interface and `KoogLlmProvider`
- Remove unused `source` property from `LocalTool` and `McpTool`
- Move `WRITE_ACTIONS`/`STOP_WORDS` to companion object in `ToolRouter`
- Remove unused `networkJson` import from `AssistantViewModel`
- Update `KoogLlmProviderTest` to use SSE format for streaming tests
- Remove dead `buildResponseMessages` helper from `ChatEngineTest`
- Net: 62 insertions, 103 deletions (-41 LOC)

Closes #64, closes #73

## Test plan

- [x] `./gradlew compileDebugKotlin` — zero warnings
- [x] `./gradlew testDebugUnitTest` — all tests pass

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>