### PR TITLE
Remove redundant ProGuard rules, bump compileSdk to 37

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "com.example.aapremote"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.aapremote"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,45 +20,5 @@
     public static ** INSTANCE;
 }
 
--keepclassmembers class kotlinx.serialization.json.** { *; }
--keep,includedescriptorclasses class com.example.aapremote.model.**$$serializer { *; }
--keepclassmembers class com.example.aapremote.model.** {
-    *** Companion;
-}
-
-# ── Retrofit ─────────────────────────────────────────────────────────
--keepattributes Signature,Exceptions,InnerClasses,EnclosingMethod
--keepattributes *Annotation*
-
--keepclasseswithmembers class * {
-    @retrofit2.http.* <methods>;
-}
--keep,allowobfuscation,allowshrinking interface retrofit2.Call
--keep,allowobfuscation,allowshrinking class retrofit2.Response
--keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
-
-# ── OkHttp ───────────────────────────────────────────────────────────
--dontwarn okhttp3.internal.platform.**
--dontwarn org.conscrypt.**
--dontwarn org.bouncycastle.**
--dontwarn org.openjsse.**
-
-# ── Tink ─────────────────────────────────────────────────────────────
--keep class com.google.crypto.tink.** { *; }
+# ── Tink (protobuf reflection for key storage) ──────────────────────
 -keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
--dontwarn com.google.errorprone.annotations.**
--dontwarn javax.annotation.**
-
-# ── Koin ─────────────────────────────────────────────────────────────
--keep class org.koin.** { *; }
--keepclassmembers class com.example.aapremote.** {
-    public <init>(...);
-}
-
-# ── Markdown Renderer ────────────────────────────────────────────────
--keep class com.mikepenz.markdown.** { *; }
-
-# ── App models (Retrofit response types need full generic info) ──────
--keep class com.example.aapremote.model.** { *; }
--keep class com.example.aapremote.network.** { *; }
--keep class com.example.aapremote.assistant.llm.** { *; }


### PR DESCRIPTION
## Summary

- Remove 40 lines of redundant/overly-broad ProGuard keep rules (65 → 25 lines)
- Bump compileSdk from 36 to 37 to unblock Android 16 APIs

### Rules removed
- **Retrofit** (2.12.0 bundles rules since 2.9.0)
- **OkHttp** (5.3.2 bundles `-dontwarn` entries)
- **Koin** (4.2.1 bundles rules — blanket `org.koin.**` was Level 1 severity)
- **Markdown Renderer** (blanket `com.mikepenz.**` was Level 1)
- **kotlinx.serialization.json** (bundles rules since 1.7+)
- **Tink** blanket keep (1.21.0 bundles rules — kept only `GeneratedMessageLite` for protobuf)
- **App blanket keeps** on `model.**`, `network.**`, `assistant.llm.**` — `@Serializable` conditional keeps already protect serialized classes

### Rules retained
- Conditional `@Serializable` keeps (recommended kotlinx-serialization pattern)
- `GeneratedMessageLite` keep (Tink protobuf reflection)

## Test plan
- [x] `./gradlew assembleRelease` passes with no R8 errors
- [ ] Test login flow in release build
- [ ] Test template listing and job launch
- [ ] Test MCP connection
- [ ] Test AI assistant chat
- [ ] Verify Markdown rendering in assistant responses

Closes #84

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>