### PR TITLE
Eliminate JSON→Map→JSON round-trip in tool execution

### DIFF
--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolExecutor.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolExecutor.kt
@@ -8,9 +8,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.intOrNull
@@ -38,15 +36,15 @@ class ToolExecutor(
         }
 
         val argsJson = try {
-            json.parseToJsonElement(toolCall.content)
+            val parsed = json.parseToJsonElement(toolCall.content)
+            if (parsed is JsonObject) parsed else JsonObject(emptyMap())
         } catch (_: Exception) {
             JsonObject(emptyMap())
         }
-        val argsMap = if (argsJson is JsonObject) jsonObjectToMap(argsJson) else emptyMap()
 
         val result = try {
             withTimeout(30_000L) {
-                tool.execute(argsMap)
+                tool.execute(argsJson)
             }
         } catch (_: TimeoutCancellationException) {
             return ToolResult(
@@ -69,28 +67,6 @@ class ToolExecutor(
             resultCache[cacheKey] = System.currentTimeMillis() to finalResult
         }
         return finalResult
-    }
-
-    private fun jsonObjectToMap(json: JsonObject): Map<String, Any> {
-        return json.entries.associate { (key, value) ->
-            key to jsonElementToAny(value)
-        }
-    }
-
-    private fun jsonElementToAny(element: JsonElement): Any {
-        return when (element) {
-            is JsonPrimitive -> {
-                when {
-                    element.isString -> element.content
-                    element.content == "true" -> true
-                    element.content == "false" -> false
-                    element.content.contains('.') -> element.content.toDoubleOrNull() ?: element.content
-                    else -> element.content.toLongOrNull() ?: element.content
-                }
-            }
-            is JsonArray -> element.map { jsonElementToAny(it) }
-            is JsonObject -> jsonObjectToMap(element)
-        }
     }
 
     companion object {

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/LocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/LocalTool.kt
@@ -1,5 +1,13 @@
 package com.example.aapremote.assistant.tools
 
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
 enum class ToolSource { LOCAL, MCP }
 
 abstract class LocalTool(
@@ -10,4 +18,13 @@ abstract class LocalTool(
         try { block() } catch (e: Exception) {
             ToolResult(success = false, data = "Error: ${e.message}", errorType = ErrorType.SERVER_ERROR)
         }
+
+    protected fun JsonObject.intArg(name: String): Int? =
+        this[name]?.jsonPrimitive?.intOrNull
+
+    protected fun JsonObject.stringArg(name: String): String? =
+        this[name]?.jsonPrimitive?.contentOrNull
+
+    protected fun JsonObject.booleanArg(name: String): Boolean? =
+        this[name]?.jsonPrimitive?.booleanOrNull
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/McpTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/McpTool.kt
@@ -2,11 +2,8 @@ package com.example.aapremote.assistant.tools
 
 import com.example.aapremote.network.mcp.McpClient
 import com.example.aapremote.network.mcp.McpToolDefinition
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
@@ -30,10 +27,9 @@ class McpTool(
         parametersSchema = mcpToolDef.inputSchema
     )
 
-    override suspend fun execute(args: Map<String, Any>): ToolResult {
+    override suspend fun execute(args: JsonObject): ToolResult {
         return try {
-            val jsonArgs = argsToJsonObject(args)
-            val cappedArgs = capPageSize(jsonArgs)
+            val cappedArgs = capPageSize(args)
             val mcpResult = client.callTool(mcpToolDef.name, cappedArgs)
 
             val text = mcpResult.content
@@ -66,12 +62,6 @@ class McpTool(
         }
     }
 
-    private fun argsToJsonObject(args: Map<String, Any>): JsonObject = buildJsonObject {
-        args.forEach { (key, value) ->
-            put(key, toJsonElement(value))
-        }
-    }
-
     private fun capPageSize(args: JsonObject, max: Int = MAX_PAGE_SIZE): JsonObject {
         val current = args["page_size"]?.jsonPrimitive?.intOrNull
         if (current != null && current <= max) return args
@@ -81,17 +71,4 @@ class McpTool(
         }
     }
 
-    private fun toJsonElement(value: Any?): JsonElement = when (value) {
-        null -> JsonNull
-        is String -> JsonPrimitive(value)
-        is Number -> JsonPrimitive(value)
-        is Boolean -> JsonPrimitive(value)
-        is Map<*, *> -> buildJsonObject {
-            value.forEach { (k, v) -> put(k.toString(), toJsonElement(v)) }
-        }
-        is List<*> -> buildJsonArray {
-            value.forEach { add(toJsonElement(it)) }
-        }
-        else -> JsonPrimitive(value.toString())
-    }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/ToolSpec.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/ToolSpec.kt
@@ -10,7 +10,7 @@ data class ToolSpec(
 
 interface Tool {
     val spec: ToolSpec
-    suspend fun execute(args: Map<String, Any>): ToolResult
+    suspend fun execute(args: JsonObject): ToolResult
 }
 
 data class ToolResult(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetCredentialLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetCredentialLocalTool.kt
@@ -7,6 +7,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.CredentialRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class GetCredentialLocalTool(
     private val repository: CredentialRepository
@@ -20,8 +21,8 @@ class GetCredentialLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val credentialId = (args["credential_id"] as? Number)?.toInt()
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val credentialId = args.intArg("credential_id")
             ?: return@executeSafely ToolResult(success = false, data = "credential_id is required", errorType = ErrorType.NOT_FOUND)
         val credential = repository.getCredential(credentialId).getOrThrow()
         ToolResult(success = true, data = networkJson.encodeToString(credential))

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetEdaActivationLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetEdaActivationLocalTool.kt
@@ -7,6 +7,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.EdaActivationRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class GetEdaActivationLocalTool(
     private val repository: EdaActivationRepository
@@ -20,8 +21,8 @@ class GetEdaActivationLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val activationId = (args["activation_id"] as? Number)?.toInt()
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val activationId = args.intArg("activation_id")
             ?: return@executeSafely ToolResult(success = false, data = "activation_id is required", errorType = ErrorType.NOT_FOUND)
         val activation = repository.getActivation(activationId).getOrThrow()
         ToolResult(success = true, data = networkJson.encodeToString(activation))

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetHostFactsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetHostFactsLocalTool.kt
@@ -7,6 +7,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.HostRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class GetHostFactsLocalTool(
     private val repository: HostRepository
@@ -20,8 +21,8 @@ class GetHostFactsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val hostId = (args["host_id"] as? Number)?.toInt()
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val hostId = args.intArg("host_id")
             ?: return@executeSafely ToolResult(success = false, data = "host_id is required", errorType = ErrorType.NOT_FOUND)
         val facts = repository.getHostFacts(hostId).getOrThrow()
         ToolResult(success = true, data = networkJson.encodeToString(facts))

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetInstanceLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetInstanceLocalTool.kt
@@ -7,6 +7,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.InfrastructureRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class GetInstanceLocalTool(
     private val repository: InfrastructureRepository
@@ -20,8 +21,8 @@ class GetInstanceLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val instanceId = (args["instance_id"] as? Number)?.toInt()
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val instanceId = args.intArg("instance_id")
             ?: return@executeSafely ToolResult(success = false, data = "instance_id is required", errorType = ErrorType.NOT_FOUND)
         val instance = repository.getInstance(instanceId).getOrThrow()
         ToolResult(success = true, data = networkJson.encodeToString(instance))

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetJobLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetJobLocalTool.kt
@@ -7,6 +7,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.JobRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class GetJobLocalTool(
     private val repository: JobRepository
@@ -20,8 +21,8 @@ class GetJobLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val jobId = (args["job_id"] as? Number)?.toInt()
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val jobId = args.intArg("job_id")
             ?: return@executeSafely ToolResult(success = false, data = "job_id is required", errorType = ErrorType.NOT_FOUND)
         val job = repository.getJobStatus(jobId).getOrThrow()
         ToolResult(success = true, data = networkJson.encodeToString(job))

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetJobStdoutLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetJobStdoutLocalTool.kt
@@ -5,6 +5,7 @@ import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.JobRepository
+import kotlinx.serialization.json.JsonObject
 
 class GetJobStdoutLocalTool(
     private val repository: JobRepository
@@ -18,8 +19,8 @@ class GetJobStdoutLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val jobId = (args["job_id"] as? Number)?.toInt()
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val jobId = args.intArg("job_id")
             ?: return@executeSafely ToolResult(success = false, data = "job_id is required", errorType = ErrorType.NOT_FOUND)
         val stdout = repository.getJobStdout(jobId).getOrThrow()
         ToolResult(success = true, data = stdout)

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetMeshTopologyLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetMeshTopologyLocalTool.kt
@@ -4,6 +4,7 @@ import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.InfrastructureRepository
+import kotlinx.serialization.json.JsonObject
 
 class GetMeshTopologyLocalTool(
     private val repository: InfrastructureRepository
@@ -14,7 +15,7 @@ class GetMeshTopologyLocalTool(
         parametersSchema = buildToolSchema()
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val topology = repository.getMeshTopology().getOrThrow()
         ToolResult(success = true, data = topology.toString())
     }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetProjectLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetProjectLocalTool.kt
@@ -7,6 +7,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.ProjectRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class GetProjectLocalTool(
     private val repository: ProjectRepository
@@ -20,8 +21,8 @@ class GetProjectLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val projectId = (args["project_id"] as? Number)?.toInt()
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val projectId = args.intArg("project_id")
             ?: return@executeSafely ToolResult(success = false, data = "project_id is required", errorType = ErrorType.NOT_FOUND)
         val project = repository.getProject(projectId).getOrThrow()
         ToolResult(success = true, data = networkJson.encodeToString(project))

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetWorkflowJobLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/GetWorkflowJobLocalTool.kt
@@ -7,6 +7,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.WorkflowRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class GetWorkflowJobLocalTool(
     private val repository: WorkflowRepository
@@ -20,8 +21,8 @@ class GetWorkflowJobLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val jobId = (args["workflow_job_id"] as? Number)?.toInt()
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val jobId = args.intArg("workflow_job_id")
             ?: return@executeSafely ToolResult(success = false, data = "workflow_job_id is required", errorType = ErrorType.NOT_FOUND)
         val job = repository.getWorkflowJobStatus(jobId).getOrThrow()
         val nodes = repository.getWorkflowNodes(jobId).getOrElse { emptyList() }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/LaunchJobLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/LaunchJobLocalTool.kt
@@ -5,6 +5,7 @@ import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.TemplateRepository
+import kotlinx.serialization.json.JsonObject
 
 class LaunchJobLocalTool(
     private val repository: TemplateRepository
@@ -20,10 +21,10 @@ class LaunchJobLocalTool(
     ),
     destructive = true
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val templateId = (args["template_id"] as? Number)?.toInt()
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val templateId = args.intArg("template_id")
             ?: return@executeSafely ToolResult(success = false, data = "template_id is required", errorType = ErrorType.NOT_FOUND)
-        val extraVars = args["extra_vars"] as? String
+        val extraVars = args.stringArg("extra_vars")
         val jobId = repository.launchJob(templateId, extraVars).getOrThrow()
         ToolResult(success = true, data = """{"job_id": $jobId, "status": "launched"}""")
     }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/LaunchWorkflowLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/LaunchWorkflowLocalTool.kt
@@ -5,6 +5,7 @@ import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.WorkflowRepository
+import kotlinx.serialization.json.JsonObject
 
 class LaunchWorkflowLocalTool(
     private val repository: WorkflowRepository
@@ -20,10 +21,10 @@ class LaunchWorkflowLocalTool(
     ),
     destructive = true
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val templateId = (args["template_id"] as? Number)?.toInt()
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val templateId = args.intArg("template_id")
             ?: return@executeSafely ToolResult(success = false, data = "template_id is required", errorType = ErrorType.NOT_FOUND)
-        val extraVars = args["extra_vars"] as? String
+        val extraVars = args.stringArg("extra_vars")
         val jobId = repository.launchWorkflow(templateId, extraVars).getOrThrow()
         ToolResult(success = true, data = """{"workflow_job_id": $jobId, "status": "launched"}""")
     }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListCredentialsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListCredentialsLocalTool.kt
@@ -6,6 +6,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.CredentialRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ListCredentialsLocalTool(
     private val repository: CredentialRepository
@@ -20,12 +21,12 @@ class ListCredentialsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
         val result = repository.getCredentials(
-            page = (args["page"] as? Number)?.toInt() ?: 1,
+            page = args.intArg("page") ?: 1,
             pageSize = pageSize,
-            search = args["search"] as? String
+            search = args.stringArg("search")
         ).getOrThrow()
         ToolResult(
             success = true,

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaActivationsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaActivationsLocalTool.kt
@@ -6,6 +6,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.EdaActivationRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ListEdaActivationsLocalTool(
     private val repository: EdaActivationRepository
@@ -19,10 +20,10 @@ class ListEdaActivationsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 20) ?: 20
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 20
         val result = repository.getActivations(
-            page = (args["page"] as? Number)?.toInt() ?: 1,
+            page = args.intArg("page") ?: 1,
             pageSize = pageSize
         ).getOrThrow()
         ToolResult(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaAuditRulesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaAuditRulesLocalTool.kt
@@ -6,6 +6,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.EdaAuditRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ListEdaAuditRulesLocalTool(
     private val repository: EdaAuditRepository
@@ -19,10 +20,10 @@ class ListEdaAuditRulesLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 20) ?: 10
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 10
         val result = repository.getAuditRules(
-            page = (args["page"] as? Number)?.toInt() ?: 1,
+            page = args.intArg("page") ?: 1,
             pageSize = pageSize
         ).getOrThrow()
         ToolResult(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListExecutionEnvironmentsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListExecutionEnvironmentsLocalTool.kt
@@ -6,6 +6,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.ProjectRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ListExecutionEnvironmentsLocalTool(
     private val repository: ProjectRepository
@@ -19,10 +20,10 @@ class ListExecutionEnvironmentsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
         val result = repository.getExecutionEnvironments(
-            page = (args["page"] as? Number)?.toInt() ?: 1,
+            page = args.intArg("page") ?: 1,
             pageSize = pageSize
         ).getOrThrow()
         ToolResult(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListHostsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListHostsLocalTool.kt
@@ -6,6 +6,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.HostRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ListHostsLocalTool(
     private val repository: HostRepository
@@ -20,10 +21,10 @@ class ListHostsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val inventoryId = (args["inventory_id"] as? Number)?.toInt()
-        val page = (args["page"] as? Number)?.toInt() ?: 1
-        val search = args["search"] as? String
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val inventoryId = args.intArg("inventory_id")
+        val page = args.intArg("page") ?: 1
+        val search = args.stringArg("search")
 
         val result = if (inventoryId != null) {
             repository.getInventoryHosts(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstanceGroupsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstanceGroupsLocalTool.kt
@@ -6,6 +6,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.InfrastructureRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ListInstanceGroupsLocalTool(
     private val repository: InfrastructureRepository
@@ -19,10 +20,10 @@ class ListInstanceGroupsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
         val result = repository.getInstanceGroups(
-            page = (args["page"] as? Number)?.toInt() ?: 1,
+            page = args.intArg("page") ?: 1,
             pageSize = pageSize
         ).getOrThrow()
         ToolResult(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstancesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstancesLocalTool.kt
@@ -6,6 +6,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.InfrastructureRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ListInstancesLocalTool(
     private val repository: InfrastructureRepository
@@ -19,10 +20,10 @@ class ListInstancesLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
         val result = repository.getInstances(
-            page = (args["page"] as? Number)?.toInt() ?: 1,
+            page = args.intArg("page") ?: 1,
             pageSize = pageSize
         ).getOrThrow()
         ToolResult(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInventoriesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInventoriesLocalTool.kt
@@ -6,6 +6,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.InventoryRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ListInventoriesLocalTool(
     private val repository: InventoryRepository
@@ -19,10 +20,10 @@ class ListInventoriesLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val result = repository.getInventories(
-            page = (args["page"] as? Number)?.toInt() ?: 1,
-            search = args["search"] as? String
+            page = args.intArg("page") ?: 1,
+            search = args.stringArg("search")
         ).getOrThrow()
         ToolResult(
             success = true,

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListJobTemplatesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListJobTemplatesLocalTool.kt
@@ -6,6 +6,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.TemplateRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ListJobTemplatesLocalTool(
     private val repository: TemplateRepository
@@ -20,11 +21,11 @@ class ListJobTemplatesLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val result = repository.getTemplates(
-            page = (args["page"] as? Number)?.toInt() ?: 1,
-            search = args["search"] as? String,
-            labelFilter = args["labels"] as? String
+            page = args.intArg("page") ?: 1,
+            search = args.stringArg("search"),
+            labelFilter = args.stringArg("labels")
         ).getOrThrow()
         ToolResult(
             success = true,

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListJobsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListJobsLocalTool.kt
@@ -7,6 +7,7 @@ import com.example.aapremote.data.JobRepository
 import com.example.aapremote.model.JobStatus
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ListJobsLocalTool(
     private val repository: JobRepository
@@ -21,13 +22,13 @@ class ListJobsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val statusFilter = (args["status"] as? String)?.let { statusStr ->
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val statusFilter = args.stringArg("status")?.let { statusStr ->
             JobStatus.entries.filter { it.apiValue == statusStr }.toSet()
         } ?: emptySet()
-        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 20) ?: 10
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 10
         val result = repository.getRecentJobs(
-            page = (args["page"] as? Number)?.toInt() ?: 1,
+            page = args.intArg("page") ?: 1,
             pageSize = pageSize,
             statusFilters = statusFilter
         ).getOrThrow()

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListProjectsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListProjectsLocalTool.kt
@@ -6,6 +6,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.ProjectRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ListProjectsLocalTool(
     private val repository: ProjectRepository
@@ -20,12 +21,12 @@ class ListProjectsLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val pageSize = (args["page_size"] as? Number)?.toInt()?.coerceIn(1, 25) ?: 25
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
         val result = repository.getProjects(
-            page = (args["page"] as? Number)?.toInt() ?: 1,
+            page = args.intArg("page") ?: 1,
             pageSize = pageSize,
-            search = args["search"] as? String
+            search = args.stringArg("search")
         ).getOrThrow()
         ToolResult(
             success = true,

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListSchedulesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListSchedulesLocalTool.kt
@@ -6,6 +6,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.ScheduleRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ListSchedulesLocalTool(
     private val repository: ScheduleRepository
@@ -18,9 +19,9 @@ class ListSchedulesLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val result = repository.getSchedules(
-            page = (args["page"] as? Number)?.toInt() ?: 1
+            page = args.intArg("page") ?: 1
         ).getOrThrow()
         ToolResult(
             success = true,

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListWorkflowTemplatesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListWorkflowTemplatesLocalTool.kt
@@ -6,6 +6,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.WorkflowRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ListWorkflowTemplatesLocalTool(
     private val repository: WorkflowRepository
@@ -20,11 +21,11 @@ class ListWorkflowTemplatesLocalTool(
         )
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val result = repository.getWorkflowTemplates(
-            page = (args["page"] as? Number)?.toInt() ?: 1,
-            search = args["search"] as? String,
-            labelFilter = args["labels"] as? String
+            page = args.intArg("page") ?: 1,
+            search = args.stringArg("search"),
+            labelFilter = args.stringArg("labels")
         ).getOrThrow()
         ToolResult(
             success = true,

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/PingLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/PingLocalTool.kt
@@ -6,6 +6,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.InfrastructureRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class PingLocalTool(
     private val repository: InfrastructureRepository
@@ -16,7 +17,7 @@ class PingLocalTool(
         parametersSchema = buildToolSchema()
     )
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val ping = repository.ping().getOrThrow()
         ToolResult(success = true, data = networkJson.encodeToString(ping))
     }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ToggleScheduleLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ToggleScheduleLocalTool.kt
@@ -7,6 +7,7 @@ import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.data.ScheduleRepository
 import com.example.aapremote.network.networkJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
 
 class ToggleScheduleLocalTool(
     private val repository: ScheduleRepository
@@ -22,10 +23,10 @@ class ToggleScheduleLocalTool(
     ),
     destructive = true
 ) {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = executeSafely {
-        val scheduleId = (args["schedule_id"] as? Number)?.toInt()
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val scheduleId = args.intArg("schedule_id")
             ?: return@executeSafely ToolResult(success = false, data = "schedule_id is required", errorType = ErrorType.NOT_FOUND)
-        val enabled = args["enabled"] as? Boolean
+        val enabled = args.booleanArg("enabled")
             ?: return@executeSafely ToolResult(success = false, data = "enabled is required", errorType = ErrorType.NOT_FOUND)
         val schedule = repository.toggleSchedule(scheduleId, enabled).getOrThrow()
         ToolResult(

--- a/app/src/test/kotlin/com/example/aapremote/assistant/engine/ChatEngineTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/assistant/engine/ChatEngineTest.kt
@@ -166,5 +166,5 @@ private class FakeTool(
     override val spec: ToolSpec,
     private val result: ToolResult
 ) : Tool {
-    override suspend fun execute(args: Map<String, Any>): ToolResult = result
+    override suspend fun execute(args: JsonObject): ToolResult = result
 }

--- a/app/src/test/kotlin/com/example/aapremote/assistant/engine/ToolExecutorTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/assistant/engine/ToolExecutorTest.kt
@@ -8,7 +8,10 @@ import com.example.aapremote.assistant.tools.ToolResult
 import com.example.aapremote.assistant.tools.ToolSpec
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -86,10 +89,10 @@ class ToolExecutorTest {
 
     @Test
     fun `execute passes arguments to tool`() = runTest {
-        var capturedArgs: Map<String, Any>? = null
+        var capturedArgs: JsonObject? = null
         val tool = object : Tool {
             override val spec = ToolSpec("arg_tool", "desc", JsonObject(emptyMap()))
-            override suspend fun execute(args: Map<String, Any>): ToolResult {
+            override suspend fun execute(args: JsonObject): ToolResult {
                 capturedArgs = args
                 return ToolResult(success = true, data = "ok")
             }
@@ -103,9 +106,9 @@ class ToolExecutorTest {
         }
         executor.execute(toolCall("arg_tool", args.toString()))
 
-        assertEquals("test", capturedArgs!!["name"])
-        assertEquals(42L, capturedArgs!!["count"])
-        assertEquals(true, capturedArgs!!["enabled"])
+        assertEquals("test", capturedArgs!!["name"]!!.jsonPrimitive.content)
+        assertEquals(42, capturedArgs!!["count"]!!.jsonPrimitive.int)
+        assertEquals(true, capturedArgs!!["enabled"]!!.jsonPrimitive.boolean)
     }
 }
 
@@ -114,5 +117,5 @@ private class StubTool(
     private val result: ToolResult
 ) : Tool {
     override val spec = ToolSpec(name, "Fake tool", JsonObject(emptyMap()))
-    override suspend fun execute(args: Map<String, Any>): ToolResult = result
+    override suspend fun execute(args: JsonObject): ToolResult = result
 }

--- a/app/src/test/kotlin/com/example/aapremote/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/assistant/engine/ToolRouterTest.kt
@@ -19,14 +19,14 @@ class ToolRouterTest {
 
     private fun mcpTool(name: String, serverLabel: String = "aap") = object : Tool {
         override val spec = ToolSpec(name, "[$serverLabel] description of $name", JsonObject(emptyMap()))
-        override suspend fun execute(args: Map<String, Any>) = ToolResult(success = true)
+        override suspend fun execute(args: JsonObject) = ToolResult(success = true)
     }
 
     private fun localTool(name: String, destructive: Boolean = false) = object : LocalTool(
         spec = ToolSpec(name, "Local: $name", JsonObject(emptyMap())),
         destructive = destructive
     ) {
-        override suspend fun execute(args: Map<String, Any>) = ToolResult(success = true)
+        override suspend fun execute(args: JsonObject) = ToolResult(success = true)
     }
 
     @Before


### PR DESCRIPTION
## Summary
- Change `Tool.execute()` from `Map<String, Any>` to `JsonObject` directly
- Remove ~45 LOC of conversion code (jsonObjectToMap, argsToJsonObject, etc.)
- Add typed `intArg`/`stringArg`/`booleanArg` helpers to LocalTool
- McpTool passes JsonObject directly to MCP client — no intermediate Map
- 33 files changed, net -1 line (132 added, 133 removed)

## Test plan
- [x] `./gradlew compileDebugKotlin` passes
- [x] `./gradlew testDebugUnitTest` passes (ToolExecutorTest assertions updated)
- [ ] Pure refactor — no behavior change, no emulator test needed

Closes #71

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>