### PR TITLE
Extract executeSafely() from 26 local tools

### DIFF
--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/LocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/LocalTool.kt
@@ -5,4 +5,9 @@ enum class ToolSource { LOCAL, MCP }
 abstract class LocalTool(
     override val spec: ToolSpec,
     val destructive: Boolean = false
-) : Tool
+) : Tool {
+    protected suspend fun executeSafely(block: suspend () -> ToolResult): ToolResult =
+        try { block() } catch (e: Exception) {
+            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
+        }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetCredentialLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetCredentialLocalTool.kt
@@ -20,14 +20,10 @@ class GetCredentialLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val credentialId = (args["credential_id"] as? Number)?.toInt()
-                ?: return ToolResult(success = false, data = "credential_id is required", errorType = ErrorType.NOT_FOUND)
-            val credential = repository.getCredential(credentialId).getOrThrow()
-            ToolResult(success = true, data = networkJson.encodeToString(credential))
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val credentialId = (args["credential_id"] as? Number)?.toInt()
+            ?: return@executeSafely ToolResult(success = false, data = "credential_id is required", errorType = ErrorType.NOT_FOUND)
+        val credential = repository.getCredential(credentialId).getOrThrow()
+        ToolResult(success = true, data = networkJson.encodeToString(credential))
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetEdaActivationLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetEdaActivationLocalTool.kt
@@ -20,14 +20,10 @@ class GetEdaActivationLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val activationId = (args["activation_id"] as? Number)?.toInt()
-                ?: return ToolResult(success = false, data = "activation_id is required", errorType = ErrorType.NOT_FOUND)
-            val activation = repository.getActivation(activationId).getOrThrow()
-            ToolResult(success = true, data = networkJson.encodeToString(activation))
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val activationId = (args["activation_id"] as? Number)?.toInt()
+            ?: return@executeSafely ToolResult(success = false, data = "activation_id is required", errorType = ErrorType.NOT_FOUND)
+        val activation = repository.getActivation(activationId).getOrThrow()
+        ToolResult(success = true, data = networkJson.encodeToString(activation))
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetHostFactsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetHostFactsLocalTool.kt
@@ -20,14 +20,10 @@ class GetHostFactsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val hostId = (args["host_id"] as? Number)?.toInt()
-                ?: return ToolResult(success = false, data = "host_id is required", errorType = ErrorType.NOT_FOUND)
-            val facts = repository.getHostFacts(hostId).getOrThrow()
-            ToolResult(success = true, data = networkJson.encodeToString(facts))
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val hostId = (args["host_id"] as? Number)?.toInt()
+            ?: return@executeSafely ToolResult(success = false, data = "host_id is required", errorType = ErrorType.NOT_FOUND)
+        val facts = repository.getHostFacts(hostId).getOrThrow()
+        ToolResult(success = true, data = networkJson.encodeToString(facts))
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetInstanceLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetInstanceLocalTool.kt
@@ -20,14 +20,10 @@ class GetInstanceLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val instanceId = (args["instance_id"] as? Number)?.toInt()
-                ?: return ToolResult(success = false, data = "instance_id is required", errorType = ErrorType.NOT_FOUND)
-            val instance = repository.getInstance(instanceId).getOrThrow()
-            ToolResult(success = true, data = networkJson.encodeToString(instance))
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val instanceId = (args["instance_id"] as? Number)?.toInt()
+            ?: return@executeSafely ToolResult(success = false, data = "instance_id is required", errorType = ErrorType.NOT_FOUND)
+        val instance = repository.getInstance(instanceId).getOrThrow()
+        ToolResult(success = true, data = networkJson.encodeToString(instance))
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetJobLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetJobLocalTool.kt
@@ -20,14 +20,10 @@ class GetJobLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val jobId = (args["job_id"] as? Number)?.toInt()
-                ?: return ToolResult(success = false, data = "job_id is required", errorType = ErrorType.NOT_FOUND)
-            val job = repository.getJobStatus(jobId).getOrThrow()
-            ToolResult(success = true, data = networkJson.encodeToString(job))
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val jobId = (args["job_id"] as? Number)?.toInt()
+            ?: return@executeSafely ToolResult(success = false, data = "job_id is required", errorType = ErrorType.NOT_FOUND)
+        val job = repository.getJobStatus(jobId).getOrThrow()
+        ToolResult(success = true, data = networkJson.encodeToString(job))
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetJobStdoutLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetJobStdoutLocalTool.kt
@@ -18,14 +18,10 @@ class GetJobStdoutLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val jobId = (args["job_id"] as? Number)?.toInt()
-                ?: return ToolResult(success = false, data = "job_id is required", errorType = ErrorType.NOT_FOUND)
-            val stdout = repository.getJobStdout(jobId).getOrThrow()
-            ToolResult(success = true, data = stdout)
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val jobId = (args["job_id"] as? Number)?.toInt()
+            ?: return@executeSafely ToolResult(success = false, data = "job_id is required", errorType = ErrorType.NOT_FOUND)
+        val stdout = repository.getJobStdout(jobId).getOrThrow()
+        ToolResult(success = true, data = stdout)
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetMeshTopologyLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetMeshTopologyLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -15,12 +14,8 @@ class GetMeshTopologyLocalTool(
         parametersSchema = buildToolSchema()
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val topology = repository.getMeshTopology().getOrThrow()
-            ToolResult(success = true, data = topology.toString())
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val topology = repository.getMeshTopology().getOrThrow()
+        ToolResult(success = true, data = topology.toString())
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetProjectLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetProjectLocalTool.kt
@@ -20,14 +20,10 @@ class GetProjectLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val projectId = (args["project_id"] as? Number)?.toInt()
-                ?: return ToolResult(success = false, data = "project_id is required", errorType = ErrorType.NOT_FOUND)
-            val project = repository.getProject(projectId).getOrThrow()
-            ToolResult(success = true, data = networkJson.encodeToString(project))
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val projectId = (args["project_id"] as? Number)?.toInt()
+            ?: return@executeSafely ToolResult(success = false, data = "project_id is required", errorType = ErrorType.NOT_FOUND)
+        val project = repository.getProject(projectId).getOrThrow()
+        ToolResult(success = true, data = networkJson.encodeToString(project))
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetWorkflowJobLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetWorkflowJobLocalTool.kt
@@ -20,21 +20,17 @@ class GetWorkflowJobLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val jobId = (args["workflow_job_id"] as? Number)?.toInt()
-                ?: return ToolResult(success = false, data = "workflow_job_id is required", errorType = ErrorType.NOT_FOUND)
-            val job = repository.getWorkflowJobStatus(jobId).getOrThrow()
-            val nodes = repository.getWorkflowNodes(jobId).getOrElse { emptyList() }
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "workflow_job" to networkJson.encodeToString(job),
-                    "nodes" to networkJson.encodeToString(nodes)
-                ))
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val jobId = (args["workflow_job_id"] as? Number)?.toInt()
+            ?: return@executeSafely ToolResult(success = false, data = "workflow_job_id is required", errorType = ErrorType.NOT_FOUND)
+        val job = repository.getWorkflowJobStatus(jobId).getOrThrow()
+        val nodes = repository.getWorkflowNodes(jobId).getOrElse { emptyList() }
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "workflow_job" to networkJson.encodeToString(job),
+                "nodes" to networkJson.encodeToString(nodes)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/LaunchJobLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/LaunchJobLocalTool.kt
@@ -20,15 +20,11 @@ class LaunchJobLocalTool(
     ),
     destructive = true
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val templateId = (args["template_id"] as? Number)?.toInt()
-                ?: return ToolResult(success = false, data = "template_id is required", errorType = ErrorType.NOT_FOUND)
-            val extraVars = args["extra_vars"] as? String
-            val jobId = repository.launchJob(templateId, extraVars).getOrThrow()
-            ToolResult(success = true, data = """{"job_id": $jobId, "status": "launched"}""")
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val templateId = (args["template_id"] as? Number)?.toInt()
+            ?: return@executeSafely ToolResult(success = false, data = "template_id is required", errorType = ErrorType.NOT_FOUND)
+        val extraVars = args["extra_vars"] as? String
+        val jobId = repository.launchJob(templateId, extraVars).getOrThrow()
+        ToolResult(success = true, data = """{"job_id": $jobId, "status": "launched"}""")
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/LaunchWorkflowLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/LaunchWorkflowLocalTool.kt
@@ -20,15 +20,11 @@ class LaunchWorkflowLocalTool(
     ),
     destructive = true
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val templateId = (args["template_id"] as? Number)?.toInt()
-                ?: return ToolResult(success = false, data = "template_id is required", errorType = ErrorType.NOT_FOUND)
-            val extraVars = args["extra_vars"] as? String
-            val jobId = repository.launchWorkflow(templateId, extraVars).getOrThrow()
-            ToolResult(success = true, data = """{"workflow_job_id": $jobId, "status": "launched"}""")
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val templateId = (args["template_id"] as? Number)?.toInt()
+            ?: return@executeSafely ToolResult(success = false, data = "template_id is required", errorType = ErrorType.NOT_FOUND)
+        val extraVars = args["extra_vars"] as? String
+        val jobId = repository.launchWorkflow(templateId, extraVars).getOrThrow()
+        ToolResult(success = true, data = """{"workflow_job_id": $jobId, "status": "launched"}""")
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListCredentialsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListCredentialsLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -21,23 +20,19 @@ class ListCredentialsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
-            val result = repository.getCredentials(
-                page = (args["page"] as? Number)?.toInt() ?: 1,
-                pageSize = pageSize,
-                search = args["search"] as? String
-            ).getOrThrow()
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "count" to result.totalCount.toString(),
-                    "credentials" to networkJson.encodeToString(result.credentials)
-                ))
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+        val result = repository.getCredentials(
+            page = (args["page"] as? Number)?.toInt() ?: 1,
+            pageSize = pageSize,
+            search = args["search"] as? String
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "credentials" to networkJson.encodeToString(result.credentials)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaActivationsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaActivationsLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -20,22 +19,18 @@ class ListEdaActivationsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 20) ?: 20
-            val result = repository.getActivations(
-                page = (args["page"] as? Number)?.toInt() ?: 1,
-                pageSize = pageSize
-            ).getOrThrow()
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "count" to result.totalCount.toString(),
-                    "activations" to networkJson.encodeToString(result.activations)
-                ))
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 20) ?: 20
+        val result = repository.getActivations(
+            page = (args["page"] as? Number)?.toInt() ?: 1,
+            pageSize = pageSize
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "activations" to networkJson.encodeToString(result.activations)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaAuditRulesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaAuditRulesLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -20,22 +19,18 @@ class ListEdaAuditRulesLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 20) ?: 10
-            val result = repository.getAuditRules(
-                page = (args["page"] as? Number)?.toInt() ?: 1,
-                pageSize = pageSize
-            ).getOrThrow()
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "count" to result.totalCount.toString(),
-                    "audit_rules" to networkJson.encodeToString(result.auditRules)
-                ))
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 20) ?: 10
+        val result = repository.getAuditRules(
+            page = (args["page"] as? Number)?.toInt() ?: 1,
+            pageSize = pageSize
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "audit_rules" to networkJson.encodeToString(result.auditRules)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListExecutionEnvironmentsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListExecutionEnvironmentsLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -20,22 +19,18 @@ class ListExecutionEnvironmentsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
-            val result = repository.getExecutionEnvironments(
-                page = (args["page"] as? Number)?.toInt() ?: 1,
-                pageSize = pageSize
-            ).getOrThrow()
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "count" to result.totalCount.toString(),
-                    "execution_environments" to networkJson.encodeToString(result.executionEnvironments)
-                ))
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+        val result = repository.getExecutionEnvironments(
+            page = (args["page"] as? Number)?.toInt() ?: 1,
+            pageSize = pageSize
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "execution_environments" to networkJson.encodeToString(result.executionEnvironments)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListHostsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListHostsLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -21,34 +20,30 @@ class ListHostsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val inventoryId = (args["inventory_id"] as? Number)?.toInt()
-            val page = (args["page"] as? Number)?.toInt() ?: 1
-            val search = args["search"] as? String
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val inventoryId = (args["inventory_id"] as? Number)?.toInt()
+        val page = (args["page"] as? Number)?.toInt() ?: 1
+        val search = args["search"] as? String
 
-            val result = if (inventoryId != null) {
-                repository.getInventoryHosts(
-                    inventoryId = inventoryId,
-                    page = page,
-                    search = search
-                )
-            } else {
-                repository.getAllHosts(
-                    page = page,
-                    search = search
-                )
-            }.getOrThrow()
-
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "count" to result.totalCount.toString(),
-                    "hosts" to networkJson.encodeToString(result.hosts)
-                ))
+        val result = if (inventoryId != null) {
+            repository.getInventoryHosts(
+                inventoryId = inventoryId,
+                page = page,
+                search = search
             )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+        } else {
+            repository.getAllHosts(
+                page = page,
+                search = search
+            )
+        }.getOrThrow()
+
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "hosts" to networkJson.encodeToString(result.hosts)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstanceGroupsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstanceGroupsLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -20,22 +19,18 @@ class ListInstanceGroupsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
-            val result = repository.getInstanceGroups(
-                page = (args["page"] as? Number)?.toInt() ?: 1,
-                pageSize = pageSize
-            ).getOrThrow()
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "count" to result.totalCount.toString(),
-                    "instance_groups" to networkJson.encodeToString(result.instanceGroups)
-                ))
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+        val result = repository.getInstanceGroups(
+            page = (args["page"] as? Number)?.toInt() ?: 1,
+            pageSize = pageSize
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "instance_groups" to networkJson.encodeToString(result.instanceGroups)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstancesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstancesLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -20,22 +19,18 @@ class ListInstancesLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
-            val result = repository.getInstances(
-                page = (args["page"] as? Number)?.toInt() ?: 1,
-                pageSize = pageSize
-            ).getOrThrow()
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "count" to result.totalCount.toString(),
-                    "instances" to networkJson.encodeToString(result.instances)
-                ))
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+        val result = repository.getInstances(
+            page = (args["page"] as? Number)?.toInt() ?: 1,
+            pageSize = pageSize
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "instances" to networkJson.encodeToString(result.instances)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInventoriesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInventoriesLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -20,21 +19,17 @@ class ListInventoriesLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val result = repository.getInventories(
-                page = (args["page"] as? Number)?.toInt() ?: 1,
-                search = args["search"] as? String
-            ).getOrThrow()
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "count" to result.totalCount.toString(),
-                    "inventories" to networkJson.encodeToString(result.inventories)
-                ))
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val result = repository.getInventories(
+            page = (args["page"] as? Number)?.toInt() ?: 1,
+            search = args["search"] as? String
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "inventories" to networkJson.encodeToString(result.inventories)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListJobTemplatesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListJobTemplatesLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -21,22 +20,18 @@ class ListJobTemplatesLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val result = repository.getTemplates(
-                page = (args["page"] as? Number)?.toInt() ?: 1,
-                search = args["search"] as? String,
-                labelFilter = args["labels"] as? String
-            ).getOrThrow()
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "count" to result.totalCount.toString(),
-                    "templates" to networkJson.encodeToString(result.templates)
-                ))
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val result = repository.getTemplates(
+            page = (args["page"] as? Number)?.toInt() ?: 1,
+            search = args["search"] as? String,
+            labelFilter = args["labels"] as? String
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "templates" to networkJson.encodeToString(result.templates)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListJobsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListJobsLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -22,26 +21,22 @@ class ListJobsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val statusFilter = (args["status"] as? String)?.let { statusStr ->
-                JobStatus.entries.filter { it.apiValue == statusStr }.toSet()
-            } ?: emptySet()
-            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 20) ?: 10
-            val result = repository.getRecentJobs(
-                page = (args["page"] as? Number)?.toInt() ?: 1,
-                pageSize = pageSize,
-                statusFilters = statusFilter
-            ).getOrThrow()
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "count" to result.totalCount.toString(),
-                    "jobs" to networkJson.encodeToString(result.jobs)
-                ))
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val statusFilter = (args["status"] as? String)?.let { statusStr ->
+            JobStatus.entries.filter { it.apiValue == statusStr }.toSet()
+        } ?: emptySet()
+        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 20) ?: 10
+        val result = repository.getRecentJobs(
+            page = (args["page"] as? Number)?.toInt() ?: 1,
+            pageSize = pageSize,
+            statusFilters = statusFilter
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "jobs" to networkJson.encodeToString(result.jobs)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListProjectsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListProjectsLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -21,23 +20,19 @@ class ListProjectsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
-            val result = repository.getProjects(
-                page = (args["page"] as? Number)?.toInt() ?: 1,
-                pageSize = pageSize,
-                search = args["search"] as? String
-            ).getOrThrow()
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "count" to result.totalCount.toString(),
-                    "projects" to networkJson.encodeToString(result.projects)
-                ))
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+        val result = repository.getProjects(
+            page = (args["page"] as? Number)?.toInt() ?: 1,
+            pageSize = pageSize,
+            search = args["search"] as? String
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "projects" to networkJson.encodeToString(result.projects)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListSchedulesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListSchedulesLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -19,20 +18,16 @@ class ListSchedulesLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val result = repository.getSchedules(
-                page = (args["page"] as? Number)?.toInt() ?: 1
-            ).getOrThrow()
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "count" to result.totalCount.toString(),
-                    "schedules" to networkJson.encodeToString(result.schedules)
-                ))
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val result = repository.getSchedules(
+            page = (args["page"] as? Number)?.toInt() ?: 1
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "schedules" to networkJson.encodeToString(result.schedules)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListWorkflowTemplatesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListWorkflowTemplatesLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -21,22 +20,18 @@ class ListWorkflowTemplatesLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val result = repository.getWorkflowTemplates(
-                page = (args["page"] as? Number)?.toInt() ?: 1,
-                search = args["search"] as? String,
-                labelFilter = args["labels"] as? String
-            ).getOrThrow()
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(mapOf(
-                    "count" to result.totalCount.toString(),
-                    "templates" to networkJson.encodeToString(result.templates)
-                ))
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val result = repository.getWorkflowTemplates(
+            page = (args["page"] as? Number)?.toInt() ?: 1,
+            search = args["search"] as? String,
+            labelFilter = args["labels"] as? String
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "templates" to networkJson.encodeToString(result.templates)
+            ))
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/PingLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/PingLocalTool.kt
@@ -1,6 +1,5 @@
 package com.example.aapremote.assistant.tools.local
 
-import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
@@ -17,12 +16,8 @@ class PingLocalTool(
         parametersSchema = buildToolSchema()
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val ping = repository.ping().getOrThrow()
-            ToolResult(success = true, data = networkJson.encodeToString(ping))
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val ping = repository.ping().getOrThrow()
+        ToolResult(success = true, data = networkJson.encodeToString(ping))
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ToggleScheduleLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ToggleScheduleLocalTool.kt
@@ -22,19 +22,15 @@ class ToggleScheduleLocalTool(
     ),
     destructive = true
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
-        return try {
-            val scheduleId = (args["schedule_id"] as? Number)?.toInt()
-                ?: return ToolResult(success = false, data = "schedule_id is required", errorType = ErrorType.NOT_FOUND)
-            val enabled = args["enabled"] as? Boolean
-                ?: return ToolResult(success = false, data = "enabled is required", errorType = ErrorType.NOT_FOUND)
-            val schedule = repository.toggleSchedule(scheduleId, enabled).getOrThrow()
-            ToolResult(
-                success = true,
-                data = networkJson.encodeToString(schedule)
-            )
-        } catch (e: Exception) {
-            ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
-        }
+    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+        val scheduleId = (args["schedule_id"] as? Number)?.toInt()
+            ?: return@executeSafely ToolResult(success = false, data = "schedule_id is required", errorType = ErrorType.NOT_FOUND)
+        val enabled = args["enabled"] as? Boolean
+            ?: return@executeSafely ToolResult(success = false, data = "enabled is required", errorType = ErrorType.NOT_FOUND)
+        val schedule = repository.toggleSchedule(scheduleId, enabled).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(schedule)
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Add `executeSafely()` helper to `LocalTool` base class
- Replace identical try/catch blocks across all 26 local tools
- Net -114 lines (263 added, 377 removed)
- Tools with validation use `return@executeSafely` for early exits

## Test plan
- [x] `./gradlew compileDebugKotlin` passes
- [x] `./gradlew testDebugUnitTest` passes
- [ ] Pure refactor — no behavior change, no emulator test needed

Closes #70

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>