### PR TITLE
Add password-protected credential backup and restore

### DIFF
--- a/app/src/main/kotlin/com/example/aapremote/data/DataModule.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/DataModule.kt
@@ -1,10 +1,12 @@
 package com.example.aapremote.data
 
+import com.example.aapremote.data.backup.BackupManager
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 val dataModule = module {
     single { TokenManager(androidContext()) }
+    single { BackupManager() }
     single { ConnectivityObserver(androidContext()) }
     single { AuthRepository(get(), get()) }
     single { TemplateRepository(get<com.example.aapremote.network.AapApiProvider>()) }

--- a/app/src/main/kotlin/com/example/aapremote/data/backup/BackupManager.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/backup/BackupManager.kt
@@ -71,10 +71,13 @@ class BackupManager {
 
     private fun deriveKey(password: String, salt: ByteArray): SecretKeySpec {
         val spec = PBEKeySpec(password.toCharArray(), salt, PBKDF2_ITERATIONS, KEY_LENGTH_BITS)
-        val factory = SecretKeyFactory.getInstance(PBKDF2_ALGORITHM)
-        val keyBytes = factory.generateSecret(spec).encoded
-        spec.clearPassword()
-        return SecretKeySpec(keyBytes, "AES")
+        try {
+            val factory = SecretKeyFactory.getInstance(PBKDF2_ALGORITHM)
+            val keyBytes = factory.generateSecret(spec).encoded
+            return SecretKeySpec(keyBytes, "AES")
+        } finally {
+            spec.clearPassword()
+        }
     }
 
     private fun AapInstance.toBackupInstance() = BackupInstance(

--- a/app/src/main/kotlin/com/example/aapremote/data/backup/BackupManager.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/backup/BackupManager.kt
@@ -1,0 +1,101 @@
+package com.example.aapremote.data.backup
+
+import com.example.aapremote.assistant.data.LlmProviderConfig
+import com.example.aapremote.model.AapInstance
+import kotlinx.serialization.json.Json
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+
+class BackupManager {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun exportBackup(
+        password: String,
+        instances: List<AapInstance>,
+        llmConfig: LlmProviderConfig? = null
+    ): ByteArray {
+        val envelope = BackupEnvelope(
+            createdAt = System.currentTimeMillis(),
+            instances = instances.map { it.toBackupInstance() },
+            llmConfig = llmConfig
+        )
+        val plaintext = json.encodeToString(BackupEnvelope.serializer(), envelope)
+        return encrypt(plaintext.toByteArray(Charsets.UTF_8), password)
+    }
+
+    fun importBackup(data: ByteArray, password: String): BackupEnvelope {
+        val plaintext = try {
+            decrypt(data, password)
+        } catch (e: javax.crypto.AEADBadTagException) {
+            throw BackupDecryptionException("Incorrect password")
+        } catch (e: Exception) {
+            throw BackupDecryptionException("Failed to decrypt backup: ${e.message}")
+        }
+        return try {
+            json.decodeFromString(BackupEnvelope.serializer(), String(plaintext, Charsets.UTF_8))
+        } catch (e: Exception) {
+            throw BackupDecryptionException("Invalid backup format: ${e.message}")
+        }
+    }
+
+    private fun encrypt(data: ByteArray, password: String): ByteArray {
+        val salt = ByteArray(SALT_LENGTH).also { SecureRandom().nextBytes(it) }
+        val iv = ByteArray(IV_LENGTH).also { SecureRandom().nextBytes(it) }
+        val key = deriveKey(password, salt)
+
+        val cipher = Cipher.getInstance(CIPHER_TRANSFORM)
+        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(TAG_LENGTH_BITS, iv))
+        val ciphertext = cipher.doFinal(data)
+
+        return salt + iv + ciphertext
+    }
+
+    private fun decrypt(data: ByteArray, password: String): ByteArray {
+        if (data.size < SALT_LENGTH + IV_LENGTH + TAG_LENGTH_BITS / 8) {
+            throw BackupDecryptionException("Backup file is too small or corrupted")
+        }
+        val salt = data.copyOfRange(0, SALT_LENGTH)
+        val iv = data.copyOfRange(SALT_LENGTH, SALT_LENGTH + IV_LENGTH)
+        val ciphertext = data.copyOfRange(SALT_LENGTH + IV_LENGTH, data.size)
+        val key = deriveKey(password, salt)
+
+        val cipher = Cipher.getInstance(CIPHER_TRANSFORM)
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(TAG_LENGTH_BITS, iv))
+        return cipher.doFinal(ciphertext)
+    }
+
+    private fun deriveKey(password: String, salt: ByteArray): SecretKeySpec {
+        val spec = PBEKeySpec(password.toCharArray(), salt, PBKDF2_ITERATIONS, KEY_LENGTH_BITS)
+        val factory = SecretKeyFactory.getInstance(PBKDF2_ALGORITHM)
+        val keyBytes = factory.generateSecret(spec).encoded
+        spec.clearPassword()
+        return SecretKeySpec(keyBytes, "AES")
+    }
+
+    private fun AapInstance.toBackupInstance() = BackupInstance(
+        id = id,
+        baseUrl = baseUrl,
+        token = token,
+        alias = alias,
+        apiVersion = apiVersion,
+        trustSelfSigned = trustSelfSigned,
+        certFingerprint = certFingerprint,
+        mcpServerUrls = mcpServerUrls,
+        mcpEnabled = mcpEnabled
+    )
+
+    companion object {
+        private const val SALT_LENGTH = 32
+        private const val IV_LENGTH = 12
+        private const val TAG_LENGTH_BITS = 128
+        private const val KEY_LENGTH_BITS = 256
+        private const val PBKDF2_ITERATIONS = 600_000
+        private const val PBKDF2_ALGORITHM = "PBKDF2WithHmacSHA256"
+        private const val CIPHER_TRANSFORM = "AES/GCM/NoPadding"
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/backup/BackupModels.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/backup/BackupModels.kt
@@ -1,0 +1,28 @@
+package com.example.aapremote.data.backup
+
+import com.example.aapremote.assistant.data.LlmProviderConfig
+import com.example.aapremote.model.McpServerConfig
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BackupEnvelope(
+    val version: Int = 1,
+    val createdAt: Long,
+    val instances: List<BackupInstance>,
+    val llmConfig: LlmProviderConfig? = null
+)
+
+@Serializable
+data class BackupInstance(
+    val id: String,
+    val baseUrl: String,
+    val token: String,
+    val alias: String? = null,
+    val apiVersion: String,
+    val trustSelfSigned: Boolean = false,
+    val certFingerprint: String? = null,
+    val mcpServerUrls: List<McpServerConfig>? = null,
+    val mcpEnabled: Boolean = false
+)
+
+class BackupDecryptionException(message: String) : Exception(message)

--- a/app/src/main/kotlin/com/example/aapremote/presentation/PresentationModule.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/PresentationModule.kt
@@ -1,6 +1,7 @@
 package com.example.aapremote.presentation
 
 import com.example.aapremote.presentation.auth.AuthViewModel
+import com.example.aapremote.presentation.settings.BackupViewModel
 import com.example.aapremote.presentation.jobs.JobStatusViewModel
 import com.example.aapremote.presentation.jobs.RecentJobsViewModel
 import com.example.aapremote.presentation.eda.EdaAuditViewModel
@@ -28,4 +29,5 @@ val presentationModule = module {
     viewModelOf(::InventoryHostsViewModel)
     viewModelOf(::HostsViewModel)
     viewModelOf(::SettingsViewModel)
+    viewModelOf(::BackupViewModel)
 }

--- a/app/src/main/kotlin/com/example/aapremote/presentation/settings/BackupViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/settings/BackupViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.aapremote.assistant.data.AssistantRepository
 import com.example.aapremote.data.TokenManager
+import com.example.aapremote.assistant.data.LlmProviderConfig
 import com.example.aapremote.data.backup.BackupDecryptionException
 import com.example.aapremote.data.backup.BackupEnvelope
+import com.example.aapremote.data.backup.BackupInstance
 import com.example.aapremote.data.backup.BackupManager
 import com.example.aapremote.network.ApiVersion
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,7 +26,10 @@ sealed interface BackupUiState {
         val rawData: ByteArray,
         val password: String,
         val duplicateCount: Int,
-        val newCount: Int
+        val newCount: Int,
+        val instances: List<BackupInstance>,
+        val llmConfig: LlmProviderConfig?,
+        val hasExistingInstances: Boolean
     ) : BackupUiState
     data object Importing : BackupUiState
     data class Success(val message: String) : BackupUiState
@@ -78,7 +83,10 @@ class BackupViewModel(
                     rawData = data,
                     password = password,
                     duplicateCount = duplicates,
-                    newCount = newOnes
+                    newCount = newOnes,
+                    instances = envelope.instances,
+                    llmConfig = envelope.llmConfig,
+                    hasExistingInstances = existingUrls.isNotEmpty()
                 )
             } catch (e: BackupDecryptionException) {
                 _uiState.value = BackupUiState.Error(e.message ?: "Decryption failed")

--- a/app/src/main/kotlin/com/example/aapremote/presentation/settings/BackupViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/settings/BackupViewModel.kt
@@ -23,8 +23,6 @@ sealed interface BackupUiState {
     data class ExportReady(val data: ByteArray) : BackupUiState
     data class ImportPreview(
         val envelope: BackupEnvelope,
-        val rawData: ByteArray,
-        val password: String,
         val duplicateCount: Int,
         val newCount: Int,
         val instances: List<BackupInstance>,
@@ -44,6 +42,8 @@ class BackupViewModel(
 
     private val _uiState = MutableStateFlow<BackupUiState>(BackupUiState.Idle)
     val uiState: StateFlow<BackupUiState> = _uiState.asStateFlow()
+
+    private var pendingEnvelope: BackupEnvelope? = null
 
     fun exportBackup(password: String, includeAssistantConfig: Boolean) {
         viewModelScope.launch {
@@ -78,10 +78,9 @@ class BackupViewModel(
                     if (inst.baseUrl.trimEnd('/').lowercase() in existingUrls) duplicates++ else newOnes++
                 }
 
+                pendingEnvelope = envelope
                 _uiState.value = BackupUiState.ImportPreview(
                     envelope = envelope,
-                    rawData = data,
-                    password = password,
                     duplicateCount = duplicates,
                     newCount = newOnes,
                     instances = envelope.instances,
@@ -97,7 +96,7 @@ class BackupViewModel(
     }
 
     fun confirmImport(mode: ImportMode) {
-        val preview = _uiState.value as? BackupUiState.ImportPreview ?: return
+        val envelope = pendingEnvelope ?: return
         viewModelScope.launch {
             _uiState.value = BackupUiState.Importing
             try {
@@ -110,7 +109,7 @@ class BackupViewModel(
                     .toSet()
 
                 var imported = 0
-                for (inst in preview.envelope.instances) {
+                for (inst in envelope.instances) {
                     val normalizedUrl = inst.baseUrl.trimEnd('/').lowercase()
                     if (mode == ImportMode.MERGE && normalizedUrl in existingUrls) continue
 
@@ -141,11 +140,12 @@ class BackupViewModel(
                     imported++
                 }
 
-                preview.envelope.llmConfig?.let { config ->
+                envelope.llmConfig?.let { config ->
                     assistantRepository.saveLlmConfig(config)
                 }
 
-                val llmNote = if (preview.envelope.llmConfig != null) " + LLM config" else ""
+                val llmNote = if (envelope.llmConfig != null) " + LLM config" else ""
+                pendingEnvelope = null
                 _uiState.value = BackupUiState.Success("Imported $imported instance(s)$llmNote")
             } catch (e: Exception) {
                 _uiState.value = BackupUiState.Error("Import failed: ${e.message}")
@@ -154,6 +154,7 @@ class BackupViewModel(
     }
 
     fun dismiss() {
+        pendingEnvelope = null
         _uiState.value = BackupUiState.Idle
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/presentation/settings/BackupViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/settings/BackupViewModel.kt
@@ -1,0 +1,151 @@
+package com.example.aapremote.presentation.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.aapremote.assistant.data.AssistantRepository
+import com.example.aapremote.data.TokenManager
+import com.example.aapremote.data.backup.BackupDecryptionException
+import com.example.aapremote.data.backup.BackupEnvelope
+import com.example.aapremote.data.backup.BackupManager
+import com.example.aapremote.network.ApiVersion
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+enum class ImportMode { MERGE, REPLACE }
+
+sealed interface BackupUiState {
+    data object Idle : BackupUiState
+    data object Exporting : BackupUiState
+    data class ExportReady(val data: ByteArray) : BackupUiState
+    data class ImportPreview(
+        val envelope: BackupEnvelope,
+        val rawData: ByteArray,
+        val password: String,
+        val duplicateCount: Int,
+        val newCount: Int
+    ) : BackupUiState
+    data object Importing : BackupUiState
+    data class Success(val message: String) : BackupUiState
+    data class Error(val message: String) : BackupUiState
+}
+
+class BackupViewModel(
+    private val backupManager: BackupManager,
+    private val tokenManager: TokenManager,
+    private val assistantRepository: AssistantRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<BackupUiState>(BackupUiState.Idle)
+    val uiState: StateFlow<BackupUiState> = _uiState.asStateFlow()
+
+    fun exportBackup(password: String, includeAssistantConfig: Boolean) {
+        viewModelScope.launch {
+            _uiState.value = BackupUiState.Exporting
+            try {
+                val instances = tokenManager.instances.value
+                if (instances.isEmpty()) {
+                    _uiState.value = BackupUiState.Error("No instances to export")
+                    return@launch
+                }
+                val llmConfig = if (includeAssistantConfig) assistantRepository.loadLlmConfig() else null
+                val data = backupManager.exportBackup(password, instances, llmConfig)
+                _uiState.value = BackupUiState.ExportReady(data)
+            } catch (e: Exception) {
+                _uiState.value = BackupUiState.Error("Export failed: ${e.message}")
+            }
+        }
+    }
+
+    fun startImport(data: ByteArray, password: String) {
+        viewModelScope.launch {
+            _uiState.value = BackupUiState.Importing
+            try {
+                val envelope = backupManager.importBackup(data, password)
+                val existingUrls = tokenManager.instances.value
+                    .map { it.baseUrl.trimEnd('/').lowercase() }
+                    .toSet()
+
+                var duplicates = 0
+                var newOnes = 0
+                for (inst in envelope.instances) {
+                    if (inst.baseUrl.trimEnd('/').lowercase() in existingUrls) duplicates++ else newOnes++
+                }
+
+                _uiState.value = BackupUiState.ImportPreview(
+                    envelope = envelope,
+                    rawData = data,
+                    password = password,
+                    duplicateCount = duplicates,
+                    newCount = newOnes
+                )
+            } catch (e: BackupDecryptionException) {
+                _uiState.value = BackupUiState.Error(e.message ?: "Decryption failed")
+            } catch (e: Exception) {
+                _uiState.value = BackupUiState.Error("Import failed: ${e.message}")
+            }
+        }
+    }
+
+    fun confirmImport(mode: ImportMode) {
+        val preview = _uiState.value as? BackupUiState.ImportPreview ?: return
+        viewModelScope.launch {
+            _uiState.value = BackupUiState.Importing
+            try {
+                if (mode == ImportMode.REPLACE) {
+                    tokenManager.clearCredentials()
+                }
+
+                val existingUrls = tokenManager.instances.value
+                    .map { it.baseUrl.trimEnd('/').lowercase() }
+                    .toSet()
+
+                var imported = 0
+                for (inst in preview.envelope.instances) {
+                    val normalizedUrl = inst.baseUrl.trimEnd('/').lowercase()
+                    if (mode == ImportMode.MERGE && normalizedUrl in existingUrls) continue
+
+                    val apiVersion = try {
+                        ApiVersion.valueOf(inst.apiVersion)
+                    } catch (_: Exception) {
+                        ApiVersion.CONTROLLER_V2
+                    }
+
+                    tokenManager.saveInstance(
+                        baseUrl = inst.baseUrl,
+                        token = inst.token,
+                        alias = inst.alias,
+                        apiVersion = apiVersion,
+                        trustSelfSigned = inst.trustSelfSigned,
+                        certFingerprint = inst.certFingerprint
+                    )
+
+                    if (inst.mcpEnabled || !inst.mcpServerUrls.isNullOrEmpty()) {
+                        val savedInstances = tokenManager.instances.value
+                        val savedId = savedInstances.find {
+                            it.baseUrl.trimEnd('/').lowercase() == normalizedUrl
+                        }?.id
+                        if (savedId != null) {
+                            tokenManager.updateMcpConfig(savedId, inst.mcpEnabled, inst.mcpServerUrls)
+                        }
+                    }
+                    imported++
+                }
+
+                preview.envelope.llmConfig?.let { config ->
+                    assistantRepository.saveLlmConfig(config)
+                }
+
+                val llmNote = if (preview.envelope.llmConfig != null) " + LLM config" else ""
+                _uiState.value = BackupUiState.Success("Imported $imported instance(s)$llmNote")
+            } catch (e: Exception) {
+                _uiState.value = BackupUiState.Error("Import failed: ${e.message}")
+            }
+        }
+    }
+
+    fun dismiss() {
+        _uiState.value = BackupUiState.Idle
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/ui/auth/AuthScreen.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/auth/AuthScreen.kt
@@ -1,9 +1,13 @@
 package com.example.aapremote.ui.auth
 
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
@@ -11,6 +15,7 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -24,7 +29,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.aapremote.R
 import com.example.aapremote.presentation.auth.AuthUiState
 import com.example.aapremote.presentation.auth.AuthViewModel
+import com.example.aapremote.presentation.settings.BackupViewModel
+import com.example.aapremote.presentation.settings.BackupUiState
+import com.example.aapremote.presentation.settings.ImportMode
 import com.example.aapremote.ui.components.ErrorMessage
+import com.example.aapremote.ui.settings.ImportFromBackupButton
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -245,6 +254,11 @@ fun AuthScreen(
                     }
                 }
             }
+        }
+
+        if (!isReAuth && !isAddInstance) {
+            Spacer(modifier = Modifier.height(16.dp))
+            ImportFromBackupButton(onNavigateToDashboard = onNavigateToDashboard)
         }
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/ui/settings/BackupRestoreSection.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/settings/BackupRestoreSection.kt
@@ -1,0 +1,369 @@
+package com.example.aapremote.ui.settings
+
+import android.content.Context
+import android.net.Uri
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FileDownload
+import androidx.compose.material.icons.filled.FileUpload
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.aapremote.presentation.settings.BackupUiState
+import com.example.aapremote.presentation.settings.BackupViewModel
+import com.example.aapremote.presentation.settings.ImportMode
+import org.koin.compose.viewmodel.koinViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun BackupRestoreSection(
+    viewModel: BackupViewModel = koinViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    var showExportDialog by remember { mutableStateOf(false) }
+    var showImportPasswordDialog by remember { mutableStateOf(false) }
+    var pendingImportData by remember { mutableStateOf<ByteArray?>(null) }
+
+    val exportLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("application/octet-stream")
+    ) { uri ->
+        if (uri != null) {
+            val data = (uiState as? BackupUiState.ExportReady)?.data ?: return@rememberLauncherForActivityResult
+            writeToUri(context, uri, data)
+            viewModel.dismiss()
+            Toast.makeText(context, "Backup exported", Toast.LENGTH_SHORT).show()
+        } else {
+            viewModel.dismiss()
+        }
+    }
+
+    val importLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri != null) {
+            val data = readFromUri(context, uri)
+            if (data != null) {
+                pendingImportData = data
+                showImportPasswordDialog = true
+            } else {
+                Toast.makeText(context, "Failed to read file", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    LaunchedEffect(uiState) {
+        when (val state = uiState) {
+            is BackupUiState.ExportReady -> {
+                val dateStr = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(Date())
+                exportLauncher.launch("aapdroid-backup-$dateStr.aapdroid")
+            }
+            is BackupUiState.Success -> {
+                Toast.makeText(context, state.message, Toast.LENGTH_SHORT).show()
+                viewModel.dismiss()
+            }
+            is BackupUiState.Error -> {
+                Toast.makeText(context, state.message, Toast.LENGTH_LONG).show()
+                viewModel.dismiss()
+            }
+            else -> {}
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "Backup & Restore",
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+            text = "Export credentials to transfer between devices or as a safety backup.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        val isLoading = uiState is BackupUiState.Exporting || uiState is BackupUiState.Importing
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            FilledTonalButton(
+                onClick = { showExportDialog = true },
+                enabled = !isLoading,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("button_export_backup")
+            ) {
+                if (uiState is BackupUiState.Exporting) {
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                } else {
+                    Icon(Icons.Default.FileUpload, contentDescription = null, modifier = Modifier.padding(end = 4.dp))
+                    Text("Export")
+                }
+            }
+
+            FilledTonalButton(
+                onClick = { importLauncher.launch(arrayOf("*/*")) },
+                enabled = !isLoading,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("button_import_backup")
+            ) {
+                if (uiState is BackupUiState.Importing) {
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                } else {
+                    Icon(Icons.Default.FileDownload, contentDescription = null, modifier = Modifier.padding(end = 4.dp))
+                    Text("Import")
+                }
+            }
+        }
+    }
+
+    if (showExportDialog) {
+        ExportPasswordDialog(
+            onConfirm = { password, includeLlm ->
+                showExportDialog = false
+                viewModel.exportBackup(password, includeLlm)
+            },
+            onDismiss = { showExportDialog = false }
+        )
+    }
+
+    if (showImportPasswordDialog) {
+        ImportPasswordDialog(
+            onConfirm = { password ->
+                showImportPasswordDialog = false
+                pendingImportData?.let { viewModel.startImport(it, password) }
+                pendingImportData = null
+            },
+            onDismiss = {
+                showImportPasswordDialog = false
+                pendingImportData = null
+            }
+        )
+    }
+
+    (uiState as? BackupUiState.ImportPreview)?.let { preview ->
+        ImportPreviewDialog(
+            totalInstances = preview.envelope.instances.size,
+            duplicateCount = preview.duplicateCount,
+            newCount = preview.newCount,
+            hasLlmConfig = preview.envelope.llmConfig != null,
+            onMerge = { viewModel.confirmImport(ImportMode.MERGE) },
+            onReplace = { viewModel.confirmImport(ImportMode.REPLACE) },
+            onDismiss = { viewModel.dismiss() }
+        )
+    }
+}
+
+@Composable
+private fun ExportPasswordDialog(
+    onConfirm: (password: String, includeLlm: Boolean) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var password by remember { mutableStateOf("") }
+    var confirmPassword by remember { mutableStateOf("") }
+    var includeLlm by remember { mutableStateOf(true) }
+    var showMismatch by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Export Credentials") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    "Enter a password to encrypt the backup file.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = { password = it; showMismatch = false },
+                    label = { Text("Password") },
+                    visualTransformation = PasswordVisualTransformation(),
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("field_export_password")
+                )
+                OutlinedTextField(
+                    value = confirmPassword,
+                    onValueChange = { confirmPassword = it; showMismatch = false },
+                    label = { Text("Confirm password") },
+                    visualTransformation = PasswordVisualTransformation(),
+                    singleLine = true,
+                    isError = showMismatch,
+                    supportingText = if (showMismatch) {{ Text("Passwords don't match") }} else null,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("field_export_confirm_password")
+                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Checkbox(
+                        checked = includeLlm,
+                        onCheckedChange = { includeLlm = it },
+                        modifier = Modifier.testTag("switch_include_llm")
+                    )
+                    Text("Include LLM API keys", style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (password != confirmPassword) {
+                        showMismatch = true
+                    } else {
+                        onConfirm(password, includeLlm)
+                    }
+                },
+                enabled = password.isNotEmpty()
+            ) {
+                Text("Export")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}
+
+@Composable
+private fun ImportPasswordDialog(
+    onConfirm: (password: String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var password by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Import Credentials") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    "Enter the password used when exporting.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    label = { Text("Password") },
+                    visualTransformation = PasswordVisualTransformation(),
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("field_import_password")
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(password) },
+                enabled = password.isNotEmpty()
+            ) {
+                Text("Decrypt")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}
+
+@Composable
+private fun ImportPreviewDialog(
+    totalInstances: Int,
+    duplicateCount: Int,
+    newCount: Int,
+    hasLlmConfig: Boolean,
+    onMerge: () -> Unit,
+    onReplace: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Import Preview") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text("Found $totalInstances instance(s) in backup.")
+                if (duplicateCount > 0) {
+                    Text(
+                        "$duplicateCount already on this device.",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                if (newCount > 0) {
+                    Text("$newCount new instance(s) to import.")
+                }
+                if (hasLlmConfig) {
+                    Text(
+                        "LLM configuration included.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (newCount > 0 || duplicateCount > 0) {
+                    TextButton(onClick = onReplace) { Text("Replace All") }
+                }
+                TextButton(onClick = onMerge) {
+                    Text(if (newCount > 0) "Merge" else "Import")
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}
+
+private fun writeToUri(context: Context, uri: Uri, data: ByteArray) {
+    context.contentResolver.openOutputStream(uri)?.use { it.write(data) }
+}
+
+private fun readFromUri(context: Context, uri: Uri): ByteArray? {
+    return try {
+        context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+    } catch (_: Exception) {
+        null
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/ui/settings/BackupRestoreSection.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/settings/BackupRestoreSection.kt
@@ -356,6 +356,87 @@ private fun ImportPreviewDialog(
     )
 }
 
+@Composable
+fun ImportFromBackupButton(
+    onNavigateToDashboard: () -> Unit,
+    viewModel: BackupViewModel = koinViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    var showPasswordDialog by remember { mutableStateOf(false) }
+    var pendingData by remember { mutableStateOf<ByteArray?>(null) }
+
+    val importLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri != null) {
+            val data = readFromUri(context, uri)
+            if (data != null) {
+                pendingData = data
+                showPasswordDialog = true
+            } else {
+                Toast.makeText(context, "Failed to read file", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    LaunchedEffect(uiState) {
+        when (val state = uiState) {
+            is BackupUiState.Success -> {
+                Toast.makeText(context, state.message, Toast.LENGTH_SHORT).show()
+                viewModel.dismiss()
+                onNavigateToDashboard()
+            }
+            is BackupUiState.Error -> {
+                Toast.makeText(context, state.message, Toast.LENGTH_LONG).show()
+                viewModel.dismiss()
+            }
+            else -> {}
+        }
+    }
+
+    TextButton(
+        onClick = { importLauncher.launch(arrayOf("*/*")) },
+        modifier = Modifier.testTag("button_import_backup_auth")
+    ) {
+        Icon(
+            Icons.Default.FileDownload,
+            contentDescription = null,
+            modifier = Modifier
+                .size(18.dp)
+                .padding(end = 4.dp)
+        )
+        Text("Import from backup")
+    }
+
+    if (showPasswordDialog) {
+        ImportPasswordDialog(
+            onConfirm = { password ->
+                showPasswordDialog = false
+                pendingData?.let { viewModel.startImport(it, password) }
+                pendingData = null
+            },
+            onDismiss = {
+                showPasswordDialog = false
+                pendingData = null
+            }
+        )
+    }
+
+    (uiState as? BackupUiState.ImportPreview)?.let { preview ->
+        ImportPreviewDialog(
+            totalInstances = preview.envelope.instances.size,
+            duplicateCount = preview.duplicateCount,
+            newCount = preview.newCount,
+            hasLlmConfig = preview.envelope.llmConfig != null,
+            onMerge = { viewModel.confirmImport(ImportMode.MERGE) },
+            onReplace = { viewModel.confirmImport(ImportMode.REPLACE) },
+            onDismiss = { viewModel.dismiss() }
+        )
+    }
+}
+
 private fun writeToUri(context: Context, uri: Uri, data: ByteArray) {
     context.contentResolver.openOutputStream(uri)?.use { it.write(data) }
 }

--- a/app/src/main/kotlin/com/example/aapremote/ui/settings/BackupRestoreSection.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/settings/BackupRestoreSection.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -402,11 +403,18 @@ private fun ImportPreviewScreen(
             }
 
             preview.llmConfig?.let { config ->
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(16.dp))
+                HorizontalDivider(modifier = Modifier.padding(bottom = 16.dp))
                 Text(
-                    text = "LLM Configuration",
+                    text = "AI Assistant (global setting)",
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(bottom = 4.dp)
+                )
+                Text(
+                    text = "Shared across all instances — not tied to any specific AAP server.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(bottom = 8.dp)
                 )
                 Card(

--- a/app/src/main/kotlin/com/example/aapremote/ui/settings/BackupRestoreSection.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/settings/BackupRestoreSection.kt
@@ -225,6 +225,9 @@ private fun ExportPasswordDialog(
                     label = { Text("Password") },
                     visualTransformation = PasswordVisualTransformation(),
                     singleLine = true,
+                    supportingText = if (password.isNotEmpty() && password.length < 8) {
+                        { Text("At least 8 characters") }
+                    } else null,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag("field_export_password")
@@ -260,7 +263,7 @@ private fun ExportPasswordDialog(
                         onConfirm(password, includeLlm)
                     }
                 },
-                enabled = password.isNotEmpty()
+                enabled = password.length >= 8
             ) {
                 Text("Export")
             }

--- a/app/src/main/kotlin/com/example/aapremote/ui/settings/BackupRestoreSection.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/settings/BackupRestoreSection.kt
@@ -16,15 +16,24 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.FileUpload
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -181,11 +190,8 @@ fun BackupRestoreSection(
     }
 
     (uiState as? BackupUiState.ImportPreview)?.let { preview ->
-        ImportPreviewDialog(
-            totalInstances = preview.envelope.instances.size,
-            duplicateCount = preview.duplicateCount,
-            newCount = preview.newCount,
-            hasLlmConfig = preview.envelope.llmConfig != null,
+        ImportPreviewScreen(
+            preview = preview,
             onMerge = { viewModel.confirmImport(ImportMode.MERGE) },
             onReplace = { viewModel.confirmImport(ImportMode.REPLACE) },
             onDismiss = { viewModel.dismiss() }
@@ -306,54 +312,183 @@ private fun ImportPasswordDialog(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun ImportPreviewDialog(
-    totalInstances: Int,
-    duplicateCount: Int,
-    newCount: Int,
-    hasLlmConfig: Boolean,
+private fun ImportPreviewScreen(
+    preview: BackupUiState.ImportPreview,
     onMerge: () -> Unit,
     onReplace: () -> Unit,
     onDismiss: () -> Unit
 ) {
-    AlertDialog(
+    ModalBottomSheet(
         onDismissRequest = onDismiss,
-        title = { Text("Import Preview") },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text("Found $totalInstances instance(s) in backup.")
-                if (duplicateCount > 0) {
-                    Text(
-                        "$duplicateCount already on this device.",
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 32.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                text = "Restore Backup",
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Text(
+                text = "AAP Instances",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+
+            preview.instances.forEach { inst ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 8.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant
                     )
-                }
-                if (newCount > 0) {
-                    Text("$newCount new instance(s) to import.")
-                }
-                if (hasLlmConfig) {
-                    Text(
-                        "LLM configuration included.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.primary
-                    )
+                ) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        if (inst.alias != null) {
+                            Text(
+                                text = inst.alias,
+                                style = MaterialTheme.typography.titleSmall
+                            )
+                        }
+                        Text(
+                            text = inst.baseUrl,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Row(
+                            modifier = Modifier.padding(top = 4.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Text(
+                                text = inst.apiVersion,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            if (inst.mcpEnabled) {
+                                Text(
+                                    text = "MCP enabled",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                            if (inst.trustSelfSigned) {
+                                Text(
+                                    text = "Self-signed",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                        if (!inst.mcpServerUrls.isNullOrEmpty()) {
+                            Text(
+                                text = inst.mcpServerUrls.joinToString(", ") { it.label },
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(top = 2.dp)
+                            )
+                        }
+                    }
                 }
             }
-        },
-        confirmButton = {
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                if (newCount > 0 || duplicateCount > 0) {
-                    TextButton(onClick = onReplace) { Text("Replace All") }
-                }
-                TextButton(onClick = onMerge) {
-                    Text(if (newCount > 0) "Merge" else "Import")
+
+            preview.llmConfig?.let { config ->
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "LLM Configuration",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                    )
+                ) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        if (config is com.example.aapremote.assistant.data.LlmProviderConfig.OpenAiCompatible) {
+                            Text(
+                                text = config.model,
+                                style = MaterialTheme.typography.titleSmall
+                            )
+                            Text(
+                                text = config.url,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = if (config.apiKey != null) "API key: ••••${config.apiKey.takeLast(4)}" else "No API key",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(top = 2.dp)
+                            )
+                            Text(
+                                text = "Token mode: ${config.tokenSavingMode.displayName}",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(top = 2.dp)
+                            )
+                        }
+                    }
                 }
             }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
+
+            if (preview.hasExistingInstances && preview.duplicateCount > 0) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = "${preview.duplicateCount} instance(s) already on this device.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            if (preview.hasExistingInstances) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    OutlinedButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Cancel") }
+                    OutlinedButton(
+                        onClick = onReplace,
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Replace existing") }
+                    Button(
+                        onClick = onMerge,
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Add new") }
+                }
+            } else {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    OutlinedButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Cancel") }
+                    Button(
+                        onClick = onMerge,
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Restore") }
+                }
+            }
         }
-    )
+    }
 }
 
 @Composable
@@ -425,11 +560,8 @@ fun ImportFromBackupButton(
     }
 
     (uiState as? BackupUiState.ImportPreview)?.let { preview ->
-        ImportPreviewDialog(
-            totalInstances = preview.envelope.instances.size,
-            duplicateCount = preview.duplicateCount,
-            newCount = preview.newCount,
-            hasLlmConfig = preview.envelope.llmConfig != null,
+        ImportPreviewScreen(
+            preview = preview,
             onMerge = { viewModel.confirmImport(ImportMode.MERGE) },
             onReplace = { viewModel.confirmImport(ImportMode.REPLACE) },
             onDismiss = { viewModel.dismiss() }

--- a/app/src/main/kotlin/com/example/aapremote/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/settings/SettingsScreen.kt
@@ -151,6 +151,10 @@ fun SettingsScreen(
                 else -> {}
             }
 
+            Spacer(modifier = Modifier.height(24.dp))
+
+            BackupRestoreSection()
+
             Spacer(modifier = Modifier.weight(1f))
 
             AboutSection()

--- a/app/src/test/kotlin/com/example/aapremote/data/backup/BackupManagerTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/data/backup/BackupManagerTest.kt
@@ -1,0 +1,143 @@
+package com.example.aapremote.data.backup
+
+import com.example.aapremote.assistant.data.LlmProviderConfig
+import com.example.aapremote.assistant.data.TokenSavingMode
+import com.example.aapremote.model.AapInstance
+import com.example.aapremote.model.McpServerConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BackupManagerTest {
+
+    private val manager = BackupManager()
+
+    private val testInstances = listOf(
+        AapInstance(
+            id = "inst-1",
+            baseUrl = "https://aap.example.com",
+            token = "secret-token-123",
+            alias = "Production",
+            apiVersion = "CONTROLLER_V2",
+            trustSelfSigned = false,
+            mcpServerUrls = listOf(
+                McpServerConfig(url = "https://aap.example.com:8448/mcp", label = "aap")
+            ),
+            mcpEnabled = true
+        ),
+        AapInstance(
+            id = "inst-2",
+            baseUrl = "https://staging.example.com",
+            token = "staging-token-456",
+            alias = "Staging",
+            apiVersion = "CONTROLLER_V2",
+            trustSelfSigned = true
+        )
+    )
+
+    @Test
+    fun `round-trip export and import preserves all instance data`() {
+        val exported = manager.exportBackup("mypassword", testInstances)
+        val envelope = manager.importBackup(exported, "mypassword")
+
+        assertEquals(2, envelope.instances.size)
+
+        val prod = envelope.instances.find { it.id == "inst-1" }!!
+        assertEquals("https://aap.example.com", prod.baseUrl)
+        assertEquals("secret-token-123", prod.token)
+        assertEquals("Production", prod.alias)
+        assertEquals(true, prod.mcpEnabled)
+        assertEquals(1, prod.mcpServerUrls?.size)
+
+        val staging = envelope.instances.find { it.id == "inst-2" }!!
+        assertEquals("https://staging.example.com", staging.baseUrl)
+        assertEquals("staging-token-456", staging.token)
+        assertEquals(true, staging.trustSelfSigned)
+    }
+
+    @Test
+    fun `round-trip preserves LLM config when included`() {
+        val llmConfig = LlmProviderConfig.OpenAiCompatible(
+            url = "https://openrouter.ai/api/v1",
+            model = "anthropic/claude-sonnet-4-6",
+            apiKey = "sk-or-key-123",
+            tokenSavingMode = TokenSavingMode.TOKEN_SAVER
+        )
+        val exported = manager.exportBackup("pass", testInstances, llmConfig)
+        val envelope = manager.importBackup(exported, "pass")
+
+        assertNotNull(envelope.llmConfig)
+        val config = envelope.llmConfig as LlmProviderConfig.OpenAiCompatible
+        assertEquals("https://openrouter.ai/api/v1", config.url)
+        assertEquals("anthropic/claude-sonnet-4-6", config.model)
+        assertEquals("sk-or-key-123", config.apiKey)
+        assertEquals(TokenSavingMode.TOKEN_SAVER, config.tokenSavingMode)
+    }
+
+    @Test
+    fun `export without LLM config leaves it null`() {
+        val exported = manager.exportBackup("pass", testInstances)
+        val envelope = manager.importBackup(exported, "pass")
+        assertNull(envelope.llmConfig)
+    }
+
+    @Test(expected = BackupDecryptionException::class)
+    fun `wrong password throws BackupDecryptionException`() {
+        val exported = manager.exportBackup("correct", testInstances)
+        manager.importBackup(exported, "wrong")
+    }
+
+    @Test(expected = BackupDecryptionException::class)
+    fun `corrupted data throws BackupDecryptionException`() {
+        manager.importBackup(ByteArray(100) { 0x42 }, "password")
+    }
+
+    @Test(expected = BackupDecryptionException::class)
+    fun `truncated data throws BackupDecryptionException`() {
+        manager.importBackup(ByteArray(10), "password")
+    }
+
+    @Test
+    fun `exported data is not readable as plaintext`() {
+        val exported = manager.exportBackup("pass", testInstances)
+        val asString = String(exported, Charsets.UTF_8)
+        assertTrue(!asString.contains("secret-token-123"))
+        assertTrue(!asString.contains("aap.example.com"))
+    }
+
+    @Test
+    fun `different passwords produce different ciphertexts`() {
+        val export1 = manager.exportBackup("password1", testInstances)
+        val export2 = manager.exportBackup("password2", testInstances)
+        assertTrue(!export1.contentEquals(export2))
+    }
+
+    @Test
+    fun `same password produces different ciphertexts due to random salt`() {
+        val export1 = manager.exportBackup("same", testInstances)
+        val export2 = manager.exportBackup("same", testInstances)
+        assertTrue(!export1.contentEquals(export2))
+        // But both decrypt to the same data
+        val env1 = manager.importBackup(export1, "same")
+        val env2 = manager.importBackup(export2, "same")
+        assertEquals(env1.instances.size, env2.instances.size)
+    }
+
+    @Test
+    fun `envelope version is set to 1`() {
+        val exported = manager.exportBackup("pass", testInstances)
+        val envelope = manager.importBackup(exported, "pass")
+        assertEquals(1, envelope.version)
+    }
+
+    @Test
+    fun `envelope has valid timestamp`() {
+        val before = System.currentTimeMillis()
+        val exported = manager.exportBackup("pass", testInstances)
+        val after = System.currentTimeMillis()
+        val envelope = manager.importBackup(exported, "pass")
+        assertTrue(envelope.createdAt in before..after)
+    }
+}


### PR DESCRIPTION
## Summary

Password-protected credential backup and restore using PBKDF2 (600K iterations) + AES-256-GCM encryption.

- Export all instances (URLs, tokens, MCP config) + optional LLM config to encrypted `.aapdroid` file
- Import from backup on login screen (clean install) or Settings (existing install)
- Full restore preview as bottom sheet showing each instance URL, MCP status, and LLM config details
- Merge vs replace conflict handling when importing to a device with existing instances
- Minimum 8-character password enforced on export
- Password cleared from memory immediately after decryption (try-finally on PBEKeySpec)

## Depends on

- #77 (hallucination fix + TOOLS_ONLY rename) — must be merged first

## New files

- `data/backup/BackupManager.kt` — encryption/decryption, no Android deps
- `data/backup/BackupModels.kt` — serializable envelope + exception
- `presentation/settings/BackupViewModel.kt` — export/import flow orchestration
- `ui/settings/BackupRestoreSection.kt` — Compose UI with dialogs and bottom sheet

## Test plan

- [x] `./gradlew testDebugUnitTest` — all tests pass (10 new BackupManager tests)
- [x] Export with password → file not readable as plaintext
- [x] Import with correct password → instances restored
- [x] Import with wrong password → "Incorrect password" error
- [x] Import from login screen on clean install
- [x] LLM config included/excluded based on checkbox
- [x] Restore preview shows instance URLs, MCP status, LLM details
- [x] Minimum 8-char password enforced

Closes #59

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>