### PR TITLE
Testing Phase 2: ViewModel unit tests

### DIFF
--- a/app/src/main/kotlin/com/example/aapremote/assistant/AssistantModule.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/AssistantModule.kt
@@ -1,6 +1,7 @@
 package com.example.aapremote.assistant
 
 import com.example.aapremote.assistant.data.AssistantRepository
+import com.example.aapremote.assistant.data.IAssistantRepository
 import com.example.aapremote.assistant.presentation.AssistantViewModel
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.network.AuthInterceptor
@@ -11,6 +12,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val assistantModule = module {
@@ -40,7 +42,7 @@ val assistantModule = module {
         )
     }
 
-    single { AssistantRepository(get()) }
+    single { AssistantRepository(get()) } bind IAssistantRepository::class
 
     single(named("llm")) {
         OkHttpClient.Builder()

--- a/app/src/main/kotlin/com/example/aapremote/assistant/data/AssistantRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/data/AssistantRepository.kt
@@ -15,7 +15,7 @@ private val Context.assistantDataStore: DataStore<Preferences> by preferencesDat
     name = "assistant_config"
 )
 
-class AssistantRepository(private val context: Context) {
+class AssistantRepository(private val context: Context) : IAssistantRepository {
 
     private val messages = mutableListOf<ChatMessage>()
     private val json = Json { ignoreUnknownKeys = true }
@@ -25,27 +25,27 @@ class AssistantRepository(private val context: Context) {
         const val MAX_MESSAGES = 100
     }
 
-    fun addMessage(message: ChatMessage) {
+    override fun addMessage(message: ChatMessage) {
         messages.add(message)
         if (messages.size > MAX_MESSAGES) {
             messages.removeAt(0)
         }
     }
 
-    fun getHistory(): List<ChatMessage> = messages.toList()
+    override fun getHistory(): List<ChatMessage> = messages.toList()
 
-    fun clearHistory() {
+    override fun clearHistory() {
         messages.clear()
     }
 
-    suspend fun saveLlmConfig(config: LlmProviderConfig) {
+    override suspend fun saveLlmConfig(config: LlmProviderConfig) {
         val jsonString = json.encodeToString(LlmProviderConfig.serializer(), config)
         context.assistantDataStore.edit { prefs ->
             prefs[KEY_LLM_CONFIG] = jsonString
         }
     }
 
-    suspend fun loadLlmConfig(): LlmProviderConfig? {
+    override suspend fun loadLlmConfig(): LlmProviderConfig? {
         val prefs = context.assistantDataStore.data.first()
         val jsonString = prefs[KEY_LLM_CONFIG] ?: return null
         return try {

--- a/app/src/main/kotlin/com/example/aapremote/assistant/data/IAssistantRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/data/IAssistantRepository.kt
@@ -1,0 +1,11 @@
+package com.example.aapremote.assistant.data
+
+import com.example.aapremote.assistant.engine.ChatMessage
+
+interface IAssistantRepository {
+    fun addMessage(message: ChatMessage)
+    fun getHistory(): List<ChatMessage>
+    fun clearHistory()
+    suspend fun saveLlmConfig(config: LlmProviderConfig)
+    suspend fun loadLlmConfig(): LlmProviderConfig?
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
@@ -2,7 +2,7 @@ package com.example.aapremote.assistant.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.assistant.data.AssistantRepository
+import com.example.aapremote.assistant.data.IAssistantRepository
 import com.example.aapremote.assistant.data.LlmProviderConfig
 import com.example.aapremote.assistant.data.ModelFetcher
 import com.example.aapremote.assistant.data.TokenSavingMode
@@ -14,7 +14,7 @@ import com.example.aapremote.assistant.engine.ToolExecutor
 import com.example.aapremote.assistant.engine.ToolRouter
 import com.example.aapremote.assistant.llm.KoogLlmProvider
 import com.example.aapremote.assistant.tools.LocalTool
-import com.example.aapremote.data.TokenManager
+import com.example.aapremote.data.ITokenManager
 import com.example.aapremote.model.McpServerConfig
 import com.example.aapremote.network.CertTrustManager
 import com.example.aapremote.network.mcp.McpServerManager
@@ -31,8 +31,8 @@ import okhttp3.OkHttpClient
 
 class AssistantViewModel(
     private val mcpServerManager: McpServerManager,
-    private val repository: AssistantRepository,
-    private val tokenManager: TokenManager,
+    private val repository: IAssistantRepository,
+    private val tokenManager: ITokenManager,
     private val httpClient: OkHttpClient,
     private val json: Json,
     private val localTools: List<LocalTool> = emptyList()

--- a/app/src/main/kotlin/com/example/aapremote/data/AuthRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/AuthRepository.kt
@@ -1,8 +1,8 @@
 package com.example.aapremote.data
 
 import com.example.aapremote.model.User
-import com.example.aapremote.network.AapApiProvider
 import com.example.aapremote.network.AapApiService
+import com.example.aapremote.network.IAapApiProvider
 import com.example.aapremote.network.ApiVersion
 import com.example.aapremote.network.ApiVersionDetector
 import com.example.aapremote.network.AuthInterceptor
@@ -17,16 +17,16 @@ import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
 class AuthRepository(
-    private val tokenManager: TokenManager,
-    private val apiProvider: AapApiProvider
-) {
+    private val tokenManager: ITokenManager,
+    private val apiProvider: IAapApiProvider
+) : IAuthRepository {
 
-    suspend fun validateCredentials(
+    override suspend fun validateCredentials(
         baseUrl: String,
         token: String,
         trustSelfSigned: Boolean,
-        alias: String? = null,
-        existingInstanceId: String? = null
+        alias: String?,
+        existingInstanceId: String?
     ): Result<User> = withContext(Dispatchers.IO) {
         try {
             val client = buildClient(token, trustSelfSigned)
@@ -55,7 +55,7 @@ class AuthRepository(
         }
     }
 
-    suspend fun reAuthenticate(instanceId: String, newToken: String): Result<User> =
+    override suspend fun reAuthenticate(instanceId: String, newToken: String): Result<User> =
         withContext(Dispatchers.IO) {
             try {
                 val instance = tokenManager.getInstanceById(instanceId)
@@ -91,7 +91,7 @@ class AuthRepository(
             }
         }
 
-    suspend fun checkExistingCredentials(): Result<User>? = withContext(Dispatchers.IO) {
+    override suspend fun checkExistingCredentials(): Result<User>? = withContext(Dispatchers.IO) {
         if (!tokenManager.loadCredentials()) return@withContext null
         val activeInstance = tokenManager.activeInstance.value ?: return@withContext null
 
@@ -112,15 +112,15 @@ class AuthRepository(
         }
     }
 
-    suspend fun logoutInstance(instanceId: String) {
+    override suspend fun logoutInstance(instanceId: String) {
         tokenManager.removeInstance(instanceId)
     }
 
-    suspend fun logout() {
+    override suspend fun logout() {
         tokenManager.clearCredentials()
     }
 
-    fun isLoggedIn() = tokenManager.isLoggedIn
+    override fun isLoggedIn() = tokenManager.isLoggedIn
 
     private fun buildClient(token: String, trustSelfSigned: Boolean): OkHttpClient {
         val builder = OkHttpClient.Builder()

--- a/app/src/main/kotlin/com/example/aapremote/data/CredentialRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/CredentialRepository.kt
@@ -3,12 +3,12 @@ package com.example.aapremote.data
 import com.example.aapremote.model.Credential
 import com.example.aapremote.network.AapApiProvider
 
-class CredentialRepository(private val apiProvider: AapApiProvider) {
+class CredentialRepository(private val apiProvider: AapApiProvider) : ICredentialRepository {
 
-    suspend fun getCredentials(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getCredentials(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<CredentialListResult> {
         return try {
             val response = apiProvider.getApiService().getCredentials(
@@ -28,7 +28,7 @@ class CredentialRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getCredential(id: Int): Result<Credential> {
+    override suspend fun getCredential(id: Int): Result<Credential> {
         return try {
             Result.success(apiProvider.getApiService().getCredential(id))
         } catch (e: Exception) {

--- a/app/src/main/kotlin/com/example/aapremote/data/DataModule.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/DataModule.kt
@@ -1,23 +1,25 @@
 package com.example.aapremote.data
 
 import com.example.aapremote.data.backup.BackupManager
+import com.example.aapremote.network.AapApiProvider
 import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val dataModule = module {
-    single { TokenManager(androidContext()) }
+    single { TokenManager(androidContext()) } bind ITokenManager::class
     single { BackupManager() }
     single { ConnectivityObserver(androidContext()) }
-    single { AuthRepository(get(), get()) }
-    single { TemplateRepository(get<com.example.aapremote.network.AapApiProvider>()) }
-    single { JobRepository(get<com.example.aapremote.network.AapApiProvider>()) }
-    single { WorkflowRepository(get<com.example.aapremote.network.AapApiProvider>()) }
-    single { ScheduleRepository(get<com.example.aapremote.network.AapApiProvider>()) }
-    single { EdaAuditRepository(get<com.example.aapremote.network.AapApiProvider>()) }
-    single { InventoryRepository(get<com.example.aapremote.network.AapApiProvider>()) }
-    single { HostRepository(get<com.example.aapremote.network.AapApiProvider>()) }
-    single { InfrastructureRepository(get<com.example.aapremote.network.AapApiProvider>()) }
-    single { CredentialRepository(get<com.example.aapremote.network.AapApiProvider>()) }
-    single { ProjectRepository(get<com.example.aapremote.network.AapApiProvider>()) }
-    single { EdaActivationRepository(get<com.example.aapremote.network.AapApiProvider>()) }
+    single { AuthRepository(get(), get()) } bind IAuthRepository::class
+    single { TemplateRepository(get<AapApiProvider>()) } bind ITemplateRepository::class
+    single { JobRepository(get<AapApiProvider>()) } bind IJobRepository::class
+    single { WorkflowRepository(get<AapApiProvider>()) } bind IWorkflowRepository::class
+    single { ScheduleRepository(get<AapApiProvider>()) } bind IScheduleRepository::class
+    single { EdaAuditRepository(get<AapApiProvider>()) } bind IEdaAuditRepository::class
+    single { InventoryRepository(get<AapApiProvider>()) } bind IInventoryRepository::class
+    single { HostRepository(get<AapApiProvider>()) } bind IHostRepository::class
+    single { InfrastructureRepository(get<AapApiProvider>()) } bind IInfrastructureRepository::class
+    single { CredentialRepository(get<AapApiProvider>()) } bind ICredentialRepository::class
+    single { ProjectRepository(get<AapApiProvider>()) } bind IProjectRepository::class
+    single { EdaActivationRepository(get<AapApiProvider>()) } bind IEdaActivationRepository::class
 }

--- a/app/src/main/kotlin/com/example/aapremote/data/EdaActivationRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/EdaActivationRepository.kt
@@ -3,11 +3,11 @@ package com.example.aapremote.data
 import com.example.aapremote.model.EdaActivation
 import com.example.aapremote.network.AapApiProvider
 
-class EdaActivationRepository(private val apiProvider: AapApiProvider) {
+class EdaActivationRepository(private val apiProvider: AapApiProvider) : IEdaActivationRepository {
 
-    suspend fun getActivations(
-        page: Int = 1,
-        pageSize: Int = 20
+    override suspend fun getActivations(
+        page: Int,
+        pageSize: Int
     ): Result<EdaActivationListResult> {
         return try {
             val response = apiProvider.getEdaApiService().getActivations(
@@ -26,7 +26,7 @@ class EdaActivationRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getActivation(id: Int): Result<EdaActivation> {
+    override suspend fun getActivation(id: Int): Result<EdaActivation> {
         return try {
             Result.success(apiProvider.getEdaApiService().getActivation(id))
         } catch (e: Exception) {

--- a/app/src/main/kotlin/com/example/aapremote/data/EdaAuditRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/EdaAuditRepository.kt
@@ -3,9 +3,9 @@ package com.example.aapremote.data
 import com.example.aapremote.model.EdaRuleAudit
 import com.example.aapremote.network.AapApiProvider
 
-class EdaAuditRepository(private val apiProvider: AapApiProvider) {
+class EdaAuditRepository(private val apiProvider: AapApiProvider) : IEdaAuditRepository {
 
-    suspend fun getAuditRules(page: Int = 1, pageSize: Int = 20): Result<EdaAuditResult> {
+    override suspend fun getAuditRules(page: Int, pageSize: Int): Result<EdaAuditResult> {
         return try {
             val response = apiProvider.getEdaApiService().getAuditRules(
                 page = page,

--- a/app/src/main/kotlin/com/example/aapremote/data/HostRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/HostRepository.kt
@@ -5,12 +5,12 @@ import com.example.aapremote.model.JobHostSummary
 import com.example.aapremote.network.AapApiProvider
 import kotlinx.serialization.json.JsonElement
 
-class HostRepository(private val apiProvider: AapApiProvider) {
+class HostRepository(private val apiProvider: AapApiProvider) : IHostRepository {
 
-    suspend fun getAllHosts(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getAllHosts(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<HostListResult> {
         return try {
             val response = apiProvider.getApiService().getHosts(
@@ -30,11 +30,11 @@ class HostRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getInventoryHosts(
+    override suspend fun getInventoryHosts(
         inventoryId: Int,
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<HostListResult> {
         return try {
             val response = apiProvider.getApiService().getInventoryHosts(
@@ -55,7 +55,7 @@ class HostRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getHostFacts(hostId: Int): Result<Map<String, JsonElement>> {
+    override suspend fun getHostFacts(hostId: Int): Result<Map<String, JsonElement>> {
         return try {
             Result.success(apiProvider.getApiService().getHostFacts(hostId))
         } catch (e: Exception) {
@@ -63,10 +63,10 @@ class HostRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getHostJobSummaries(
+    override suspend fun getHostJobSummaries(
         hostId: Int,
-        page: Int = 1,
-        pageSize: Int = 20
+        page: Int,
+        pageSize: Int
     ): Result<JobHostSummaryResult> {
         return try {
             val response = apiProvider.getApiService().getHostJobSummaries(

--- a/app/src/main/kotlin/com/example/aapremote/data/IAuthRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/IAuthRepository.kt
@@ -1,0 +1,20 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.User
+import kotlinx.coroutines.flow.Flow
+
+interface IAuthRepository {
+    suspend fun validateCredentials(
+        baseUrl: String,
+        token: String,
+        trustSelfSigned: Boolean,
+        alias: String? = null,
+        existingInstanceId: String? = null
+    ): Result<User>
+
+    suspend fun reAuthenticate(instanceId: String, newToken: String): Result<User>
+    suspend fun checkExistingCredentials(): Result<User>?
+    suspend fun logoutInstance(instanceId: String)
+    suspend fun logout()
+    fun isLoggedIn(): Flow<Boolean>
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/ICredentialRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/ICredentialRepository.kt
@@ -1,0 +1,13 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.Credential
+
+interface ICredentialRepository {
+    suspend fun getCredentials(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<CredentialListResult>
+
+    suspend fun getCredential(id: Int): Result<Credential>
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/IEdaActivationRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/IEdaActivationRepository.kt
@@ -1,0 +1,12 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.EdaActivation
+
+interface IEdaActivationRepository {
+    suspend fun getActivations(
+        page: Int = 1,
+        pageSize: Int = 20
+    ): Result<EdaActivationListResult>
+
+    suspend fun getActivation(id: Int): Result<EdaActivation>
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/IEdaAuditRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/IEdaAuditRepository.kt
@@ -1,0 +1,5 @@
+package com.example.aapremote.data
+
+interface IEdaAuditRepository {
+    suspend fun getAuditRules(page: Int = 1, pageSize: Int = 20): Result<EdaAuditResult>
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/IHostRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/IHostRepository.kt
@@ -1,0 +1,26 @@
+package com.example.aapremote.data
+
+import kotlinx.serialization.json.JsonElement
+
+interface IHostRepository {
+    suspend fun getAllHosts(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<HostListResult>
+
+    suspend fun getInventoryHosts(
+        inventoryId: Int,
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<HostListResult>
+
+    suspend fun getHostFacts(hostId: Int): Result<Map<String, JsonElement>>
+
+    suspend fun getHostJobSummaries(
+        hostId: Int,
+        page: Int = 1,
+        pageSize: Int = 20
+    ): Result<JobHostSummaryResult>
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/IInfrastructureRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/IInfrastructureRepository.kt
@@ -1,0 +1,22 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.Instance
+import com.example.aapremote.model.PingResponse
+import kotlinx.serialization.json.JsonElement
+
+interface IInfrastructureRepository {
+    suspend fun getInstances(
+        page: Int = 1,
+        pageSize: Int = 25
+    ): Result<InstanceListResult>
+
+    suspend fun getInstance(id: Int): Result<Instance>
+
+    suspend fun getInstanceGroups(
+        page: Int = 1,
+        pageSize: Int = 25
+    ): Result<InstanceGroupListResult>
+
+    suspend fun ping(): Result<PingResponse>
+    suspend fun getMeshTopology(): Result<JsonElement>
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/IInventoryRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/IInventoryRepository.kt
@@ -1,0 +1,13 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.Inventory
+
+interface IInventoryRepository {
+    suspend fun getInventories(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<InventoryListResult>
+
+    suspend fun getInventory(id: Int): Result<Inventory>
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/IJobRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/IJobRepository.kt
@@ -1,0 +1,16 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.Job
+import com.example.aapremote.model.JobStatus
+import kotlinx.coroutines.flow.Flow
+
+interface IJobRepository {
+    suspend fun getJobStatus(jobId: Int): Result<Job>
+    fun pollJobStatus(jobId: Int): Flow<Job>
+    suspend fun getJobStdout(jobId: Int): Result<String>
+    suspend fun getRecentJobs(
+        page: Int = 1,
+        pageSize: Int = 20,
+        statusFilters: Set<JobStatus> = emptySet()
+    ): Result<RecentJobsResult>
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/IProjectRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/IProjectRepository.kt
@@ -1,0 +1,18 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.Project
+
+interface IProjectRepository {
+    suspend fun getProjects(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<ProjectListResult>
+
+    suspend fun getProject(id: Int): Result<Project>
+
+    suspend fun getExecutionEnvironments(
+        page: Int = 1,
+        pageSize: Int = 25
+    ): Result<ExecutionEnvironmentListResult>
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/IScheduleRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/IScheduleRepository.kt
@@ -1,0 +1,8 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.Schedule
+
+interface IScheduleRepository {
+    suspend fun getSchedules(page: Int = 1, pageSize: Int = 20): Result<SchedulesResult>
+    suspend fun toggleSchedule(id: Int, enabled: Boolean): Result<Schedule>
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/ITemplateRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/ITemplateRepository.kt
@@ -1,0 +1,11 @@
+package com.example.aapremote.data
+
+interface ITemplateRepository {
+    suspend fun getTemplates(
+        page: Int = 1,
+        search: String? = null,
+        labelFilter: String? = null
+    ): Result<TemplateListResult>
+
+    suspend fun launchJob(templateId: Int, extraVars: String? = null): Result<Int>
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/ITokenManager.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/ITokenManager.kt
@@ -1,0 +1,46 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.AapInstance
+import com.example.aapremote.model.McpServerConfig
+import com.example.aapremote.network.ApiVersion
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+
+interface ITokenManager {
+    val instances: StateFlow<List<AapInstance>>
+    val activeInstance: StateFlow<AapInstance?>
+    val isLoggedIn: Flow<Boolean>
+
+    suspend fun saveInstance(
+        baseUrl: String,
+        token: String,
+        alias: String? = null,
+        apiVersion: ApiVersion,
+        trustSelfSigned: Boolean = false,
+        certFingerprint: String? = null,
+        existingId: String? = null
+    ): String
+
+    suspend fun removeInstance(instanceId: String): Boolean
+    suspend fun setActiveInstance(instanceId: String)
+    fun getInstanceById(instanceId: String): AapInstance?
+    suspend fun loadCredentials(): Boolean
+
+    suspend fun saveCredentials(
+        baseUrl: String,
+        token: String,
+        apiVersion: ApiVersion,
+        trustSelfSigned: Boolean = false,
+        certFingerprint: String? = null,
+        alias: String? = null,
+        existingId: String? = null
+    ): String
+
+    suspend fun updateMcpConfig(
+        instanceId: String,
+        enabled: Boolean,
+        servers: List<McpServerConfig>?
+    )
+
+    suspend fun clearCredentials()
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/IWorkflowRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/IWorkflowRepository.kt
@@ -1,0 +1,18 @@
+package com.example.aapremote.data
+
+import com.example.aapremote.model.WorkflowJob
+import com.example.aapremote.model.WorkflowNode
+import kotlinx.coroutines.flow.Flow
+
+interface IWorkflowRepository {
+    suspend fun getWorkflowTemplates(
+        page: Int = 1,
+        search: String? = null,
+        labelFilter: String? = null
+    ): Result<WorkflowTemplateListResult>
+
+    suspend fun launchWorkflow(templateId: Int, extraVars: String? = null): Result<Int>
+    suspend fun getWorkflowJobStatus(workflowJobId: Int): Result<WorkflowJob>
+    fun pollWorkflowJobStatus(workflowJobId: Int): Flow<WorkflowJob>
+    suspend fun getWorkflowNodes(workflowJobId: Int): Result<List<WorkflowNode>>
+}

--- a/app/src/main/kotlin/com/example/aapremote/data/InfrastructureRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/InfrastructureRepository.kt
@@ -6,11 +6,11 @@ import com.example.aapremote.model.PingResponse
 import com.example.aapremote.network.AapApiProvider
 import kotlinx.serialization.json.JsonElement
 
-class InfrastructureRepository(private val apiProvider: AapApiProvider) {
+class InfrastructureRepository(private val apiProvider: AapApiProvider) : IInfrastructureRepository {
 
-    suspend fun getInstances(
-        page: Int = 1,
-        pageSize: Int = 25
+    override suspend fun getInstances(
+        page: Int,
+        pageSize: Int
     ): Result<InstanceListResult> {
         return try {
             val response = apiProvider.getApiService().getInstances(
@@ -29,7 +29,7 @@ class InfrastructureRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getInstance(id: Int): Result<Instance> {
+    override suspend fun getInstance(id: Int): Result<Instance> {
         return try {
             Result.success(apiProvider.getApiService().getInstance(id))
         } catch (e: Exception) {
@@ -37,9 +37,9 @@ class InfrastructureRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getInstanceGroups(
-        page: Int = 1,
-        pageSize: Int = 25
+    override suspend fun getInstanceGroups(
+        page: Int,
+        pageSize: Int
     ): Result<InstanceGroupListResult> {
         return try {
             val response = apiProvider.getApiService().getInstanceGroups(
@@ -58,7 +58,7 @@ class InfrastructureRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun ping(): Result<PingResponse> {
+    override suspend fun ping(): Result<PingResponse> {
         return try {
             Result.success(apiProvider.getApiService().ping())
         } catch (e: Exception) {
@@ -66,7 +66,7 @@ class InfrastructureRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getMeshTopology(): Result<JsonElement> {
+    override suspend fun getMeshTopology(): Result<JsonElement> {
         return try {
             Result.success(apiProvider.getApiService().getMeshTopology())
         } catch (e: Exception) {

--- a/app/src/main/kotlin/com/example/aapremote/data/InventoryRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/InventoryRepository.kt
@@ -3,12 +3,12 @@ package com.example.aapremote.data
 import com.example.aapremote.model.Inventory
 import com.example.aapremote.network.AapApiProvider
 
-class InventoryRepository(private val apiProvider: AapApiProvider) {
+class InventoryRepository(private val apiProvider: AapApiProvider) : IInventoryRepository {
 
-    suspend fun getInventories(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getInventories(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<InventoryListResult> {
         return try {
             val response = apiProvider.getApiService().getInventories(
@@ -28,7 +28,7 @@ class InventoryRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getInventory(id: Int): Result<Inventory> {
+    override suspend fun getInventory(id: Int): Result<Inventory> {
         return try {
             Result.success(apiProvider.getApiService().getInventory(id))
         } catch (e: Exception) {

--- a/app/src/main/kotlin/com/example/aapremote/data/JobRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/JobRepository.kt
@@ -7,9 +7,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-class JobRepository(private val apiProvider: AapApiProvider) {
+class JobRepository(private val apiProvider: AapApiProvider) : IJobRepository {
 
-    suspend fun getJobStatus(jobId: Int): Result<Job> {
+    override suspend fun getJobStatus(jobId: Int): Result<Job> {
         return try {
             Result.success(apiProvider.getApiService().getJob(jobId))
         } catch (e: Exception) {
@@ -17,7 +17,7 @@ class JobRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    fun pollJobStatus(jobId: Int): Flow<Job> = flow {
+    override fun pollJobStatus(jobId: Int): Flow<Job> = flow {
         while (true) {
             try {
                 val job = apiProvider.getApiService().getJob(jobId)
@@ -30,7 +30,7 @@ class JobRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getJobStdout(jobId: Int): Result<String> {
+    override suspend fun getJobStdout(jobId: Int): Result<String> {
         return try {
             val response = apiProvider.getApiService().getJobStdout(jobId)
             Result.success(response.string())
@@ -39,10 +39,10 @@ class JobRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getRecentJobs(
-        page: Int = 1,
-        pageSize: Int = 20,
-        statusFilters: Set<JobStatus> = emptySet()
+    override suspend fun getRecentJobs(
+        page: Int,
+        pageSize: Int,
+        statusFilters: Set<JobStatus>
     ): Result<RecentJobsResult> {
         return try {
             val orStatus = if (statusFilters.size > 1) {

--- a/app/src/main/kotlin/com/example/aapremote/data/ProjectRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/ProjectRepository.kt
@@ -4,12 +4,12 @@ import com.example.aapremote.model.ExecutionEnvironment
 import com.example.aapremote.model.Project
 import com.example.aapremote.network.AapApiProvider
 
-class ProjectRepository(private val apiProvider: AapApiProvider) {
+class ProjectRepository(private val apiProvider: AapApiProvider) : IProjectRepository {
 
-    suspend fun getProjects(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getProjects(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ProjectListResult> {
         return try {
             val response = apiProvider.getApiService().getProjects(
@@ -29,7 +29,7 @@ class ProjectRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getProject(id: Int): Result<Project> {
+    override suspend fun getProject(id: Int): Result<Project> {
         return try {
             Result.success(apiProvider.getApiService().getProject(id))
         } catch (e: Exception) {
@@ -37,9 +37,9 @@ class ProjectRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getExecutionEnvironments(
-        page: Int = 1,
-        pageSize: Int = 25
+    override suspend fun getExecutionEnvironments(
+        page: Int,
+        pageSize: Int
     ): Result<ExecutionEnvironmentListResult> {
         return try {
             val response = apiProvider.getApiService().getExecutionEnvironments(

--- a/app/src/main/kotlin/com/example/aapremote/data/ScheduleRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/ScheduleRepository.kt
@@ -3,9 +3,9 @@ package com.example.aapremote.data
 import com.example.aapremote.model.Schedule
 import com.example.aapremote.network.AapApiProvider
 
-class ScheduleRepository(private val apiProvider: AapApiProvider) {
+class ScheduleRepository(private val apiProvider: AapApiProvider) : IScheduleRepository {
 
-    suspend fun getSchedules(page: Int = 1, pageSize: Int = 20): Result<SchedulesResult> {
+    override suspend fun getSchedules(page: Int, pageSize: Int): Result<SchedulesResult> {
         return try {
             val response = apiProvider.getApiService().getSchedules(
                 page = page,
@@ -23,7 +23,7 @@ class ScheduleRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun toggleSchedule(id: Int, enabled: Boolean): Result<Schedule> {
+    override suspend fun toggleSchedule(id: Int, enabled: Boolean): Result<Schedule> {
         return try {
             val updated = apiProvider.getApiService().toggleSchedule(id, mapOf("enabled" to enabled))
             Result.success(updated)

--- a/app/src/main/kotlin/com/example/aapremote/data/TemplateRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/TemplateRepository.kt
@@ -4,12 +4,12 @@ import com.example.aapremote.model.JobTemplate
 import com.example.aapremote.model.LaunchRequest
 import com.example.aapremote.network.AapApiProvider
 
-class TemplateRepository(private val apiProvider: AapApiProvider) {
+class TemplateRepository(private val apiProvider: AapApiProvider) : ITemplateRepository {
 
-    suspend fun getTemplates(
-        page: Int = 1,
-        search: String? = null,
-        labelFilter: String? = null
+    override suspend fun getTemplates(
+        page: Int,
+        search: String?,
+        labelFilter: String?
     ): Result<TemplateListResult> {
         return try {
             val response = apiProvider.getApiService().getJobTemplates(
@@ -29,7 +29,7 @@ class TemplateRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun launchJob(templateId: Int, extraVars: String? = null): Result<Int> {
+    override suspend fun launchJob(templateId: Int, extraVars: String?): Result<Int> {
         return try {
             val request = LaunchRequest(extraVars = extraVars)
             val response = apiProvider.getApiService().launchJob(templateId, request)

--- a/app/src/main/kotlin/com/example/aapremote/data/TokenManager.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/TokenManager.kt
@@ -49,16 +49,16 @@ data class InstancesState(
     val activeInstanceId: String? = null
 )
 
-class TokenManager(private val context: Context) {
+class TokenManager(private val context: Context) : ITokenManager {
 
     private val aead: Aead
 
     // Multi-instance reactive state
     private val _instances = MutableStateFlow<List<AapInstance>>(emptyList())
-    val instances: StateFlow<List<AapInstance>> = _instances.asStateFlow()
+    override val instances: StateFlow<List<AapInstance>> = _instances.asStateFlow()
 
     private val _activeInstance = MutableStateFlow<AapInstance?>(null)
-    val activeInstance: StateFlow<AapInstance?> = _activeInstance.asStateFlow()
+    override val activeInstance: StateFlow<AapInstance?> = _activeInstance.asStateFlow()
 
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -164,14 +164,14 @@ class TokenManager(private val context: Context) {
      * If this is the first instance, it becomes active automatically.
      * Returns the instance ID.
      */
-    suspend fun saveInstance(
+    override suspend fun saveInstance(
         baseUrl: String,
         token: String,
-        alias: String? = null,
+        alias: String?,
         apiVersion: ApiVersion,
-        trustSelfSigned: Boolean = false,
-        certFingerprint: String? = null,
-        existingId: String? = null
+        trustSelfSigned: Boolean,
+        certFingerprint: String?,
+        existingId: String?
     ): String {
         val normalizedUrl = baseUrl.trimEnd('/').lowercase()
 
@@ -243,7 +243,7 @@ class TokenManager(private val context: Context) {
      * If the removed instance was active, promotes the next available instance.
      * Returns true if an instance was removed.
      */
-    suspend fun removeInstance(instanceId: String): Boolean {
+    override suspend fun removeInstance(instanceId: String): Boolean {
         val state = readState()
         val updatedInstances = state.instances.filter { it.id != instanceId }
         if (updatedInstances.size == state.instances.size) return false
@@ -261,7 +261,7 @@ class TokenManager(private val context: Context) {
     /**
      * Set the active instance by ID.
      */
-    suspend fun setActiveInstance(instanceId: String) {
+    override suspend fun setActiveInstance(instanceId: String) {
         val state = readState()
         if (state.instances.none { it.id == instanceId }) return
         writeState(state.copy(activeInstanceId = instanceId))
@@ -270,7 +270,7 @@ class TokenManager(private val context: Context) {
     /**
      * Get a specific instance by ID.
      */
-    fun getInstanceById(instanceId: String): AapInstance? {
+    override fun getInstanceById(instanceId: String): AapInstance? {
         return _instances.value.find { it.id == instanceId }
     }
 
@@ -279,7 +279,7 @@ class TokenManager(private val context: Context) {
      * Also handles legacy credential cleanup (R-005).
      * Returns true if any instances exist after loading.
      */
-    suspend fun loadCredentials(): Boolean {
+    override suspend fun loadCredentials(): Boolean {
         val prefs = context.credentialsDataStore.data.first()
 
         // Legacy cleanup (R-005): if instances_json is absent but old keys exist, clear them
@@ -307,14 +307,14 @@ class TokenManager(private val context: Context) {
      * Legacy compatibility: save credentials as a single instance.
      * Used by AuthRepository during the connect flow.
      */
-    suspend fun saveCredentials(
+    override suspend fun saveCredentials(
         baseUrl: String,
         token: String,
         apiVersion: ApiVersion,
-        trustSelfSigned: Boolean = false,
-        certFingerprint: String? = null,
-        alias: String? = null,
-        existingId: String? = null
+        trustSelfSigned: Boolean,
+        certFingerprint: String?,
+        alias: String?,
+        existingId: String?
     ): String {
         return saveInstance(
             baseUrl = baseUrl,
@@ -327,7 +327,7 @@ class TokenManager(private val context: Context) {
         )
     }
 
-    suspend fun updateMcpConfig(
+    override suspend fun updateMcpConfig(
         instanceId: String,
         enabled: Boolean,
         servers: List<McpServerConfig>?
@@ -344,13 +344,13 @@ class TokenManager(private val context: Context) {
     /**
      * Clear all instances (full logout).
      */
-    suspend fun clearCredentials() {
+    override suspend fun clearCredentials() {
         context.credentialsDataStore.edit { it.clear() }
         _instances.value = emptyList()
         _activeInstance.value = null
     }
 
-    val isLoggedIn: Flow<Boolean> = context.credentialsDataStore.data.map { prefs ->
+    override val isLoggedIn: Flow<Boolean> = context.credentialsDataStore.data.map { prefs ->
         val jsonString = prefs[KEY_INSTANCES_JSON]
         if (jsonString != null) {
             try {

--- a/app/src/main/kotlin/com/example/aapremote/data/WorkflowRepository.kt
+++ b/app/src/main/kotlin/com/example/aapremote/data/WorkflowRepository.kt
@@ -9,12 +9,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-class WorkflowRepository(private val apiProvider: AapApiProvider) {
+class WorkflowRepository(private val apiProvider: AapApiProvider) : IWorkflowRepository {
 
-    suspend fun getWorkflowTemplates(
-        page: Int = 1,
-        search: String? = null,
-        labelFilter: String? = null
+    override suspend fun getWorkflowTemplates(
+        page: Int,
+        search: String?,
+        labelFilter: String?
     ): Result<WorkflowTemplateListResult> {
         return try {
             val response = apiProvider.getApiService().getWorkflowJobTemplates(
@@ -34,7 +34,7 @@ class WorkflowRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun launchWorkflow(templateId: Int, extraVars: String? = null): Result<Int> {
+    override suspend fun launchWorkflow(templateId: Int, extraVars: String?): Result<Int> {
         return try {
             val request = LaunchRequest(extraVars = extraVars)
             val response = apiProvider.getApiService().launchWorkflowJob(templateId, request)
@@ -44,7 +44,7 @@ class WorkflowRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getWorkflowJobStatus(workflowJobId: Int): Result<WorkflowJob> {
+    override suspend fun getWorkflowJobStatus(workflowJobId: Int): Result<WorkflowJob> {
         return try {
             Result.success(apiProvider.getApiService().getWorkflowJob(workflowJobId))
         } catch (e: Exception) {
@@ -52,7 +52,7 @@ class WorkflowRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    fun pollWorkflowJobStatus(workflowJobId: Int): Flow<WorkflowJob> = flow {
+    override fun pollWorkflowJobStatus(workflowJobId: Int): Flow<WorkflowJob> = flow {
         while (true) {
             try {
                 val job = apiProvider.getApiService().getWorkflowJob(workflowJobId)
@@ -65,7 +65,7 @@ class WorkflowRepository(private val apiProvider: AapApiProvider) {
         }
     }
 
-    suspend fun getWorkflowNodes(workflowJobId: Int): Result<List<WorkflowNode>> {
+    override suspend fun getWorkflowNodes(workflowJobId: Int): Result<List<WorkflowNode>> {
         return try {
             val response = apiProvider.getApiService().getWorkflowNodes(workflowJobId)
             Result.success(response.results)

--- a/app/src/main/kotlin/com/example/aapremote/network/AapApiProvider.kt
+++ b/app/src/main/kotlin/com/example/aapremote/network/AapApiProvider.kt
@@ -11,12 +11,12 @@ import retrofit2.converter.kotlinx.serialization.asConverterFactory
 class AapApiProvider(
     private val tokenManager: TokenManager,
     private val json: Json
-) {
+) : IAapApiProvider {
     // Per-instance service cache: instanceId -> (AapApiService, EdaApiService)
     private val serviceCache = mutableMapOf<String, Pair<AapApiService, EdaApiService?>>()
 
     @Synchronized
-    fun getApiService(): AapApiService {
+    override fun getApiService(): AapApiService {
         val instance = tokenManager.activeInstance.value
             ?: throw IllegalStateException("No active AAP instance. Please log in first.")
 
@@ -36,7 +36,7 @@ class AapApiProvider(
     }
 
     @Synchronized
-    fun getEdaApiService(): EdaApiService {
+    override fun getEdaApiService(): EdaApiService {
         val instance = tokenManager.activeInstance.value
             ?: throw IllegalStateException("No active AAP instance. Please log in first.")
 
@@ -61,7 +61,7 @@ class AapApiProvider(
     }
 
     @Synchronized
-    fun evictInstance(instanceId: String) {
+    override fun evictInstance(instanceId: String) {
         serviceCache.remove(instanceId)
     }
 

--- a/app/src/main/kotlin/com/example/aapremote/network/IAapApiProvider.kt
+++ b/app/src/main/kotlin/com/example/aapremote/network/IAapApiProvider.kt
@@ -1,0 +1,7 @@
+package com.example.aapremote.network
+
+interface IAapApiProvider {
+    fun getApiService(): AapApiService
+    fun getEdaApiService(): EdaApiService
+    fun evictInstance(instanceId: String)
+}

--- a/app/src/main/kotlin/com/example/aapremote/network/NetworkModule.kt
+++ b/app/src/main/kotlin/com/example/aapremote/network/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.example.aapremote.network
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val networkJson = Json {
@@ -19,7 +20,7 @@ val networkModule = module {
             tokenManager = get(),
             json = networkJson
         )
-    }
+    } bind IAapApiProvider::class
 
     factory {
         OkHttpClient.Builder()

--- a/app/src/main/kotlin/com/example/aapremote/presentation/auth/AuthViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/auth/AuthViewModel.kt
@@ -2,7 +2,7 @@ package com.example.aapremote.presentation.auth
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.data.AuthRepository
+import com.example.aapremote.data.IAuthRepository
 import com.example.aapremote.model.AppError
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class AuthViewModel(
-    private val authRepository: AuthRepository
+    private val authRepository: IAuthRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<AuthUiState>(AuthUiState.Idle)

--- a/app/src/main/kotlin/com/example/aapremote/presentation/eda/EdaAuditViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/eda/EdaAuditViewModel.kt
@@ -2,8 +2,8 @@ package com.example.aapremote.presentation.eda
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.data.EdaAuditRepository
-import com.example.aapremote.data.TokenManager
+import com.example.aapremote.data.IEdaAuditRepository
+import com.example.aapremote.data.ITokenManager
 import com.example.aapremote.model.AppError
 import com.example.aapremote.model.EdaRuleAudit
 import kotlinx.coroutines.Job
@@ -15,8 +15,8 @@ import kotlinx.coroutines.launch
 import retrofit2.HttpException
 
 class EdaAuditViewModel(
-    private val edaAuditRepository: EdaAuditRepository,
-    private val tokenManager: TokenManager
+    private val edaAuditRepository: IEdaAuditRepository,
+    private val tokenManager: ITokenManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<EdaAuditUiState>(EdaAuditUiState.Loading)

--- a/app/src/main/kotlin/com/example/aapremote/presentation/hosts/HostsViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/hosts/HostsViewModel.kt
@@ -2,8 +2,8 @@ package com.example.aapremote.presentation.hosts
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.data.HostRepository
-import com.example.aapremote.data.TokenManager
+import com.example.aapremote.data.IHostRepository
+import com.example.aapremote.data.ITokenManager
 import com.example.aapremote.model.AppError
 import com.example.aapremote.model.Host
 import kotlinx.coroutines.Job
@@ -15,8 +15,8 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.launch
 
 class HostsViewModel(
-    private val hostRepository: HostRepository,
-    private val tokenManager: TokenManager
+    private val hostRepository: IHostRepository,
+    private val tokenManager: ITokenManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<HostsUiState>(HostsUiState.Loading)

--- a/app/src/main/kotlin/com/example/aapremote/presentation/hosts/InventoryHostsViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/hosts/InventoryHostsViewModel.kt
@@ -2,7 +2,7 @@ package com.example.aapremote.presentation.hosts
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.data.HostRepository
+import com.example.aapremote.data.IHostRepository
 import com.example.aapremote.model.AppError
 import com.example.aapremote.model.Host
 import kotlinx.coroutines.Job
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class InventoryHostsViewModel(
-    private val hostRepository: HostRepository
+    private val hostRepository: IHostRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<InventoryHostsUiState>(InventoryHostsUiState.Loading)

--- a/app/src/main/kotlin/com/example/aapremote/presentation/inventory/InventoriesViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/inventory/InventoriesViewModel.kt
@@ -2,8 +2,8 @@ package com.example.aapremote.presentation.inventory
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.data.InventoryRepository
-import com.example.aapremote.data.TokenManager
+import com.example.aapremote.data.IInventoryRepository
+import com.example.aapremote.data.ITokenManager
 import com.example.aapremote.model.AppError
 import com.example.aapremote.model.Inventory
 import kotlinx.coroutines.Job
@@ -14,8 +14,8 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.launch
 
 class InventoriesViewModel(
-    private val inventoryRepository: InventoryRepository,
-    private val tokenManager: TokenManager
+    private val inventoryRepository: IInventoryRepository,
+    private val tokenManager: ITokenManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<InventoriesUiState>(InventoriesUiState.Loading)

--- a/app/src/main/kotlin/com/example/aapremote/presentation/jobs/JobStatusViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/jobs/JobStatusViewModel.kt
@@ -3,7 +3,7 @@ package com.example.aapremote.presentation.jobs
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.data.JobRepository
+import com.example.aapremote.data.IJobRepository
 import com.example.aapremote.model.AppError
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
 
 class JobStatusViewModel(
     savedStateHandle: SavedStateHandle,
-    private val jobRepository: JobRepository
+    private val jobRepository: IJobRepository
 ) : ViewModel() {
 
     private val jobId: Int = savedStateHandle.get<Int>("jobId") ?: -1

--- a/app/src/main/kotlin/com/example/aapremote/presentation/jobs/RecentJobsViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/jobs/RecentJobsViewModel.kt
@@ -2,8 +2,8 @@ package com.example.aapremote.presentation.jobs
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.data.JobRepository
-import com.example.aapremote.data.TokenManager
+import com.example.aapremote.data.IJobRepository
+import com.example.aapremote.data.ITokenManager
 import com.example.aapremote.model.AppError
 import com.example.aapremote.model.Job
 import com.example.aapremote.model.JobStatus
@@ -14,8 +14,8 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.launch
 
 class RecentJobsViewModel(
-    private val jobRepository: JobRepository,
-    private val tokenManager: TokenManager
+    private val jobRepository: IJobRepository,
+    private val tokenManager: ITokenManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<RecentJobsUiState>(RecentJobsUiState.Loading)

--- a/app/src/main/kotlin/com/example/aapremote/presentation/schedules/SchedulesViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/schedules/SchedulesViewModel.kt
@@ -2,8 +2,8 @@ package com.example.aapremote.presentation.schedules
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.data.ScheduleRepository
-import com.example.aapremote.data.TokenManager
+import com.example.aapremote.data.IScheduleRepository
+import com.example.aapremote.data.ITokenManager
 import com.example.aapremote.model.AppError
 import com.example.aapremote.model.Schedule
 import kotlinx.coroutines.Job
@@ -17,8 +17,8 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.launch
 
 class SchedulesViewModel(
-    private val scheduleRepository: ScheduleRepository,
-    private val tokenManager: TokenManager
+    private val scheduleRepository: IScheduleRepository,
+    private val tokenManager: ITokenManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<SchedulesUiState>(SchedulesUiState.Loading)

--- a/app/src/main/kotlin/com/example/aapremote/presentation/settings/BackupViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/settings/BackupViewModel.kt
@@ -2,8 +2,8 @@ package com.example.aapremote.presentation.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.assistant.data.AssistantRepository
-import com.example.aapremote.data.TokenManager
+import com.example.aapremote.assistant.data.IAssistantRepository
+import com.example.aapremote.data.ITokenManager
 import com.example.aapremote.assistant.data.LlmProviderConfig
 import com.example.aapremote.data.backup.BackupDecryptionException
 import com.example.aapremote.data.backup.BackupEnvelope
@@ -36,8 +36,8 @@ sealed interface BackupUiState {
 
 class BackupViewModel(
     private val backupManager: BackupManager,
-    private val tokenManager: TokenManager,
-    private val assistantRepository: AssistantRepository
+    private val tokenManager: ITokenManager,
+    private val assistantRepository: IAssistantRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<BackupUiState>(BackupUiState.Idle)

--- a/app/src/main/kotlin/com/example/aapremote/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/settings/SettingsViewModel.kt
@@ -2,9 +2,9 @@ package com.example.aapremote.presentation.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.data.TokenManager
+import com.example.aapremote.data.ITokenManager
 import com.example.aapremote.model.AapInstance
-import com.example.aapremote.network.AapApiProvider
+import com.example.aapremote.network.IAapApiProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -12,8 +12,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 class SettingsViewModel(
-    private val tokenManager: TokenManager,
-    private val apiProvider: AapApiProvider
+    private val tokenManager: ITokenManager,
+    private val apiProvider: IAapApiProvider
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Idle)

--- a/app/src/main/kotlin/com/example/aapremote/presentation/templates/TemplatesViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/templates/TemplatesViewModel.kt
@@ -2,8 +2,8 @@ package com.example.aapremote.presentation.templates
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.data.TemplateRepository
-import com.example.aapremote.data.TokenManager
+import com.example.aapremote.data.ITemplateRepository
+import com.example.aapremote.data.ITokenManager
 import com.example.aapremote.model.AppError
 import com.example.aapremote.model.JobTemplate
 import com.example.aapremote.model.Label
@@ -16,8 +16,8 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.launch
 
 class TemplatesViewModel(
-    private val templateRepository: TemplateRepository,
-    private val tokenManager: TokenManager
+    private val templateRepository: ITemplateRepository,
+    private val tokenManager: ITokenManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<TemplatesUiState>(TemplatesUiState.Idle)

--- a/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowJobStatusViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowJobStatusViewModel.kt
@@ -3,8 +3,8 @@ package com.example.aapremote.presentation.workflows
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.data.JobRepository
-import com.example.aapremote.data.WorkflowRepository
+import com.example.aapremote.data.IJobRepository
+import com.example.aapremote.data.IWorkflowRepository
 import com.example.aapremote.model.AppError
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,8 +21,8 @@ sealed interface NodeStdoutState {
 
 class WorkflowJobStatusViewModel(
     savedStateHandle: SavedStateHandle,
-    private val workflowRepository: WorkflowRepository,
-    private val jobRepository: JobRepository
+    private val workflowRepository: IWorkflowRepository,
+    private val jobRepository: IJobRepository
 ) : ViewModel() {
 
     private val workflowJobId: Int = savedStateHandle.get<Int>("workflowJobId") ?: -1

--- a/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesViewModel.kt
@@ -2,8 +2,8 @@ package com.example.aapremote.presentation.workflows
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.aapremote.data.TokenManager
-import com.example.aapremote.data.WorkflowRepository
+import com.example.aapremote.data.ITokenManager
+import com.example.aapremote.data.IWorkflowRepository
 import com.example.aapremote.model.AppError
 import com.example.aapremote.model.Label
 import com.example.aapremote.model.WorkflowJobTemplate
@@ -16,8 +16,8 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.launch
 
 class WorkflowTemplatesViewModel(
-    private val workflowRepository: WorkflowRepository,
-    private val tokenManager: TokenManager
+    private val workflowRepository: IWorkflowRepository,
+    private val tokenManager: ITokenManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<WorkflowTemplatesUiState>(WorkflowTemplatesUiState.Idle)

--- a/app/src/test/kotlin/com/example/aapremote/MainDispatcherRule.kt
+++ b/app/src/test/kotlin/com/example/aapremote/MainDispatcherRule.kt
@@ -1,0 +1,21 @@
+package com.example.aapremote
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+class MainDispatcherRule(
+    private val dispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/TestData.kt
+++ b/app/src/test/kotlin/com/example/aapremote/TestData.kt
@@ -1,0 +1,185 @@
+package com.example.aapremote
+
+import com.example.aapremote.model.AapInstance
+import com.example.aapremote.model.Job
+import com.example.aapremote.model.JobStatus
+import com.example.aapremote.model.JobSummaryFields
+import com.example.aapremote.model.JobTemplate
+import com.example.aapremote.model.JobTemplateSummaryFields
+import com.example.aapremote.model.JobTemplateRef
+import com.example.aapremote.model.Label
+import com.example.aapremote.model.LabelSummary
+import com.example.aapremote.model.WorkflowJob
+import com.example.aapremote.model.WorkflowJobSummaryFields
+import com.example.aapremote.model.WorkflowJobTemplate
+import com.example.aapremote.model.WorkflowJobTemplateRef
+import com.example.aapremote.model.WorkflowNode
+import com.example.aapremote.model.WorkflowNodeJob
+import com.example.aapremote.model.WorkflowNodeSummaryFields
+import com.example.aapremote.model.EdaRuleAudit
+import com.example.aapremote.model.Host
+import com.example.aapremote.model.Inventory
+import com.example.aapremote.model.Schedule
+import com.example.aapremote.model.ScheduleSummaryFields
+import com.example.aapremote.model.UnifiedJobTemplateRef
+import com.example.aapremote.model.WorkflowTemplateSummaryFields
+
+val testInstance = AapInstance(
+    id = "test-instance-1",
+    baseUrl = "https://aap.example.com",
+    token = "test-token-123"
+)
+
+val testInstance2 = AapInstance(
+    id = "test-instance-2",
+    baseUrl = "https://aap2.example.com",
+    token = "test-token-456"
+)
+
+val testLabel1 = Label(id = 1, name = "production")
+val testLabel2 = Label(id = 2, name = "staging")
+
+fun testJobTemplate(
+    id: Int = 1,
+    name: String = "Deploy App",
+    description: String = "Deploy the application",
+    askVariablesOnLaunch: Boolean = false,
+    labels: List<Label> = emptyList()
+) = JobTemplate(
+    id = id,
+    name = name,
+    description = description,
+    askVariablesOnLaunch = askVariablesOnLaunch,
+    summaryFields = JobTemplateSummaryFields(
+        labels = LabelSummary(count = labels.size, results = labels)
+    )
+)
+
+fun testJob(
+    id: Int = 1,
+    name: String = "Deploy App",
+    status: JobStatus = JobStatus.RUNNING,
+    failed: Boolean = false,
+    started: String? = "2024-01-15T10:00:00Z",
+    finished: String? = null,
+    elapsed: Double? = null,
+    templateId: Int = 1,
+    templateName: String = "Deploy App"
+) = Job(
+    id = id,
+    name = name,
+    status = status,
+    failed = failed,
+    started = started,
+    finished = finished,
+    elapsed = elapsed,
+    summaryFields = JobSummaryFields(
+        jobTemplate = JobTemplateRef(id = templateId, name = templateName)
+    )
+)
+
+fun testWorkflowJobTemplate(
+    id: Int = 1,
+    name: String = "Full Deploy Pipeline",
+    description: String = "Complete deployment workflow",
+    askVariablesOnLaunch: Boolean = false,
+    labels: List<Label> = emptyList()
+) = WorkflowJobTemplate(
+    id = id,
+    name = name,
+    description = description,
+    askVariablesOnLaunch = askVariablesOnLaunch,
+    summaryFields = WorkflowTemplateSummaryFields(
+        labels = LabelSummary(count = labels.size, results = labels)
+    )
+)
+
+fun testWorkflowJob(
+    id: Int = 1,
+    name: String = "Full Deploy Pipeline",
+    status: JobStatus = JobStatus.RUNNING,
+    failed: Boolean = false,
+    started: String? = "2024-01-15T10:00:00Z",
+    finished: String? = null,
+    elapsed: Double? = null,
+    templateId: Int = 1,
+    templateName: String = "Full Deploy Pipeline"
+) = WorkflowJob(
+    id = id,
+    name = name,
+    status = status,
+    failed = failed,
+    started = started,
+    finished = finished,
+    elapsed = elapsed,
+    summaryFields = WorkflowJobSummaryFields(
+        workflowJobTemplate = WorkflowJobTemplateRef(id = templateId, name = templateName)
+    )
+)
+
+fun testWorkflowNode(
+    id: Int = 1,
+    jobId: Int = 10,
+    jobName: String = "Step 1",
+    jobStatus: JobStatus = JobStatus.SUCCESSFUL,
+    doNotRun: Boolean = false
+) = WorkflowNode(
+    id = id,
+    summaryFields = WorkflowNodeSummaryFields(
+        job = WorkflowNodeJob(id = jobId, name = jobName, status = jobStatus)
+    ),
+    doNotRun = doNotRun
+)
+
+object TestData {
+    val testInstance = com.example.aapremote.testInstance
+    val testInstance2 = com.example.aapremote.testInstance2
+
+    fun createInventory(id: Int, name: String = "Inventory $id") = Inventory(
+        id = id,
+        name = name,
+        description = "Test inventory $id",
+        totalHosts = id * 10,
+        totalGroups = id * 2
+    )
+
+    fun createHost(id: Int, name: String = "host-$id.example.com") = Host(
+        id = id,
+        name = name,
+        description = "Test host $id",
+        enabled = true,
+        inventory = 1
+    )
+
+    fun createSchedule(
+        id: Int,
+        name: String = "Schedule $id",
+        enabled: Boolean = true
+    ) = Schedule(
+        id = id,
+        name = name,
+        enabled = enabled,
+        rrule = "DTSTART:20240101T000000Z RRULE:FREQ=DAILY",
+        summaryFields = ScheduleSummaryFields(
+            unifiedJobTemplate = UnifiedJobTemplateRef(
+                id = id * 10,
+                name = "Template for $name"
+            )
+        )
+    )
+
+    fun createEdaRuleAudit(id: Int, name: String = "Rule Audit $id") = EdaRuleAudit(
+        id = id,
+        name = name,
+        status = "successful",
+        firedAt = "2024-01-01T00:00:00Z",
+        ruleName = "rule-$id",
+        ruleSetName = "ruleset-$id",
+        activationName = "activation-$id"
+    )
+
+    val sampleInventories = (1..3).map { createInventory(it) }
+    val sampleHosts = (1..3).map { createHost(it) }
+    val sampleSchedules = (1..3).map { createSchedule(it) }
+    val sampleEdaRuleAudits = (1..3).map { createEdaRuleAudit(it) }
+}

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeAapApiProvider.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeAapApiProvider.kt
@@ -1,0 +1,21 @@
+package com.example.aapremote.fakes
+
+import com.example.aapremote.network.AapApiService
+import com.example.aapremote.network.EdaApiService
+import com.example.aapremote.network.IAapApiProvider
+
+class FakeAapApiProvider : IAapApiProvider {
+    val evictedInstances = mutableListOf<String>()
+
+    override fun getApiService(): AapApiService {
+        throw UnsupportedOperationException("Use repository fakes instead")
+    }
+
+    override fun getEdaApiService(): EdaApiService {
+        throw UnsupportedOperationException("Use repository fakes instead")
+    }
+
+    override fun evictInstance(instanceId: String) {
+        evictedInstances.add(instanceId)
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeAssistantRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeAssistantRepository.kt
@@ -1,0 +1,26 @@
+package com.example.aapremote.fakes
+
+import com.example.aapremote.assistant.data.IAssistantRepository
+import com.example.aapremote.assistant.data.LlmProviderConfig
+import com.example.aapremote.assistant.engine.ChatMessage
+
+class FakeAssistantRepository : IAssistantRepository {
+    private val messages = mutableListOf<ChatMessage>()
+    var savedConfig: LlmProviderConfig? = null
+
+    override fun addMessage(message: ChatMessage) {
+        messages.add(message)
+    }
+
+    override fun getHistory(): List<ChatMessage> = messages.toList()
+
+    override fun clearHistory() {
+        messages.clear()
+    }
+
+    override suspend fun saveLlmConfig(config: LlmProviderConfig) {
+        savedConfig = config
+    }
+
+    override suspend fun loadLlmConfig(): LlmProviderConfig? = savedConfig
+}

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeAuthRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeAuthRepository.kt
@@ -1,0 +1,48 @@
+package com.example.aapremote.fakes
+
+import com.example.aapremote.data.IAuthRepository
+import com.example.aapremote.model.User
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeAuthRepository : IAuthRepository {
+    var validateResult: Result<User>? = null
+    var shouldFail = false
+    var failureException: Exception = RuntimeException("Test error")
+    var existingCredentialsResult: Result<User>? = null
+    private val _isLoggedIn = MutableStateFlow(false)
+
+    override suspend fun validateCredentials(
+        baseUrl: String,
+        token: String,
+        trustSelfSigned: Boolean,
+        alias: String?,
+        existingInstanceId: String?
+    ): Result<User> {
+        if (shouldFail) return Result.failure(failureException)
+        return validateResult ?: Result.failure(RuntimeException("No result configured"))
+    }
+
+    override suspend fun reAuthenticate(instanceId: String, newToken: String): Result<User> {
+        if (shouldFail) return Result.failure(failureException)
+        return validateResult ?: Result.failure(RuntimeException("No result configured"))
+    }
+
+    override suspend fun checkExistingCredentials(): Result<User>? {
+        return existingCredentialsResult
+    }
+
+    override suspend fun logoutInstance(instanceId: String) {
+        _isLoggedIn.value = false
+    }
+
+    override suspend fun logout() {
+        _isLoggedIn.value = false
+    }
+
+    override fun isLoggedIn(): Flow<Boolean> = _isLoggedIn
+
+    fun setLoggedIn(loggedIn: Boolean) {
+        _isLoggedIn.value = loggedIn
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeEdaAuditRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeEdaAuditRepository.kt
@@ -1,0 +1,16 @@
+package com.example.aapremote.fakes
+
+import com.example.aapremote.data.EdaAuditResult
+import com.example.aapremote.data.IEdaAuditRepository
+import com.example.aapremote.model.EdaRuleAudit
+
+class FakeEdaAuditRepository : IEdaAuditRepository {
+    var auditRules = listOf<EdaRuleAudit>()
+    var shouldFail = false
+    var failureException: Exception = RuntimeException("Test error")
+
+    override suspend fun getAuditRules(page: Int, pageSize: Int): Result<EdaAuditResult> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(EdaAuditResult(auditRules, hasMore = false, totalCount = auditRules.size))
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeEdaAuditRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeEdaAuditRepository.kt
@@ -8,9 +8,10 @@ class FakeEdaAuditRepository : IEdaAuditRepository {
     var auditRules = listOf<EdaRuleAudit>()
     var shouldFail = false
     var failureException: Exception = RuntimeException("Test error")
+    var hasMore = false
 
     override suspend fun getAuditRules(page: Int, pageSize: Int): Result<EdaAuditResult> {
         if (shouldFail) return Result.failure(failureException)
-        return Result.success(EdaAuditResult(auditRules, hasMore = false, totalCount = auditRules.size))
+        return Result.success(EdaAuditResult(auditRules, hasMore = hasMore, totalCount = auditRules.size))
     }
 }

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeHostRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeHostRepository.kt
@@ -1,0 +1,37 @@
+package com.example.aapremote.fakes
+
+import com.example.aapremote.data.HostListResult
+import com.example.aapremote.data.IHostRepository
+import com.example.aapremote.data.JobHostSummaryResult
+import com.example.aapremote.model.Host
+import com.example.aapremote.model.JobHostSummary
+import kotlinx.serialization.json.JsonElement
+
+class FakeHostRepository : IHostRepository {
+    var hosts = listOf<Host>()
+    var inventoryHosts = listOf<Host>()
+    var hostFacts = mapOf<String, JsonElement>()
+    var jobSummaries = listOf<JobHostSummary>()
+    var shouldFail = false
+    var failureException: Exception = RuntimeException("Test error")
+
+    override suspend fun getAllHosts(page: Int, pageSize: Int, search: String?): Result<HostListResult> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(HostListResult(hosts, hasMore = false, totalCount = hosts.size))
+    }
+
+    override suspend fun getInventoryHosts(inventoryId: Int, page: Int, pageSize: Int, search: String?): Result<HostListResult> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(HostListResult(inventoryHosts, hasMore = false, totalCount = inventoryHosts.size))
+    }
+
+    override suspend fun getHostFacts(hostId: Int): Result<Map<String, JsonElement>> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(hostFacts)
+    }
+
+    override suspend fun getHostJobSummaries(hostId: Int, page: Int, pageSize: Int): Result<JobHostSummaryResult> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(JobHostSummaryResult(jobSummaries, hasMore = false, totalCount = jobSummaries.size))
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeHostRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeHostRepository.kt
@@ -14,15 +14,17 @@ class FakeHostRepository : IHostRepository {
     var jobSummaries = listOf<JobHostSummary>()
     var shouldFail = false
     var failureException: Exception = RuntimeException("Test error")
+    var hasMore = false
+    var inventoryHostsHasMore = false
 
     override suspend fun getAllHosts(page: Int, pageSize: Int, search: String?): Result<HostListResult> {
         if (shouldFail) return Result.failure(failureException)
-        return Result.success(HostListResult(hosts, hasMore = false, totalCount = hosts.size))
+        return Result.success(HostListResult(hosts, hasMore = hasMore, totalCount = hosts.size))
     }
 
     override suspend fun getInventoryHosts(inventoryId: Int, page: Int, pageSize: Int, search: String?): Result<HostListResult> {
         if (shouldFail) return Result.failure(failureException)
-        return Result.success(HostListResult(inventoryHosts, hasMore = false, totalCount = inventoryHosts.size))
+        return Result.success(HostListResult(inventoryHosts, hasMore = inventoryHostsHasMore, totalCount = inventoryHosts.size))
     }
 
     override suspend fun getHostFacts(hostId: Int): Result<Map<String, JsonElement>> {

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeInventoryRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeInventoryRepository.kt
@@ -1,0 +1,22 @@
+package com.example.aapremote.fakes
+
+import com.example.aapremote.data.IInventoryRepository
+import com.example.aapremote.data.InventoryListResult
+import com.example.aapremote.model.Inventory
+
+class FakeInventoryRepository : IInventoryRepository {
+    var inventories = listOf<Inventory>()
+    var shouldFail = false
+    var failureException: Exception = RuntimeException("Test error")
+
+    override suspend fun getInventories(page: Int, pageSize: Int, search: String?): Result<InventoryListResult> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(InventoryListResult(inventories, hasMore = false, totalCount = inventories.size))
+    }
+
+    override suspend fun getInventory(id: Int): Result<Inventory> {
+        if (shouldFail) return Result.failure(failureException)
+        val inv = inventories.find { it.id == id }
+        return if (inv != null) Result.success(inv) else Result.failure(RuntimeException("Not found"))
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeInventoryRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeInventoryRepository.kt
@@ -8,10 +8,17 @@ class FakeInventoryRepository : IInventoryRepository {
     var inventories = listOf<Inventory>()
     var shouldFail = false
     var failureException: Exception = RuntimeException("Test error")
+    var hasMore = false
+    private var resultOverride: ((Int) -> Result<InventoryListResult>)? = null
+
+    fun setResultForPage(block: (Int) -> Result<InventoryListResult>) {
+        resultOverride = block
+    }
 
     override suspend fun getInventories(page: Int, pageSize: Int, search: String?): Result<InventoryListResult> {
+        resultOverride?.let { return it(page) }
         if (shouldFail) return Result.failure(failureException)
-        return Result.success(InventoryListResult(inventories, hasMore = false, totalCount = inventories.size))
+        return Result.success(InventoryListResult(inventories, hasMore = hasMore, totalCount = inventories.size))
     }
 
     override suspend fun getInventory(id: Int): Result<Inventory> {

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeJobRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeJobRepository.kt
@@ -1,0 +1,38 @@
+package com.example.aapremote.fakes
+
+import com.example.aapremote.data.IJobRepository
+import com.example.aapremote.data.RecentJobsResult
+import com.example.aapremote.model.Job
+import com.example.aapremote.model.JobStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class FakeJobRepository : IJobRepository {
+    var jobs = listOf<Job>()
+    var jobStdout = ""
+    var shouldFail = false
+    var failureException: Exception = RuntimeException("Test error")
+    var polledJob: Job? = null
+
+    override suspend fun getJobStatus(jobId: Int): Result<Job> {
+        if (shouldFail) return Result.failure(failureException)
+        val job = jobs.find { it.id == jobId } ?: polledJob
+        return if (job != null) Result.success(job)
+        else Result.failure(RuntimeException("Job not found"))
+    }
+
+    override fun pollJobStatus(jobId: Int): Flow<Job> = flow {
+        if (shouldFail) throw failureException
+        polledJob?.let { emit(it) }
+    }
+
+    override suspend fun getJobStdout(jobId: Int): Result<String> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(jobStdout)
+    }
+
+    override suspend fun getRecentJobs(page: Int, pageSize: Int, statusFilters: Set<JobStatus>): Result<RecentJobsResult> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(RecentJobsResult(jobs, hasMore = false, totalCount = jobs.size))
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeJobRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeJobRepository.kt
@@ -11,8 +11,11 @@ class FakeJobRepository : IJobRepository {
     var jobs = listOf<Job>()
     var jobStdout = ""
     var shouldFail = false
+    var stdoutShouldFail = false
     var failureException: Exception = RuntimeException("Test error")
     var polledJob: Job? = null
+    var hasMore = false
+    var lastRequestedPage = 0
 
     override suspend fun getJobStatus(jobId: Int): Result<Job> {
         if (shouldFail) return Result.failure(failureException)
@@ -27,12 +30,13 @@ class FakeJobRepository : IJobRepository {
     }
 
     override suspend fun getJobStdout(jobId: Int): Result<String> {
-        if (shouldFail) return Result.failure(failureException)
+        if (stdoutShouldFail) return Result.failure(failureException)
         return Result.success(jobStdout)
     }
 
     override suspend fun getRecentJobs(page: Int, pageSize: Int, statusFilters: Set<JobStatus>): Result<RecentJobsResult> {
+        lastRequestedPage = page
         if (shouldFail) return Result.failure(failureException)
-        return Result.success(RecentJobsResult(jobs, hasMore = false, totalCount = jobs.size))
+        return Result.success(RecentJobsResult(jobs, hasMore = hasMore, totalCount = jobs.size))
     }
 }

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeScheduleRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeScheduleRepository.kt
@@ -9,15 +9,19 @@ class FakeScheduleRepository : IScheduleRepository {
     var shouldFail = false
     var failureException: Exception = RuntimeException("Test error")
     var toggleResult: Schedule? = null
+    var toggleShouldFail = false
+    var toggleFailureException: Exception = RuntimeException("Toggle failed")
+    var hasMore = false
 
     override suspend fun getSchedules(page: Int, pageSize: Int): Result<SchedulesResult> {
         if (shouldFail) return Result.failure(failureException)
-        return Result.success(SchedulesResult(schedules, hasMore = false, totalCount = schedules.size))
+        return Result.success(SchedulesResult(schedules, hasMore = hasMore, totalCount = schedules.size))
     }
 
     override suspend fun toggleSchedule(id: Int, enabled: Boolean): Result<Schedule> {
+        if (toggleShouldFail) return Result.failure(toggleFailureException)
         if (shouldFail) return Result.failure(failureException)
-        val schedule = toggleResult ?: schedules.find { it.id == id }
+        val schedule = toggleResult ?: schedules.find { it.id == id }?.copy(enabled = enabled)
         return if (schedule != null) Result.success(schedule) else Result.failure(RuntimeException("Not found"))
     }
 }

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeScheduleRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeScheduleRepository.kt
@@ -1,0 +1,23 @@
+package com.example.aapremote.fakes
+
+import com.example.aapremote.data.IScheduleRepository
+import com.example.aapremote.data.SchedulesResult
+import com.example.aapremote.model.Schedule
+
+class FakeScheduleRepository : IScheduleRepository {
+    var schedules = listOf<Schedule>()
+    var shouldFail = false
+    var failureException: Exception = RuntimeException("Test error")
+    var toggleResult: Schedule? = null
+
+    override suspend fun getSchedules(page: Int, pageSize: Int): Result<SchedulesResult> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(SchedulesResult(schedules, hasMore = false, totalCount = schedules.size))
+    }
+
+    override suspend fun toggleSchedule(id: Int, enabled: Boolean): Result<Schedule> {
+        if (shouldFail) return Result.failure(failureException)
+        val schedule = toggleResult ?: schedules.find { it.id == id }
+        return if (schedule != null) Result.success(schedule) else Result.failure(RuntimeException("Not found"))
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeTemplateRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeTemplateRepository.kt
@@ -11,11 +11,18 @@ class FakeTemplateRepository : ITemplateRepository {
     var launchResult = 42
     var getTemplatesCalled = 0
     var launchJobCalled = 0
+    var hasMore = false
+    var lastRequestedPage = 0
+    var lastSearchQuery: String? = null
+    var lastLabelFilter: String? = null
 
     override suspend fun getTemplates(page: Int, search: String?, labelFilter: String?): Result<TemplateListResult> {
         getTemplatesCalled++
+        lastRequestedPage = page
+        lastSearchQuery = search
+        lastLabelFilter = labelFilter
         if (shouldFail) return Result.failure(failureException)
-        return Result.success(TemplateListResult(templates, hasMore = false, totalCount = templates.size))
+        return Result.success(TemplateListResult(templates, hasMore = hasMore, totalCount = templates.size))
     }
 
     override suspend fun launchJob(templateId: Int, extraVars: String?): Result<Int> {

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeTemplateRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeTemplateRepository.kt
@@ -1,0 +1,26 @@
+package com.example.aapremote.fakes
+
+import com.example.aapremote.data.ITemplateRepository
+import com.example.aapremote.data.TemplateListResult
+import com.example.aapremote.model.JobTemplate
+
+class FakeTemplateRepository : ITemplateRepository {
+    var templates = listOf<JobTemplate>()
+    var shouldFail = false
+    var failureException: Exception = RuntimeException("Test error")
+    var launchResult = 42
+    var getTemplatesCalled = 0
+    var launchJobCalled = 0
+
+    override suspend fun getTemplates(page: Int, search: String?, labelFilter: String?): Result<TemplateListResult> {
+        getTemplatesCalled++
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(TemplateListResult(templates, hasMore = false, totalCount = templates.size))
+    }
+
+    override suspend fun launchJob(templateId: Int, extraVars: String?): Result<Int> {
+        launchJobCalled++
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(launchResult)
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeTokenManager.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeTokenManager.kt
@@ -1,0 +1,107 @@
+package com.example.aapremote.fakes
+
+import com.example.aapremote.data.ITokenManager
+import com.example.aapremote.model.AapInstance
+import com.example.aapremote.model.McpServerConfig
+import com.example.aapremote.network.ApiVersion
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+
+class FakeTokenManager : ITokenManager {
+    private val _instances = MutableStateFlow<List<AapInstance>>(emptyList())
+    override val instances: StateFlow<List<AapInstance>> = _instances.asStateFlow()
+
+    private val _activeInstance = MutableStateFlow<AapInstance?>(null)
+    override val activeInstance: StateFlow<AapInstance?> = _activeInstance.asStateFlow()
+
+    override val isLoggedIn: Flow<Boolean> = _instances.map { it.isNotEmpty() }
+
+    var saveInstanceResult: String = "test-id"
+
+    override suspend fun saveInstance(
+        baseUrl: String,
+        token: String,
+        alias: String?,
+        apiVersion: ApiVersion,
+        trustSelfSigned: Boolean,
+        certFingerprint: String?,
+        existingId: String?
+    ): String {
+        val id = existingId ?: saveInstanceResult
+        val instance = AapInstance(
+            id = id,
+            baseUrl = baseUrl,
+            token = token,
+            alias = alias,
+            apiVersion = apiVersion.name,
+            trustSelfSigned = trustSelfSigned,
+            certFingerprint = certFingerprint
+        )
+        _instances.value = _instances.value + instance
+        if (_activeInstance.value == null) _activeInstance.value = instance
+        return id
+    }
+
+    override suspend fun removeInstance(instanceId: String): Boolean {
+        val before = _instances.value.size
+        _instances.value = _instances.value.filter { it.id != instanceId }
+        if (_activeInstance.value?.id == instanceId) {
+            _activeInstance.value = _instances.value.firstOrNull()
+        }
+        return _instances.value.size < before
+    }
+
+    override suspend fun setActiveInstance(instanceId: String) {
+        _activeInstance.value = _instances.value.find { it.id == instanceId }
+    }
+
+    override fun getInstanceById(instanceId: String): AapInstance? {
+        return _instances.value.find { it.id == instanceId }
+    }
+
+    override suspend fun loadCredentials(): Boolean {
+        return _instances.value.isNotEmpty()
+    }
+
+    override suspend fun saveCredentials(
+        baseUrl: String,
+        token: String,
+        apiVersion: ApiVersion,
+        trustSelfSigned: Boolean,
+        certFingerprint: String?,
+        alias: String?,
+        existingId: String?
+    ): String = saveInstance(baseUrl, token, alias, apiVersion, trustSelfSigned, certFingerprint, existingId)
+
+    override suspend fun updateMcpConfig(
+        instanceId: String,
+        enabled: Boolean,
+        servers: List<McpServerConfig>?
+    ) {
+        _instances.value = _instances.value.map {
+            if (it.id == instanceId) it.copy(mcpEnabled = enabled, mcpServerUrls = servers) else it
+        }
+        _activeInstance.value?.let { active ->
+            if (active.id == instanceId) {
+                _activeInstance.value = _instances.value.find { it.id == instanceId }
+            }
+        }
+    }
+
+    override suspend fun clearCredentials() {
+        _instances.value = emptyList()
+        _activeInstance.value = null
+    }
+
+    fun setInstances(list: List<AapInstance>) {
+        _instances.value = list
+        _activeInstance.value = list.firstOrNull()
+    }
+
+    fun setActiveInstanceDirect(instance: AapInstance?) {
+        _activeInstance.value = instance
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeWorkflowRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeWorkflowRepository.kt
@@ -1,0 +1,43 @@
+package com.example.aapremote.fakes
+
+import com.example.aapremote.data.IWorkflowRepository
+import com.example.aapremote.data.WorkflowTemplateListResult
+import com.example.aapremote.model.WorkflowJob
+import com.example.aapremote.model.WorkflowJobTemplate
+import com.example.aapremote.model.WorkflowNode
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class FakeWorkflowRepository : IWorkflowRepository {
+    var templates = listOf<WorkflowJobTemplate>()
+    var workflowJob: WorkflowJob? = null
+    var nodes = listOf<WorkflowNode>()
+    var shouldFail = false
+    var failureException: Exception = RuntimeException("Test error")
+    var launchResult = 99
+
+    override suspend fun getWorkflowTemplates(page: Int, search: String?, labelFilter: String?): Result<WorkflowTemplateListResult> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(WorkflowTemplateListResult(templates, hasMore = false, totalCount = templates.size))
+    }
+
+    override suspend fun launchWorkflow(templateId: Int, extraVars: String?): Result<Int> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(launchResult)
+    }
+
+    override suspend fun getWorkflowJobStatus(workflowJobId: Int): Result<WorkflowJob> {
+        if (shouldFail) return Result.failure(failureException)
+        return workflowJob?.let { Result.success(it) } ?: Result.failure(RuntimeException("Not found"))
+    }
+
+    override fun pollWorkflowJobStatus(workflowJobId: Int): Flow<WorkflowJob> = flow {
+        if (shouldFail) throw failureException
+        workflowJob?.let { emit(it) }
+    }
+
+    override suspend fun getWorkflowNodes(workflowJobId: Int): Result<List<WorkflowNode>> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(nodes)
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/fakes/FakeWorkflowRepository.kt
+++ b/app/src/test/kotlin/com/example/aapremote/fakes/FakeWorkflowRepository.kt
@@ -15,10 +15,17 @@ class FakeWorkflowRepository : IWorkflowRepository {
     var shouldFail = false
     var failureException: Exception = RuntimeException("Test error")
     var launchResult = 99
+    var hasMore = false
+    var lastRequestedPage = 0
+    var lastSearchQuery: String? = null
+    var lastLabelFilter: String? = null
 
     override suspend fun getWorkflowTemplates(page: Int, search: String?, labelFilter: String?): Result<WorkflowTemplateListResult> {
+        lastRequestedPage = page
+        lastSearchQuery = search
+        lastLabelFilter = labelFilter
         if (shouldFail) return Result.failure(failureException)
-        return Result.success(WorkflowTemplateListResult(templates, hasMore = false, totalCount = templates.size))
+        return Result.success(WorkflowTemplateListResult(templates, hasMore = hasMore, totalCount = templates.size))
     }
 
     override suspend fun launchWorkflow(templateId: Int, extraVars: String?): Result<Int> {

--- a/app/src/test/kotlin/com/example/aapremote/presentation/auth/AuthViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/presentation/auth/AuthViewModelTest.kt
@@ -1,0 +1,195 @@
+package com.example.aapremote.presentation.auth
+
+import app.cash.turbine.test
+import com.example.aapremote.MainDispatcherRule
+import com.example.aapremote.fakes.FakeAuthRepository
+import com.example.aapremote.model.AppError
+import com.example.aapremote.model.User
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class AuthViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeAuthRepo: FakeAuthRepository
+    private lateinit var viewModel: AuthViewModel
+
+    private val testUser = User(
+        id = 1,
+        username = "admin",
+        firstName = "Test",
+        lastName = "User",
+        email = "admin@example.com",
+        isSuperuser = true
+    )
+
+    @Before
+    fun setup() {
+        fakeAuthRepo = FakeAuthRepository()
+        viewModel = AuthViewModel(fakeAuthRepo)
+    }
+
+    @Test
+    fun `initial state is Idle`() = runTest {
+        assertEquals(AuthUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `connect with valid credentials transitions to Success`() = runTest {
+        fakeAuthRepo.validateResult = Result.success(testUser)
+
+        viewModel.connect(
+            baseUrl = "https://aap.example.com",
+            token = "valid-token",
+            trustSelfSigned = false
+        )
+
+        val state = viewModel.uiState.value
+        assertTrue(state is AuthUiState.Success)
+        assertEquals("admin", (state as AuthUiState.Success).username)
+    }
+
+    @Test
+    fun `connect with blank URL emits Error immediately`() = runTest {
+        viewModel.connect(
+            baseUrl = "",
+            token = "some-token",
+            trustSelfSigned = false
+        )
+
+        val state = viewModel.uiState.value
+        assertTrue(state is AuthUiState.Error)
+        assertEquals(
+            "URL and token are required",
+            (state as AuthUiState.Error).error.message
+        )
+    }
+
+    @Test
+    fun `connect with blank token emits Error immediately`() = runTest {
+        viewModel.connect(
+            baseUrl = "https://aap.example.com",
+            token = "",
+            trustSelfSigned = false
+        )
+
+        val state = viewModel.uiState.value
+        assertTrue(state is AuthUiState.Error)
+        assertEquals(
+            "URL and token are required",
+            (state as AuthUiState.Error).error.message
+        )
+    }
+
+    @Test
+    fun `connect failure transitions to Error with AppError`() = runTest {
+        fakeAuthRepo.shouldFail = true
+        fakeAuthRepo.failureException = RuntimeException("Connection refused")
+
+        viewModel.connect(
+            baseUrl = "https://aap.example.com",
+            token = "bad-token",
+            trustSelfSigned = false
+        )
+
+        val state = viewModel.uiState.value
+        assertTrue(state is AuthUiState.Error)
+        val appError = (state as AuthUiState.Error).error
+        assertTrue(appError is AppError.Unknown)
+        assertEquals("Connection refused", appError.message)
+    }
+
+    @Test
+    fun `resetState returns to Idle from Error`() = runTest {
+        fakeAuthRepo.shouldFail = true
+        viewModel.connect(
+            baseUrl = "https://aap.example.com",
+            token = "token",
+            trustSelfSigned = false
+        )
+        assertTrue(viewModel.uiState.value is AuthUiState.Error)
+
+        viewModel.resetState()
+        assertEquals(AuthUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `resetState returns to Idle from Success`() = runTest {
+        fakeAuthRepo.validateResult = Result.success(testUser)
+        viewModel.connect(
+            baseUrl = "https://aap.example.com",
+            token = "token",
+            trustSelfSigned = false
+        )
+        assertTrue(viewModel.uiState.value is AuthUiState.Success)
+
+        viewModel.resetState()
+        assertEquals(AuthUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `checkExistingCredentials with valid result transitions to Success`() = runTest {
+        fakeAuthRepo.existingCredentialsResult = Result.success(testUser)
+
+        viewModel.checkExistingCredentials()
+
+        val state = viewModel.uiState.value
+        assertTrue(state is AuthUiState.Success)
+        assertEquals("admin", (state as AuthUiState.Success).username)
+    }
+
+    @Test
+    fun `checkExistingCredentials with null result stays Idle`() = runTest {
+        fakeAuthRepo.existingCredentialsResult = null
+
+        viewModel.checkExistingCredentials()
+
+        assertEquals(AuthUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `checkExistingCredentials with failure returns to Idle`() = runTest {
+        fakeAuthRepo.existingCredentialsResult =
+            Result.failure(RuntimeException("Token expired"))
+
+        viewModel.checkExistingCredentials()
+
+        assertEquals(AuthUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `logout transitions to Idle`() = runTest {
+        fakeAuthRepo.validateResult = Result.success(testUser)
+        viewModel.connect(
+            baseUrl = "https://aap.example.com",
+            token = "token",
+            trustSelfSigned = false
+        )
+        assertTrue(viewModel.uiState.value is AuthUiState.Success)
+
+        viewModel.logout()
+
+        assertEquals(AuthUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `connect passes alias and existingInstanceId to repository`() = runTest {
+        fakeAuthRepo.validateResult = Result.success(testUser)
+
+        viewModel.connect(
+            baseUrl = "https://aap.example.com",
+            token = "token",
+            trustSelfSigned = true,
+            alias = "My Server",
+            existingInstanceId = "existing-123"
+        )
+
+        assertTrue(viewModel.uiState.value is AuthUiState.Success)
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/presentation/eda/EdaAuditViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/presentation/eda/EdaAuditViewModelTest.kt
@@ -1,0 +1,246 @@
+package com.example.aapremote.presentation.eda
+
+import app.cash.turbine.test
+import com.example.aapremote.MainDispatcherRule
+import com.example.aapremote.TestData
+import com.example.aapremote.fakes.FakeEdaAuditRepository
+import com.example.aapremote.fakes.FakeTokenManager
+import com.example.aapremote.model.AppError
+import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+
+class EdaAuditViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeRepo: FakeEdaAuditRepository
+    private lateinit var fakeTokenManager: FakeTokenManager
+
+    @Before
+    fun setup() {
+        fakeRepo = FakeEdaAuditRepository()
+        fakeTokenManager = FakeTokenManager()
+    }
+
+    private fun createViewModel(): EdaAuditViewModel {
+        return EdaAuditViewModel(fakeRepo, fakeTokenManager)
+    }
+
+    private fun createHttpException(code: Int): HttpException {
+        val response = Response.error<Any>(code, "".toResponseBody(null))
+        return HttpException(response)
+    }
+
+    @Test
+    fun `initial state is Loading when no active instance`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(EdaAuditUiState.Loading, awaitItem())
+        }
+    }
+
+    @Test
+    fun `loads audit rules when active instance is set`() = runTest {
+        fakeRepo.auditRules = TestData.sampleEdaRuleAudits
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is EdaAuditUiState.Success)
+            val success = state as EdaAuditUiState.Success
+            assertEquals(3, success.auditRules.size)
+            assertEquals("Rule Audit 1", success.auditRules[0].name)
+            assertFalse(success.hasMore)
+        }
+    }
+
+    @Test
+    fun `shows error state when loading fails with generic error`() = runTest {
+        fakeRepo.shouldFail = true
+        fakeRepo.failureException = RuntimeException("Connection timeout")
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is EdaAuditUiState.Error)
+            val error = state as EdaAuditUiState.Error
+            assertTrue(error.error is AppError.Unknown)
+        }
+    }
+
+    @Test
+    fun `shows empty state when no audit rules returned`() = runTest {
+        fakeRepo.auditRules = emptyList()
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is EdaAuditUiState.Empty)
+            assertEquals("No EDA audit events", (state as EdaAuditUiState.Empty).message)
+        }
+    }
+
+    @Test
+    fun `treats 404 as EDA not configured empty state`() = runTest {
+        fakeRepo.shouldFail = true
+        fakeRepo.failureException = createHttpException(404)
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is EdaAuditUiState.Empty)
+            assertEquals(
+                "EDA is not configured on this AAP instance",
+                (state as EdaAuditUiState.Empty).message
+            )
+        }
+    }
+
+    @Test
+    fun `treats 502 as EDA not configured empty state`() = runTest {
+        fakeRepo.shouldFail = true
+        fakeRepo.failureException = createHttpException(502)
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is EdaAuditUiState.Empty)
+            assertEquals(
+                "EDA is not configured on this AAP instance",
+                (state as EdaAuditUiState.Empty).message
+            )
+        }
+    }
+
+    @Test
+    fun `treats 503 as EDA not configured empty state`() = runTest {
+        fakeRepo.shouldFail = true
+        fakeRepo.failureException = createHttpException(503)
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is EdaAuditUiState.Empty)
+            assertEquals(
+                "EDA is not configured on this AAP instance",
+                (state as EdaAuditUiState.Empty).message
+            )
+        }
+    }
+
+    @Test
+    fun `treats 500 as server error, not empty state`() = runTest {
+        fakeRepo.shouldFail = true
+        fakeRepo.failureException = createHttpException(500)
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is EdaAuditUiState.Error)
+            val error = state as EdaAuditUiState.Error
+            assertTrue(error.error is AppError.Server)
+        }
+    }
+
+    @Test
+    fun `loadMore appends audit rules when hasMore is true`() = runTest {
+        fakeRepo.auditRules = TestData.sampleEdaRuleAudits
+        fakeRepo.hasMore = true
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val firstPage = awaitItem()
+            assertTrue(firstPage is EdaAuditUiState.Success)
+            assertEquals(3, (firstPage as EdaAuditUiState.Success).auditRules.size)
+            assertTrue(firstPage.hasMore)
+
+            // Set up page 2 data
+            fakeRepo.auditRules = listOf(TestData.createEdaRuleAudit(4))
+            fakeRepo.hasMore = false
+
+            viewModel.loadMore()
+
+            val loadingMore = awaitItem()
+            assertTrue(loadingMore is EdaAuditUiState.Success)
+            assertTrue((loadingMore as EdaAuditUiState.Success).isLoadingMore)
+
+            val secondPage = awaitItem()
+            assertTrue(secondPage is EdaAuditUiState.Success)
+            assertEquals(4, (secondPage as EdaAuditUiState.Success).auditRules.size)
+            assertFalse(secondPage.hasMore)
+        }
+    }
+
+    @Test
+    fun `refresh reloads audit rules from page 1`() = runTest {
+        fakeRepo.auditRules = TestData.sampleEdaRuleAudits
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem()
+            assertTrue(initial is EdaAuditUiState.Success)
+
+            fakeRepo.auditRules = listOf(TestData.createEdaRuleAudit(99, "Refreshed Rule"))
+            viewModel.refresh()
+
+            val refreshed = awaitItem()
+            assertTrue(refreshed is EdaAuditUiState.Success)
+            assertEquals(1, (refreshed as EdaAuditUiState.Success).auditRules.size)
+            assertEquals("Refreshed Rule", refreshed.auditRules[0].name)
+        }
+    }
+
+    @Test
+    fun `reloads when active instance changes`() = runTest {
+        fakeRepo.auditRules = TestData.sampleEdaRuleAudits
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem()
+            assertTrue(initial is EdaAuditUiState.Success)
+
+            fakeRepo.auditRules = listOf(TestData.createEdaRuleAudit(10, "New Instance Rule"))
+            fakeTokenManager.setInstances(listOf(TestData.testInstance2))
+
+            val loading = awaitItem()
+            assertEquals(EdaAuditUiState.Loading, loading)
+
+            val newState = awaitItem()
+            assertTrue(newState is EdaAuditUiState.Success)
+            assertEquals(
+                "New Instance Rule",
+                (newState as EdaAuditUiState.Success).auditRules[0].name
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/presentation/hosts/HostsViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/presentation/hosts/HostsViewModelTest.kt
@@ -1,0 +1,231 @@
+package com.example.aapremote.presentation.hosts
+
+import app.cash.turbine.test
+import com.example.aapremote.MainDispatcherRule
+import com.example.aapremote.TestData
+import com.example.aapremote.fakes.FakeHostRepository
+import com.example.aapremote.fakes.FakeTokenManager
+import com.example.aapremote.model.AppError
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+@OptIn(ExperimentalCoroutinesApi::class)
+class HostsViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeRepo: FakeHostRepository
+    private lateinit var fakeTokenManager: FakeTokenManager
+
+    @Before
+    fun setup() {
+        fakeRepo = FakeHostRepository()
+        fakeTokenManager = FakeTokenManager()
+    }
+
+    private fun createViewModel(): HostsViewModel {
+        return HostsViewModel(fakeRepo, fakeTokenManager)
+    }
+
+    @Test
+    fun `initial state is Loading when no active instance`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(HostsUiState.Loading, awaitItem())
+        }
+    }
+
+    @Test
+    fun `loads hosts when active instance is set`() = runTest {
+        fakeRepo.hosts = TestData.sampleHosts
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is HostsUiState.Success)
+            val success = state as HostsUiState.Success
+            assertEquals(3, success.hosts.size)
+            assertEquals("host-1.example.com", success.hosts[0].name)
+            assertFalse(success.hasMore)
+        }
+    }
+
+    @Test
+    fun `shows error state when loading fails`() = runTest {
+        fakeRepo.shouldFail = true
+        fakeRepo.failureException = RuntimeException("Connection refused")
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is HostsUiState.Error)
+            val error = state as HostsUiState.Error
+            assertTrue(error.error is AppError.Unknown)
+        }
+    }
+
+    @Test
+    fun `shows empty state when no hosts returned`() = runTest {
+        fakeRepo.hosts = emptyList()
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is HostsUiState.Empty)
+            assertEquals("No hosts found", (state as HostsUiState.Empty).message)
+        }
+    }
+
+    @Test
+    fun `loadMore appends hosts when hasMore is true`() = runTest {
+        fakeRepo.hosts = TestData.sampleHosts
+        fakeRepo.hasMore = true
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val firstPage = awaitItem()
+            assertTrue(firstPage is HostsUiState.Success)
+            assertEquals(3, (firstPage as HostsUiState.Success).hosts.size)
+            assertTrue(firstPage.hasMore)
+
+            // Set up page 2 data
+            fakeRepo.hosts = listOf(TestData.createHost(4))
+            fakeRepo.hasMore = false
+
+            viewModel.loadMore()
+
+            val loadingMore = awaitItem()
+            assertTrue(loadingMore is HostsUiState.Success)
+            assertTrue((loadingMore as HostsUiState.Success).isLoadingMore)
+
+            val secondPage = awaitItem()
+            assertTrue(secondPage is HostsUiState.Success)
+            assertEquals(4, (secondPage as HostsUiState.Success).hosts.size)
+            assertFalse(secondPage.hasMore)
+        }
+    }
+
+    @Test
+    fun `loadMore does nothing when hasMore is false`() = runTest {
+        fakeRepo.hosts = TestData.sampleHosts
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is HostsUiState.Success)
+            assertFalse((state as HostsUiState.Success).hasMore)
+
+            viewModel.loadMore()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `search triggers reload with filtered results`() = runTest {
+        fakeRepo.hosts = TestData.sampleHosts
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        // Wait for initial load to complete
+        val initial = viewModel.uiState.value
+        assertTrue(initial is HostsUiState.Success)
+        assertEquals(3, (initial as HostsUiState.Success).hosts.size)
+
+        // Set up filtered results and trigger search
+        fakeRepo.hosts = listOf(TestData.createHost(1, "webserver-01"))
+        viewModel.search("webserver")
+
+        // Advance past the 300ms debounce delay
+        advanceUntilIdle()
+
+        val result = viewModel.uiState.value
+        assertTrue(result is HostsUiState.Success)
+        assertEquals(1, (result as HostsUiState.Success).hosts.size)
+        assertEquals("webserver-01", result.hosts[0].name)
+    }
+
+    @Test
+    fun `search with blank query clears search filter`() = runTest {
+        fakeRepo.hosts = TestData.sampleHosts
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        // Wait for initial load
+        assertTrue(viewModel.uiState.value is HostsUiState.Success)
+
+        // Search with blank should reload all hosts
+        viewModel.search("")
+        advanceUntilIdle()
+
+        val result = viewModel.uiState.value
+        assertTrue(result is HostsUiState.Success)
+        assertEquals(3, (result as HostsUiState.Success).hosts.size)
+    }
+
+    @Test
+    fun `refresh reloads hosts from page 1`() = runTest {
+        fakeRepo.hosts = TestData.sampleHosts
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem()
+            assertTrue(initial is HostsUiState.Success)
+
+            fakeRepo.hosts = listOf(TestData.createHost(99, "refreshed-host"))
+            viewModel.refresh()
+
+            val refreshed = awaitItem()
+            assertTrue(refreshed is HostsUiState.Success)
+            assertEquals(1, (refreshed as HostsUiState.Success).hosts.size)
+            assertEquals("refreshed-host", refreshed.hosts[0].name)
+        }
+    }
+
+    @Test
+    fun `reloads when active instance changes`() = runTest {
+        fakeRepo.hosts = TestData.sampleHosts
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem()
+            assertTrue(initial is HostsUiState.Success)
+
+            fakeRepo.hosts = listOf(TestData.createHost(10, "new-instance-host"))
+            fakeTokenManager.setInstances(listOf(TestData.testInstance2))
+
+            val loading = awaitItem()
+            assertEquals(HostsUiState.Loading, loading)
+
+            val newState = awaitItem()
+            assertTrue(newState is HostsUiState.Success)
+            assertEquals(
+                "new-instance-host",
+                (newState as HostsUiState.Success).hosts[0].name
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/presentation/hosts/InventoryHostsViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/presentation/hosts/InventoryHostsViewModelTest.kt
@@ -1,0 +1,225 @@
+package com.example.aapremote.presentation.hosts
+
+import app.cash.turbine.test
+import com.example.aapremote.MainDispatcherRule
+import com.example.aapremote.TestData
+import com.example.aapremote.fakes.FakeHostRepository
+import com.example.aapremote.model.AppError
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+@OptIn(ExperimentalCoroutinesApi::class)
+class InventoryHostsViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeRepo: FakeHostRepository
+    private lateinit var viewModel: InventoryHostsViewModel
+
+    @Before
+    fun setup() {
+        fakeRepo = FakeHostRepository()
+        viewModel = InventoryHostsViewModel(fakeRepo)
+    }
+
+    @Test
+    fun `initial state is Loading`() = runTest {
+        viewModel.uiState.test {
+            assertEquals(InventoryHostsUiState.Loading, awaitItem())
+        }
+    }
+
+    @Test
+    fun `loadHosts shows success with hosts`() = runTest {
+        fakeRepo.inventoryHosts = TestData.sampleHosts
+
+        viewModel.uiState.test {
+            assertEquals(InventoryHostsUiState.Loading, awaitItem())
+
+            viewModel.loadHosts(inventoryId = 1)
+
+            val state = awaitItem()
+            assertTrue(state is InventoryHostsUiState.Success)
+            val success = state as InventoryHostsUiState.Success
+            assertEquals(3, success.hosts.size)
+            assertEquals("host-1.example.com", success.hosts[0].name)
+            assertFalse(success.hasMore)
+        }
+    }
+
+    @Test
+    fun `loadHosts shows error when repository fails`() = runTest {
+        fakeRepo.shouldFail = true
+        fakeRepo.failureException = RuntimeException("API error")
+
+        viewModel.uiState.test {
+            assertEquals(InventoryHostsUiState.Loading, awaitItem())
+
+            viewModel.loadHosts(inventoryId = 1)
+
+            val state = awaitItem()
+            assertTrue(state is InventoryHostsUiState.Error)
+            val error = state as InventoryHostsUiState.Error
+            assertTrue(error.error is AppError.Unknown)
+        }
+    }
+
+    @Test
+    fun `loadHosts shows empty state when no hosts returned`() = runTest {
+        fakeRepo.inventoryHosts = emptyList()
+
+        viewModel.uiState.test {
+            assertEquals(InventoryHostsUiState.Loading, awaitItem())
+
+            viewModel.loadHosts(inventoryId = 1)
+
+            val state = awaitItem()
+            assertTrue(state is InventoryHostsUiState.Empty)
+            assertEquals("No hosts found", (state as InventoryHostsUiState.Empty).message)
+        }
+    }
+
+    @Test
+    fun `loadMore appends hosts when hasMore is true`() = runTest {
+        fakeRepo.inventoryHosts = TestData.sampleHosts
+        fakeRepo.inventoryHostsHasMore = true
+
+        viewModel.uiState.test {
+            assertEquals(InventoryHostsUiState.Loading, awaitItem())
+
+            viewModel.loadHosts(inventoryId = 1)
+
+            val firstPage = awaitItem()
+            assertTrue(firstPage is InventoryHostsUiState.Success)
+            assertEquals(3, (firstPage as InventoryHostsUiState.Success).hosts.size)
+            assertTrue(firstPage.hasMore)
+
+            // Set up page 2 data
+            fakeRepo.inventoryHosts = listOf(TestData.createHost(4))
+            fakeRepo.inventoryHostsHasMore = false
+
+            viewModel.loadMore()
+
+            val loadingMore = awaitItem()
+            assertTrue(loadingMore is InventoryHostsUiState.Success)
+            assertTrue((loadingMore as InventoryHostsUiState.Success).isLoadingMore)
+
+            val secondPage = awaitItem()
+            assertTrue(secondPage is InventoryHostsUiState.Success)
+            assertEquals(4, (secondPage as InventoryHostsUiState.Success).hosts.size)
+            assertFalse(secondPage.hasMore)
+        }
+    }
+
+    @Test
+    fun `loadMore does nothing when hasMore is false`() = runTest {
+        fakeRepo.inventoryHosts = TestData.sampleHosts
+
+        viewModel.uiState.test {
+            assertEquals(InventoryHostsUiState.Loading, awaitItem())
+
+            viewModel.loadHosts(inventoryId = 1)
+
+            val state = awaitItem()
+            assertTrue(state is InventoryHostsUiState.Success)
+            assertFalse((state as InventoryHostsUiState.Success).hasMore)
+
+            viewModel.loadMore()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `search triggers reload with filtered results`() = runTest {
+        fakeRepo.inventoryHosts = TestData.sampleHosts
+
+        viewModel.loadHosts(inventoryId = 1)
+
+        // Wait for initial load to complete
+        val initial = viewModel.uiState.value
+        assertTrue(initial is InventoryHostsUiState.Success)
+        assertEquals(3, (initial as InventoryHostsUiState.Success).hosts.size)
+
+        // Set up filtered results and trigger search
+        fakeRepo.inventoryHosts = listOf(TestData.createHost(1, "searched-host"))
+        viewModel.search("searched")
+
+        // Advance past the 300ms debounce delay
+        advanceUntilIdle()
+
+        val result = viewModel.uiState.value
+        assertTrue(result is InventoryHostsUiState.Success)
+        assertEquals(1, (result as InventoryHostsUiState.Success).hosts.size)
+        assertEquals("searched-host", result.hosts[0].name)
+    }
+
+    @Test
+    fun `search with blank query clears search filter`() = runTest {
+        fakeRepo.inventoryHosts = TestData.sampleHosts
+
+        viewModel.loadHosts(inventoryId = 1)
+
+        // Wait for initial load
+        assertTrue(viewModel.uiState.value is InventoryHostsUiState.Success)
+
+        // Search with blank should reload all hosts
+        viewModel.search("")
+        advanceUntilIdle()
+
+        val result = viewModel.uiState.value
+        assertTrue(result is InventoryHostsUiState.Success)
+        assertEquals(3, (result as InventoryHostsUiState.Success).hosts.size)
+    }
+
+    @Test
+    fun `refresh reloads from page 1`() = runTest {
+        fakeRepo.inventoryHosts = TestData.sampleHosts
+
+        viewModel.uiState.test {
+            assertEquals(InventoryHostsUiState.Loading, awaitItem())
+
+            viewModel.loadHosts(inventoryId = 1)
+            val initial = awaitItem()
+            assertTrue(initial is InventoryHostsUiState.Success)
+
+            fakeRepo.inventoryHosts = listOf(TestData.createHost(99, "refreshed"))
+            viewModel.refresh()
+
+            val refreshed = awaitItem()
+            assertTrue(refreshed is InventoryHostsUiState.Success)
+            assertEquals(1, (refreshed as InventoryHostsUiState.Success).hosts.size)
+            assertEquals("refreshed", refreshed.hosts[0].name)
+        }
+    }
+
+    @Test
+    fun `loadHosts with different inventoryId resets state`() = runTest {
+        fakeRepo.inventoryHosts = TestData.sampleHosts
+
+        viewModel.uiState.test {
+            assertEquals(InventoryHostsUiState.Loading, awaitItem())
+
+            viewModel.loadHosts(inventoryId = 1)
+            val first = awaitItem()
+            assertTrue(first is InventoryHostsUiState.Success)
+
+            fakeRepo.inventoryHosts = listOf(TestData.createHost(10, "inv2-host"))
+            viewModel.loadHosts(inventoryId = 2)
+
+            val loading = awaitItem()
+            assertEquals(InventoryHostsUiState.Loading, loading)
+
+            val second = awaitItem()
+            assertTrue(second is InventoryHostsUiState.Success)
+            assertEquals(1, (second as InventoryHostsUiState.Success).hosts.size)
+            assertEquals("inv2-host", second.hosts[0].name)
+        }
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/presentation/inventory/InventoriesViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/presentation/inventory/InventoriesViewModelTest.kt
@@ -1,0 +1,196 @@
+package com.example.aapremote.presentation.inventory
+
+import app.cash.turbine.test
+import com.example.aapremote.MainDispatcherRule
+import com.example.aapremote.TestData
+import com.example.aapremote.fakes.FakeInventoryRepository
+import com.example.aapremote.fakes.FakeTokenManager
+import com.example.aapremote.model.AppError
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+class InventoriesViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeRepo: FakeInventoryRepository
+    private lateinit var fakeTokenManager: FakeTokenManager
+
+    @Before
+    fun setup() {
+        fakeRepo = FakeInventoryRepository()
+        fakeTokenManager = FakeTokenManager()
+    }
+
+    private fun createViewModel(): InventoriesViewModel {
+        return InventoriesViewModel(fakeRepo, fakeTokenManager)
+    }
+
+    @Test
+    fun `initial state is Loading when no active instance`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(InventoriesUiState.Loading, awaitItem())
+        }
+    }
+
+    @Test
+    fun `loads inventories when active instance is set`() = runTest {
+        fakeRepo.inventories = TestData.sampleInventories
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is InventoriesUiState.Success)
+            val success = state as InventoriesUiState.Success
+            assertEquals(3, success.inventories.size)
+            assertEquals("Inventory 1", success.inventories[0].name)
+            assertFalse(success.hasMore)
+        }
+    }
+
+    @Test
+    fun `shows error state when loading fails`() = runTest {
+        fakeRepo.shouldFail = true
+        fakeRepo.failureException = RuntimeException("Network error")
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is InventoriesUiState.Error)
+            val error = state as InventoriesUiState.Error
+            assertTrue(error.error is AppError.Unknown)
+        }
+    }
+
+    @Test
+    fun `shows empty state when no inventories returned`() = runTest {
+        fakeRepo.inventories = emptyList()
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is InventoriesUiState.Empty)
+            assertEquals("No inventories found", (state as InventoriesUiState.Empty).message)
+        }
+    }
+
+    @Test
+    fun `loadMore appends inventories when hasMore is true`() = runTest {
+        val page1 = listOf(TestData.createInventory(1), TestData.createInventory(2))
+        val page2 = listOf(TestData.createInventory(3))
+
+        fakeRepo.setResultForPage { page ->
+            when (page) {
+                1 -> Result.success(
+                    com.example.aapremote.data.InventoryListResult(page1, hasMore = true, totalCount = 3)
+                )
+                2 -> Result.success(
+                    com.example.aapremote.data.InventoryListResult(page2, hasMore = false, totalCount = 3)
+                )
+                else -> Result.failure(RuntimeException("Unexpected page $page"))
+            }
+        }
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val firstPage = awaitItem()
+            assertTrue(firstPage is InventoriesUiState.Success)
+            assertEquals(2, (firstPage as InventoriesUiState.Success).inventories.size)
+            assertTrue(firstPage.hasMore)
+
+            viewModel.loadMore()
+
+            val loadingMore = awaitItem()
+            assertTrue(loadingMore is InventoriesUiState.Success)
+            assertTrue((loadingMore as InventoriesUiState.Success).isLoadingMore)
+
+            val secondPage = awaitItem()
+            assertTrue(secondPage is InventoriesUiState.Success)
+            assertEquals(3, (secondPage as InventoriesUiState.Success).inventories.size)
+            assertFalse(secondPage.hasMore)
+            assertFalse(secondPage.isLoadingMore)
+        }
+    }
+
+    @Test
+    fun `loadMore does nothing when hasMore is false`() = runTest {
+        fakeRepo.inventories = TestData.sampleInventories
+        fakeRepo.hasMore = false
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is InventoriesUiState.Success)
+            assertFalse((state as InventoriesUiState.Success).hasMore)
+
+            viewModel.loadMore()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `refresh reloads inventories from page 1`() = runTest {
+        fakeRepo.inventories = TestData.sampleInventories
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem()
+            assertTrue(initial is InventoriesUiState.Success)
+            assertEquals(3, (initial as InventoriesUiState.Success).inventories.size)
+
+            fakeRepo.inventories = listOf(TestData.createInventory(99, "Updated"))
+            viewModel.refresh()
+
+            val refreshed = awaitItem()
+            assertTrue(refreshed is InventoriesUiState.Success)
+            assertEquals(1, (refreshed as InventoriesUiState.Success).inventories.size)
+            assertEquals("Updated", refreshed.inventories[0].name)
+        }
+    }
+
+    @Test
+    fun `reloads when active instance changes`() = runTest {
+        fakeRepo.inventories = TestData.sampleInventories
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem()
+            assertTrue(initial is InventoriesUiState.Success)
+
+            fakeRepo.inventories = listOf(TestData.createInventory(10, "New Instance Inventory"))
+            fakeTokenManager.setInstances(listOf(TestData.testInstance2))
+
+            // Should see Loading then Success with new data
+            val loading = awaitItem()
+            assertEquals(InventoriesUiState.Loading, loading)
+
+            val newState = awaitItem()
+            assertTrue(newState is InventoriesUiState.Success)
+            assertEquals(
+                "New Instance Inventory",
+                (newState as InventoriesUiState.Success).inventories[0].name
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/presentation/jobs/JobStatusViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/presentation/jobs/JobStatusViewModelTest.kt
@@ -1,0 +1,193 @@
+package com.example.aapremote.presentation.jobs
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.example.aapremote.MainDispatcherRule
+import com.example.aapremote.fakes.FakeJobRepository
+import com.example.aapremote.model.AppError
+import com.example.aapremote.model.JobStatus
+import com.example.aapremote.testJob
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class JobStatusViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeRepo: FakeJobRepository
+
+    @Before
+    fun setup() {
+        fakeRepo = FakeJobRepository()
+    }
+
+    private fun createViewModel(jobId: Int = 42): JobStatusViewModel {
+        val savedStateHandle = SavedStateHandle(mapOf("jobId" to jobId))
+        return JobStatusViewModel(savedStateHandle, fakeRepo)
+    }
+
+    // --- Initial state ---
+
+    @Test
+    fun `initial state is Loading`() = runTest {
+        val viewModel = createViewModel()
+        assertEquals(JobStatusUiState.Loading, viewModel.uiState.value)
+    }
+
+    // --- startPolling with active job ---
+
+    @Test
+    fun `startPolling with running job emits Active state`() = runTest {
+        val runningJob = testJob(id = 42, status = JobStatus.RUNNING)
+        fakeRepo.polledJob = runningJob
+        fakeRepo.jobStdout = "PLAY [all] ***"
+
+        val viewModel = createViewModel(jobId = 42)
+        viewModel.startPolling()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is JobStatusUiState.Active)
+            val active = state as JobStatusUiState.Active
+            assertEquals(42, active.job.id)
+            assertEquals(JobStatus.RUNNING, active.job.status)
+            assertEquals("PLAY [all] ***", active.stdout)
+        }
+    }
+
+    // --- startPolling with completed job ---
+
+    @Test
+    fun `startPolling with completed job emits Completed state`() = runTest {
+        val completedJob = testJob(
+            id = 42,
+            status = JobStatus.SUCCESSFUL,
+            finished = "2024-01-15T10:05:00Z",
+            elapsed = 300.0
+        )
+        fakeRepo.polledJob = completedJob
+        fakeRepo.jobStdout = "PLAY RECAP ***"
+
+        val viewModel = createViewModel(jobId = 42)
+        viewModel.startPolling()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is JobStatusUiState.Completed)
+            val completed = state as JobStatusUiState.Completed
+            assertEquals(42, completed.job.id)
+            assertEquals(JobStatus.SUCCESSFUL, completed.job.status)
+            assertEquals("PLAY RECAP ***", completed.stdout)
+        }
+    }
+
+    @Test
+    fun `startPolling with failed job emits Completed state`() = runTest {
+        val failedJob = testJob(id = 42, status = JobStatus.FAILED, failed = true)
+        fakeRepo.polledJob = failedJob
+
+        val viewModel = createViewModel(jobId = 42)
+        viewModel.startPolling()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is JobStatusUiState.Completed)
+            assertEquals(JobStatus.FAILED, (state as JobStatusUiState.Completed).job.status)
+        }
+    }
+
+    // --- Stdout ---
+
+    @Test
+    fun `stdout is null when getJobStdout fails`() = runTest {
+        val runningJob = testJob(id = 42, status = JobStatus.RUNNING)
+        fakeRepo.polledJob = runningJob
+        fakeRepo.stdoutShouldFail = true
+
+        val viewModel = createViewModel(jobId = 42)
+        viewModel.startPolling()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is JobStatusUiState.Active)
+            assertEquals(null, (state as JobStatusUiState.Active).stdout)
+        }
+    }
+
+    // --- Error handling ---
+
+    @Test
+    fun `startPolling error emits Error state`() = runTest {
+        fakeRepo.shouldFail = true
+        fakeRepo.failureException = RuntimeException("Connection refused")
+
+        val viewModel = createViewModel(jobId = 42)
+        viewModel.startPolling()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is JobStatusUiState.Error)
+            assertTrue((state as JobStatusUiState.Error).error is AppError.Unknown)
+        }
+    }
+
+    // --- Invalid jobId ---
+
+    @Test
+    fun `startPolling does nothing with invalid jobId`() = runTest {
+        val viewModel = createViewModel(jobId = -1)
+        viewModel.startPolling()
+
+        assertEquals(JobStatusUiState.Loading, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `startPolling does nothing with zero jobId`() = runTest {
+        val viewModel = createViewModel(jobId = 0)
+        viewModel.startPolling()
+
+        assertEquals(JobStatusUiState.Loading, viewModel.uiState.value)
+    }
+
+    // --- Retry ---
+
+    @Test
+    fun `retry resets to Loading and restarts polling`() = runTest {
+        fakeRepo.shouldFail = true
+        val viewModel = createViewModel(jobId = 42)
+        viewModel.startPolling()
+
+        // Error state reached
+        viewModel.uiState.test {
+            assertTrue(expectMostRecentItem() is JobStatusUiState.Error)
+        }
+
+        // Now fix the error and retry
+        fakeRepo.shouldFail = false
+        fakeRepo.polledJob = testJob(id = 42, status = JobStatus.SUCCESSFUL)
+        viewModel.retry()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is JobStatusUiState.Completed)
+        }
+    }
+
+    // --- stopPolling ---
+
+    @Test
+    fun `stopPolling does not crash when no polling active`() {
+        val viewModel = createViewModel(jobId = 42)
+        // Should not throw
+        viewModel.stopPolling()
+        assertEquals(JobStatusUiState.Loading, viewModel.uiState.value)
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/presentation/jobs/RecentJobsViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/presentation/jobs/RecentJobsViewModelTest.kt
@@ -1,0 +1,227 @@
+package com.example.aapremote.presentation.jobs
+
+import app.cash.turbine.test
+import com.example.aapremote.MainDispatcherRule
+import com.example.aapremote.fakes.FakeJobRepository
+import com.example.aapremote.fakes.FakeTokenManager
+import com.example.aapremote.model.AppError
+import com.example.aapremote.model.JobStatus
+import com.example.aapremote.testInstance
+import com.example.aapremote.testJob
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RecentJobsViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeRepo: FakeJobRepository
+    private lateinit var fakeTokenManager: FakeTokenManager
+    private lateinit var viewModel: RecentJobsViewModel
+
+    @Before
+    fun setup() {
+        fakeRepo = FakeJobRepository()
+        fakeTokenManager = FakeTokenManager()
+    }
+
+    private fun createViewModel(): RecentJobsViewModel {
+        return RecentJobsViewModel(fakeRepo, fakeTokenManager)
+    }
+
+    // --- Init / active instance ---
+
+    @Test
+    fun `initial state is Loading`() = runTest {
+        viewModel = createViewModel()
+        assertEquals(RecentJobsUiState.Loading, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `auto-loads jobs when active instance exists`() = runTest {
+        val jobs = listOf(
+            testJob(id = 1, status = JobStatus.SUCCESSFUL),
+            testJob(id = 2, status = JobStatus.RUNNING)
+        )
+        fakeRepo.jobs = jobs
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is RecentJobsUiState.Success)
+            assertEquals(2, (state as RecentJobsUiState.Success).jobs.size)
+        }
+    }
+
+    // --- loadRecentJobs ---
+
+    @Test
+    fun `loadRecentJobs success emits Success state`() = runTest {
+        val jobs = listOf(testJob(id = 1, name = "Deploy"))
+        fakeRepo.jobs = jobs
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is RecentJobsUiState.Success)
+            val success = state as RecentJobsUiState.Success
+            assertEquals(1, success.jobs.size)
+            assertEquals("Deploy", success.jobs[0].name)
+            assertEquals(false, success.hasMore)
+        }
+    }
+
+    @Test
+    fun `loadRecentJobs error emits Error state`() = runTest {
+        fakeRepo.shouldFail = true
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is RecentJobsUiState.Error)
+            assertTrue((state as RecentJobsUiState.Error).error is AppError.Unknown)
+        }
+    }
+
+    // --- toggleFilter ---
+
+    @Test
+    fun `toggleFilter adds status to active filters`() = runTest {
+        fakeRepo.jobs = listOf(testJob(status = JobStatus.SUCCESSFUL))
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.toggleFilter(JobStatus.SUCCESSFUL)
+
+        assertTrue(viewModel.getActiveFilters().contains(JobStatus.SUCCESSFUL))
+    }
+
+    @Test
+    fun `toggleFilter removes status when toggled again`() = runTest {
+        fakeRepo.jobs = listOf(testJob())
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.toggleFilter(JobStatus.SUCCESSFUL)
+        viewModel.toggleFilter(JobStatus.SUCCESSFUL)
+
+        assertTrue(viewModel.getActiveFilters().isEmpty())
+    }
+
+    @Test
+    fun `toggleFilter reloads jobs with filter applied`() = runTest {
+        fakeRepo.jobs = listOf(testJob())
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.toggleFilter(JobStatus.FAILED)
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is RecentJobsUiState.Success)
+            val success = state as RecentJobsUiState.Success
+            assertEquals(setOf(JobStatus.FAILED), success.activeFilters)
+        }
+    }
+
+    // --- clearFilters ---
+
+    @Test
+    fun `clearFilters removes all filters and reloads`() = runTest {
+        fakeRepo.jobs = listOf(testJob())
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.toggleFilter(JobStatus.SUCCESSFUL)
+        viewModel.toggleFilter(JobStatus.FAILED)
+        viewModel.clearFilters()
+
+        assertTrue(viewModel.getActiveFilters().isEmpty())
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is RecentJobsUiState.Success)
+            assertEquals(emptySet<JobStatus>(), (state as RecentJobsUiState.Success).activeFilters)
+        }
+    }
+
+    // --- loadMore ---
+
+    @Test
+    fun `loadMore increments page when hasMore is true`() = runTest {
+        fakeRepo.jobs = listOf(testJob())
+        fakeRepo.hasMore = true
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is RecentJobsUiState.Success)
+            assertTrue((state as RecentJobsUiState.Success).hasMore)
+        }
+
+        fakeRepo.hasMore = false
+        viewModel.loadMore()
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+            assertEquals(2, fakeRepo.lastRequestedPage)
+        }
+    }
+
+    @Test
+    fun `loadMore does nothing when hasMore is false`() = runTest {
+        fakeRepo.jobs = listOf(testJob())
+        fakeRepo.hasMore = false
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        // Wait for initial load to finish
+        viewModel.uiState.test {
+            expectMostRecentItem()
+        }
+
+        fakeRepo.lastRequestedPage = 0
+        viewModel.loadMore()
+        // loadMore should not have been called
+        assertEquals(0, fakeRepo.lastRequestedPage)
+    }
+
+    // --- refresh ---
+
+    @Test
+    fun `refresh resets page and reloads`() = runTest {
+        fakeRepo.jobs = listOf(testJob())
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.refresh()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is RecentJobsUiState.Success)
+            assertEquals(1, fakeRepo.lastRequestedPage)
+        }
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/presentation/schedules/SchedulesViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/presentation/schedules/SchedulesViewModelTest.kt
@@ -1,0 +1,229 @@
+package com.example.aapremote.presentation.schedules
+
+import app.cash.turbine.test
+import com.example.aapremote.MainDispatcherRule
+import com.example.aapremote.TestData
+import com.example.aapremote.fakes.FakeScheduleRepository
+import com.example.aapremote.fakes.FakeTokenManager
+import com.example.aapremote.model.AppError
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+class SchedulesViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeRepo: FakeScheduleRepository
+    private lateinit var fakeTokenManager: FakeTokenManager
+
+    @Before
+    fun setup() {
+        fakeRepo = FakeScheduleRepository()
+        fakeTokenManager = FakeTokenManager()
+    }
+
+    private fun createViewModel(): SchedulesViewModel {
+        return SchedulesViewModel(fakeRepo, fakeTokenManager)
+    }
+
+    @Test
+    fun `initial state is Loading when no active instance`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(SchedulesUiState.Loading, awaitItem())
+        }
+    }
+
+    @Test
+    fun `loads schedules when active instance is set`() = runTest {
+        fakeRepo.schedules = TestData.sampleSchedules
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is SchedulesUiState.Success)
+            val success = state as SchedulesUiState.Success
+            assertEquals(3, success.schedules.size)
+            assertEquals("Schedule 1", success.schedules[0].name)
+            assertFalse(success.hasMore)
+        }
+    }
+
+    @Test
+    fun `shows error state when loading fails`() = runTest {
+        fakeRepo.shouldFail = true
+        fakeRepo.failureException = RuntimeException("Server error")
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is SchedulesUiState.Error)
+            val error = state as SchedulesUiState.Error
+            assertTrue(error.error is AppError.Unknown)
+        }
+    }
+
+    @Test
+    fun `loadMore appends schedules when hasMore is true`() = runTest {
+        fakeRepo.schedules = TestData.sampleSchedules
+        fakeRepo.hasMore = true
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val firstPage = awaitItem()
+            assertTrue(firstPage is SchedulesUiState.Success)
+            assertEquals(3, (firstPage as SchedulesUiState.Success).schedules.size)
+            assertTrue(firstPage.hasMore)
+
+            // Set up page 2 data
+            fakeRepo.schedules = listOf(TestData.createSchedule(4))
+            fakeRepo.hasMore = false
+
+            viewModel.loadMore()
+
+            val loadingMore = awaitItem()
+            assertTrue(loadingMore is SchedulesUiState.Success)
+            assertTrue((loadingMore as SchedulesUiState.Success).isLoadingMore)
+
+            val secondPage = awaitItem()
+            assertTrue(secondPage is SchedulesUiState.Success)
+            assertEquals(4, (secondPage as SchedulesUiState.Success).schedules.size)
+            assertFalse(secondPage.hasMore)
+        }
+    }
+
+    @Test
+    fun `loadMore does nothing when hasMore is false`() = runTest {
+        fakeRepo.schedules = TestData.sampleSchedules
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is SchedulesUiState.Success)
+            assertFalse((state as SchedulesUiState.Success).hasMore)
+
+            viewModel.loadMore()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `toggleSchedule updates schedule enabled state`() = runTest {
+        val schedule = TestData.createSchedule(1, enabled = true)
+        fakeRepo.schedules = listOf(schedule)
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem()
+            assertTrue(initial is SchedulesUiState.Success)
+            assertTrue((initial as SchedulesUiState.Success).schedules[0].enabled)
+
+            viewModel.toggleSchedule(schedule)
+
+            // With UnconfinedTestDispatcher, both the optimistic update and
+            // server confirmation happen synchronously. Turbine may conflate
+            // intermediate states, so we check the final state.
+            val updated = expectMostRecentItem()
+            assertTrue(updated is SchedulesUiState.Success)
+            assertFalse((updated as SchedulesUiState.Success).schedules[0].enabled)
+        }
+    }
+
+    @Test
+    fun `toggleSchedule reverts on failure and emits error`() = runTest {
+        val schedule = TestData.createSchedule(1, enabled = true)
+        fakeRepo.schedules = listOf(schedule)
+        fakeRepo.toggleShouldFail = true
+        fakeRepo.toggleFailureException = RuntimeException("Toggle failed")
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem()
+            assertTrue(initial is SchedulesUiState.Success)
+            assertTrue((initial as SchedulesUiState.Success).schedules[0].enabled)
+
+            viewModel.toggleSchedule(schedule)
+
+            // After failure, the schedule should be reverted to original state
+            val reverted = expectMostRecentItem()
+            assertTrue(reverted is SchedulesUiState.Success)
+            assertTrue((reverted as SchedulesUiState.Success).schedules[0].enabled)
+        }
+
+        // Verify error was emitted via toggleError SharedFlow
+        viewModel.toggleError.test {
+            // Trigger another toggle to get a fresh error emission
+            fakeRepo.toggleShouldFail = true
+            val schedule2 = (viewModel.uiState.value as SchedulesUiState.Success).schedules[0]
+            viewModel.toggleSchedule(schedule2)
+            val errorMessage = awaitItem()
+            assertEquals("Toggle failed", errorMessage)
+        }
+    }
+
+    @Test
+    fun `refresh reloads schedules from page 1`() = runTest {
+        fakeRepo.schedules = TestData.sampleSchedules
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem()
+            assertTrue(initial is SchedulesUiState.Success)
+            assertEquals(3, (initial as SchedulesUiState.Success).schedules.size)
+
+            fakeRepo.schedules = listOf(TestData.createSchedule(99, "Updated Schedule"))
+            viewModel.refresh()
+
+            val refreshed = awaitItem()
+            assertTrue(refreshed is SchedulesUiState.Success)
+            assertEquals(1, (refreshed as SchedulesUiState.Success).schedules.size)
+            assertEquals("Updated Schedule", refreshed.schedules[0].name)
+        }
+    }
+
+    @Test
+    fun `reloads when active instance changes`() = runTest {
+        fakeRepo.schedules = TestData.sampleSchedules
+
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem()
+            assertTrue(initial is SchedulesUiState.Success)
+
+            fakeRepo.schedules = listOf(TestData.createSchedule(10, "New Instance Schedule"))
+            fakeTokenManager.setInstances(listOf(TestData.testInstance2))
+
+            val loading = awaitItem()
+            assertEquals(SchedulesUiState.Loading, loading)
+
+            val newState = awaitItem()
+            assertTrue(newState is SchedulesUiState.Success)
+            assertEquals(
+                "New Instance Schedule",
+                (newState as SchedulesUiState.Success).schedules[0].name
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/presentation/settings/BackupViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/presentation/settings/BackupViewModelTest.kt
@@ -1,0 +1,238 @@
+package com.example.aapremote.presentation.settings
+
+import com.example.aapremote.MainDispatcherRule
+import com.example.aapremote.assistant.data.LlmProviderConfig
+import com.example.aapremote.assistant.data.TokenSavingMode
+import com.example.aapremote.data.backup.BackupManager
+import com.example.aapremote.fakes.FakeAssistantRepository
+import com.example.aapremote.fakes.FakeTokenManager
+import com.example.aapremote.model.AapInstance
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class BackupViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var backupManager: BackupManager
+    private lateinit var fakeTokenManager: FakeTokenManager
+    private lateinit var fakeAssistantRepo: FakeAssistantRepository
+    private lateinit var viewModel: BackupViewModel
+
+    private val instance1 = AapInstance(
+        id = "inst-1",
+        baseUrl = "https://aap1.example.com",
+        token = "token-1",
+        alias = "Production",
+        apiVersion = "CONTROLLER_V2"
+    )
+
+    private val instance2 = AapInstance(
+        id = "inst-2",
+        baseUrl = "https://aap2.example.com",
+        token = "token-2",
+        alias = "Staging",
+        apiVersion = "CONTROLLER_V2"
+    )
+
+    private val testLlmConfig = LlmProviderConfig.OpenAiCompatible(
+        url = "https://openrouter.ai/api/v1",
+        model = "anthropic/claude-sonnet-4-6",
+        apiKey = "sk-test-key",
+        tokenSavingMode = TokenSavingMode.STANDARD
+    )
+
+    @Before
+    fun setup() {
+        backupManager = BackupManager()
+        fakeTokenManager = FakeTokenManager()
+        fakeAssistantRepo = FakeAssistantRepository()
+        viewModel = BackupViewModel(backupManager, fakeTokenManager, fakeAssistantRepo)
+    }
+
+    @Test
+    fun `initial state is Idle`() = runTest {
+        assertEquals(BackupUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `exportBackup with instances produces ExportReady`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1))
+
+        viewModel.exportBackup(password = "test123", includeAssistantConfig = false)
+
+        val state = viewModel.uiState.value
+        assertTrue(state is BackupUiState.ExportReady)
+        assertTrue((state as BackupUiState.ExportReady).data.isNotEmpty())
+    }
+
+    @Test
+    fun `exportBackup with no instances emits Error`() = runTest {
+        viewModel.exportBackup(password = "test123", includeAssistantConfig = false)
+
+        val state = viewModel.uiState.value
+        assertTrue(state is BackupUiState.Error)
+        assertEquals("No instances to export", (state as BackupUiState.Error).message)
+    }
+
+    @Test
+    fun `exportBackup includes LLM config when requested`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1))
+        fakeAssistantRepo.savedConfig = testLlmConfig
+
+        viewModel.exportBackup(password = "test123", includeAssistantConfig = true)
+
+        val state = viewModel.uiState.value
+        assertTrue(state is BackupUiState.ExportReady)
+
+        // Verify by importing back that LLM config is included
+        val envelope = backupManager.importBackup(
+            (state as BackupUiState.ExportReady).data, "test123"
+        )
+        assertNotNull(envelope.llmConfig)
+    }
+
+    @Test
+    fun `exportBackup without LLM config omits it`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1))
+        fakeAssistantRepo.savedConfig = testLlmConfig
+
+        viewModel.exportBackup(password = "test123", includeAssistantConfig = false)
+
+        val state = viewModel.uiState.value
+        assertTrue(state is BackupUiState.ExportReady)
+
+        val envelope = backupManager.importBackup(
+            (state as BackupUiState.ExportReady).data, "test123"
+        )
+        assertNull(envelope.llmConfig)
+    }
+
+    @Test
+    fun `startImport with correct password shows ImportPreview`() = runTest {
+        val exportedData = backupManager.exportBackup("secret", listOf(instance1))
+
+        // No existing instances, so all are new
+        viewModel.startImport(exportedData, "secret")
+
+        val state = viewModel.uiState.value
+        assertTrue(state is BackupUiState.ImportPreview)
+        val preview = state as BackupUiState.ImportPreview
+        assertEquals(1, preview.instances.size)
+        assertEquals(1, preview.newCount)
+        assertEquals(0, preview.duplicateCount)
+        assertEquals(false, preview.hasExistingInstances)
+    }
+
+    @Test
+    fun `startImport with wrong password shows Error`() = runTest {
+        val exportedData = backupManager.exportBackup("correct", listOf(instance1))
+
+        viewModel.startImport(exportedData, "wrong")
+
+        val state = viewModel.uiState.value
+        assertTrue(state is BackupUiState.Error)
+        assertEquals("Incorrect password", (state as BackupUiState.Error).message)
+    }
+
+    @Test
+    fun `startImport detects duplicates when instances already exist`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1))
+        val exportedData = backupManager.exportBackup("pass", listOf(instance1, instance2))
+
+        viewModel.startImport(exportedData, "pass")
+
+        val state = viewModel.uiState.value
+        assertTrue(state is BackupUiState.ImportPreview)
+        val preview = state as BackupUiState.ImportPreview
+        assertEquals(1, preview.duplicateCount)
+        assertEquals(1, preview.newCount)
+        assertEquals(true, preview.hasExistingInstances)
+    }
+
+    @Test
+    fun `confirmImport MERGE skips duplicates`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1))
+        val exportedData = backupManager.exportBackup("pass", listOf(instance1, instance2))
+
+        viewModel.startImport(exportedData, "pass")
+        assertTrue(viewModel.uiState.value is BackupUiState.ImportPreview)
+
+        viewModel.confirmImport(ImportMode.MERGE)
+
+        val state = viewModel.uiState.value
+        assertTrue(state is BackupUiState.Success)
+        assertEquals("Imported 1 instance(s)", (state as BackupUiState.Success).message)
+
+        // instance1 was already there, instance2 was added
+        assertEquals(2, fakeTokenManager.instances.value.size)
+    }
+
+    @Test
+    fun `confirmImport REPLACE clears and re-imports all`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1))
+        val exportedData = backupManager.exportBackup("pass", listOf(instance2))
+
+        viewModel.startImport(exportedData, "pass")
+        assertTrue(viewModel.uiState.value is BackupUiState.ImportPreview)
+
+        viewModel.confirmImport(ImportMode.REPLACE)
+
+        val state = viewModel.uiState.value
+        assertTrue(state is BackupUiState.Success)
+        assertEquals("Imported 1 instance(s)", (state as BackupUiState.Success).message)
+
+        // instance1 was cleared, only instance2 remains
+        val remaining = fakeTokenManager.instances.value
+        assertEquals(1, remaining.size)
+        assertEquals("https://aap2.example.com", remaining[0].baseUrl)
+    }
+
+    @Test
+    fun `confirmImport with LLM config saves it and includes note`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1))
+        val exportedData = backupManager.exportBackup("pass", listOf(instance2), testLlmConfig)
+
+        viewModel.startImport(exportedData, "pass")
+        assertTrue(viewModel.uiState.value is BackupUiState.ImportPreview)
+
+        viewModel.confirmImport(ImportMode.MERGE)
+
+        val state = viewModel.uiState.value
+        assertTrue(state is BackupUiState.Success)
+        assertTrue((state as BackupUiState.Success).message.contains("LLM config"))
+
+        // Verify LLM config was saved to repository
+        assertNotNull(fakeAssistantRepo.savedConfig)
+        val saved = fakeAssistantRepo.savedConfig as LlmProviderConfig.OpenAiCompatible
+        assertEquals("anthropic/claude-sonnet-4-6", saved.model)
+    }
+
+    @Test
+    fun `dismiss resets to Idle and clears pending envelope`() = runTest {
+        val exportedData = backupManager.exportBackup("pass", listOf(instance1))
+
+        viewModel.startImport(exportedData, "pass")
+        assertTrue(viewModel.uiState.value is BackupUiState.ImportPreview)
+
+        viewModel.dismiss()
+        assertEquals(BackupUiState.Idle, viewModel.uiState.value)
+
+        // confirmImport should be a no-op after dismiss
+        viewModel.confirmImport(ImportMode.MERGE)
+        assertEquals(BackupUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `confirmImport without pending envelope is a no-op`() = runTest {
+        viewModel.confirmImport(ImportMode.MERGE)
+        assertEquals(BackupUiState.Idle, viewModel.uiState.value)
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/presentation/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/presentation/settings/SettingsViewModelTest.kt
@@ -1,0 +1,182 @@
+package com.example.aapremote.presentation.settings
+
+import app.cash.turbine.test
+import com.example.aapremote.MainDispatcherRule
+import com.example.aapremote.fakes.FakeAapApiProvider
+import com.example.aapremote.fakes.FakeTokenManager
+import com.example.aapremote.model.AapInstance
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class SettingsViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeTokenManager: FakeTokenManager
+    private lateinit var fakeApiProvider: FakeAapApiProvider
+
+    private val instance1 = AapInstance(
+        id = "inst-1",
+        baseUrl = "https://aap1.example.com",
+        token = "token-1",
+        alias = "Production"
+    )
+
+    private val instance2 = AapInstance(
+        id = "inst-2",
+        baseUrl = "https://aap2.example.com",
+        token = "token-2",
+        alias = "Staging"
+    )
+
+    @Before
+    fun setup() {
+        fakeTokenManager = FakeTokenManager()
+        fakeApiProvider = FakeAapApiProvider()
+    }
+
+    @Test
+    fun `init emits Success with instances from TokenManager`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1, instance2))
+
+        val viewModel = SettingsViewModel(fakeTokenManager, fakeApiProvider)
+
+        val state = viewModel.uiState.value
+        assertTrue(state is SettingsUiState.Success)
+        val success = state as SettingsUiState.Success
+        assertEquals(2, success.instances.size)
+        assertEquals("Production", success.instances[0].alias)
+        assertEquals("Staging", success.instances[1].alias)
+    }
+
+    @Test
+    fun `init with empty instances emits Success with empty list`() = runTest {
+        val viewModel = SettingsViewModel(fakeTokenManager, fakeApiProvider)
+
+        val state = viewModel.uiState.value
+        assertTrue(state is SettingsUiState.Success)
+        val success = state as SettingsUiState.Success
+        assertTrue(success.instances.isEmpty())
+        assertNull(success.selectedInstance)
+    }
+
+    @Test
+    fun `init sets active instance as selectedInstance`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1, instance2))
+        fakeTokenManager.setActiveInstanceDirect(instance2)
+
+        val viewModel = SettingsViewModel(fakeTokenManager, fakeApiProvider)
+
+        val state = viewModel.uiState.value as SettingsUiState.Success
+        assertEquals("inst-2", state.selectedInstance?.id)
+    }
+
+    @Test
+    fun `switchInstance updates active instance`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1, instance2))
+        val viewModel = SettingsViewModel(fakeTokenManager, fakeApiProvider)
+
+        viewModel.uiState.test {
+            val initial = awaitItem() as SettingsUiState.Success
+            assertEquals("inst-1", initial.selectedInstance?.id)
+
+            viewModel.switchInstance("inst-2")
+
+            val updated = awaitItem() as SettingsUiState.Success
+            assertEquals("inst-2", updated.selectedInstance?.id)
+        }
+    }
+
+    @Test
+    fun `removeInstance removes instance and evicts from API provider`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1, instance2))
+        val viewModel = SettingsViewModel(fakeTokenManager, fakeApiProvider)
+
+        viewModel.uiState.test {
+            val initial = awaitItem() as SettingsUiState.Success
+            assertEquals(2, initial.instances.size)
+
+            viewModel.removeInstance("inst-1")
+
+            val updated = awaitItem() as SettingsUiState.Success
+            assertEquals(1, updated.instances.size)
+            assertEquals("inst-2", updated.instances[0].id)
+            assertEquals(listOf("inst-1"), fakeApiProvider.evictedInstances)
+        }
+    }
+
+    @Test
+    fun `removeInstance with active instance switches to remaining`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1, instance2))
+        val viewModel = SettingsViewModel(fakeTokenManager, fakeApiProvider)
+
+        viewModel.uiState.test {
+            awaitItem() // initial
+
+            viewModel.removeInstance("inst-1")
+
+            val updated = awaitItem() as SettingsUiState.Success
+            assertEquals("inst-2", updated.selectedInstance?.id)
+        }
+    }
+
+    @Test
+    fun `showInstanceDetails sets selectedInstanceForDetails`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1, instance2))
+        val viewModel = SettingsViewModel(fakeTokenManager, fakeApiProvider)
+
+        // Wait for init to complete
+        val initial = viewModel.uiState.value as SettingsUiState.Success
+        assertNull(initial.selectedInstanceForDetails)
+
+        viewModel.showInstanceDetails("inst-2")
+
+        val updated = viewModel.uiState.value as SettingsUiState.Success
+        assertEquals("inst-2", updated.selectedInstanceForDetails?.id)
+        assertEquals("Staging", updated.selectedInstanceForDetails?.alias)
+    }
+
+    @Test
+    fun `showInstanceDetails with unknown ID sets null`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1))
+        val viewModel = SettingsViewModel(fakeTokenManager, fakeApiProvider)
+
+        viewModel.showInstanceDetails("unknown-id")
+
+        val state = viewModel.uiState.value as SettingsUiState.Success
+        assertNull(state.selectedInstanceForDetails)
+    }
+
+    @Test
+    fun `dismissDetails clears selectedInstanceForDetails`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance1))
+        val viewModel = SettingsViewModel(fakeTokenManager, fakeApiProvider)
+
+        viewModel.showInstanceDetails("inst-1")
+        val withDetails = viewModel.uiState.value as SettingsUiState.Success
+        assertEquals("inst-1", withDetails.selectedInstanceForDetails?.id)
+
+        viewModel.dismissDetails()
+        val dismissed = viewModel.uiState.value as SettingsUiState.Success
+        assertNull(dismissed.selectedInstanceForDetails)
+    }
+
+    @Test
+    fun `dismissDetails when no details shown is a no-op`() = runTest {
+        val viewModel = SettingsViewModel(fakeTokenManager, fakeApiProvider)
+
+        val before = viewModel.uiState.value
+        viewModel.dismissDetails()
+        val after = viewModel.uiState.value
+
+        assertTrue(before is SettingsUiState.Success)
+        assertTrue(after is SettingsUiState.Success)
+        assertNull((after as SettingsUiState.Success).selectedInstanceForDetails)
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/presentation/templates/TemplatesViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/presentation/templates/TemplatesViewModelTest.kt
@@ -1,0 +1,334 @@
+package com.example.aapremote.presentation.templates
+
+import app.cash.turbine.test
+import com.example.aapremote.MainDispatcherRule
+import com.example.aapremote.fakes.FakeTemplateRepository
+import com.example.aapremote.fakes.FakeTokenManager
+import com.example.aapremote.model.AppError
+import com.example.aapremote.testInstance
+import com.example.aapremote.testJobTemplate
+import com.example.aapremote.testLabel1
+import com.example.aapremote.testLabel2
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TemplatesViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeRepo: FakeTemplateRepository
+    private lateinit var fakeTokenManager: FakeTokenManager
+    private lateinit var viewModel: TemplatesViewModel
+
+    @Before
+    fun setup() {
+        fakeRepo = FakeTemplateRepository()
+        fakeTokenManager = FakeTokenManager()
+    }
+
+    private fun createViewModel(): TemplatesViewModel {
+        return TemplatesViewModel(fakeRepo, fakeTokenManager)
+    }
+
+    // --- Init / active instance ---
+
+    @Test
+    fun `initial state is Idle when no active instance`() = runTest {
+        viewModel = createViewModel()
+        assertEquals(TemplatesUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `auto-loads templates when active instance exists`() = runTest {
+        val templates = listOf(testJobTemplate(id = 1), testJobTemplate(id = 2, name = "Backup DB"))
+        fakeRepo.templates = templates
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is TemplatesUiState.Success)
+            assertEquals(2, (state as TemplatesUiState.Success).templates.size)
+        }
+    }
+
+    // --- loadTemplates ---
+
+    @Test
+    fun `loadTemplates success emits Success state`() = runTest {
+        val templates = listOf(testJobTemplate(id = 1, name = "Deploy App"))
+        fakeRepo.templates = templates
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is TemplatesUiState.Success)
+            val success = state as TemplatesUiState.Success
+            assertEquals(1, success.templates.size)
+            assertEquals("Deploy App", success.templates[0].name)
+            assertEquals(false, success.hasMore)
+        }
+    }
+
+    @Test
+    fun `loadTemplates error emits Error state`() = runTest {
+        fakeRepo.shouldFail = true
+        fakeRepo.failureException = RuntimeException("Network failure")
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is TemplatesUiState.Error)
+            assertTrue((state as TemplatesUiState.Error).error is AppError.Unknown)
+        }
+    }
+
+    // --- Search ---
+
+    @Test
+    fun `search passes query to repository`() = runTest {
+        fakeRepo.templates = listOf(testJobTemplate())
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        // Wait for initial load
+        viewModel.uiState.test {
+            expectMostRecentItem()
+        }
+
+        viewModel.search("deploy")
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is TemplatesUiState.Success)
+            assertEquals("deploy", fakeRepo.lastSearchQuery)
+        }
+    }
+
+    @Test
+    fun `search with blank query clears search`() = runTest {
+        fakeRepo.templates = listOf(testJobTemplate())
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.search("deploy")
+        viewModel.search("")
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+            assertEquals(null, fakeRepo.lastSearchQuery)
+        }
+    }
+
+    // --- filterByLabel ---
+
+    @Test
+    fun `filterByLabel passes label name to repository`() = runTest {
+        fakeRepo.templates = listOf(testJobTemplate(labels = listOf(testLabel1)))
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.filterByLabel(testLabel1)
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+            assertEquals("production", fakeRepo.lastLabelFilter)
+        }
+    }
+
+    @Test
+    fun `filterByLabel with null clears filter`() = runTest {
+        fakeRepo.templates = listOf(testJobTemplate())
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.filterByLabel(testLabel1)
+        viewModel.filterByLabel(null)
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+            assertEquals(null, fakeRepo.lastLabelFilter)
+        }
+    }
+
+    // --- Labels extraction ---
+
+    @Test
+    fun `Success state extracts available labels from templates`() = runTest {
+        fakeRepo.templates = listOf(
+            testJobTemplate(id = 1, labels = listOf(testLabel1, testLabel2)),
+            testJobTemplate(id = 2, labels = listOf(testLabel1))
+        )
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem() as TemplatesUiState.Success
+            // Labels should be deduplicated and sorted by name
+            assertEquals(2, state.availableLabels.size)
+            assertEquals("production", state.availableLabels[0].name)
+            assertEquals("staging", state.availableLabels[1].name)
+        }
+    }
+
+    // --- Launch flow ---
+
+    @Test
+    fun `requestLaunch with no vars shows Confirming state`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        val template = testJobTemplate(askVariablesOnLaunch = false)
+        viewModel.requestLaunch(template)
+
+        assertEquals(LaunchState.Confirming(template), viewModel.launchState.value)
+    }
+
+    @Test
+    fun `requestLaunch with askVars shows EnteringVars state`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        val template = testJobTemplate(askVariablesOnLaunch = true)
+        viewModel.requestLaunch(template)
+
+        assertEquals(LaunchState.EnteringVars(template), viewModel.launchState.value)
+    }
+
+    @Test
+    fun `confirmLaunch success emits Launched state`() = runTest {
+        fakeRepo.launchResult = 99
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        val template = testJobTemplate()
+        viewModel.requestLaunch(template)
+        viewModel.confirmLaunch()
+
+        viewModel.launchState.test {
+            val state = expectMostRecentItem()
+            assertEquals(LaunchState.Launched(99), state)
+        }
+    }
+
+    @Test
+    fun `confirmLaunch error emits LaunchError state`() = runTest {
+        fakeRepo.shouldFail = true
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        val template = testJobTemplate()
+        viewModel.requestLaunch(template)
+        viewModel.confirmLaunch()
+
+        viewModel.launchState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is LaunchState.LaunchError)
+        }
+    }
+
+    @Test
+    fun `cancelLaunch resets to Idle`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.requestLaunch(testJobTemplate())
+        viewModel.cancelLaunch()
+
+        assertEquals(LaunchState.Idle, viewModel.launchState.value)
+    }
+
+    @Test
+    fun `resetLaunchState resets to Idle`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.requestLaunch(testJobTemplate())
+        viewModel.confirmLaunch()
+        viewModel.resetLaunchState()
+
+        assertEquals(LaunchState.Idle, viewModel.launchState.value)
+    }
+
+    // --- loadMore ---
+
+    @Test
+    fun `loadMore increments page when hasMore is true`() = runTest {
+        fakeRepo.templates = listOf(testJobTemplate())
+        fakeRepo.hasMore = true
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        // Wait for initial load
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is TemplatesUiState.Success)
+            assertTrue((state as TemplatesUiState.Success).hasMore)
+        }
+
+        fakeRepo.hasMore = false
+        viewModel.loadMore()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is TemplatesUiState.Success)
+            assertEquals(2, fakeRepo.lastRequestedPage)
+        }
+    }
+
+    @Test
+    fun `loadMore does nothing when hasMore is false`() = runTest {
+        fakeRepo.templates = listOf(testJobTemplate())
+        fakeRepo.hasMore = false
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+        }
+
+        val callsBefore = fakeRepo.getTemplatesCalled
+        viewModel.loadMore()
+        assertEquals(callsBefore, fakeRepo.getTemplatesCalled)
+    }
+
+    // --- clearFilters ---
+
+    @Test
+    fun `clearFilters resets search query and reloads`() = runTest {
+        fakeRepo.templates = listOf(testJobTemplate())
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.search("deploy")
+        viewModel.filterByLabel(testLabel1)
+        viewModel.clearFilters()
+
+        assertEquals("", viewModel.searchQuery.value)
+        assertEquals(null, fakeRepo.lastSearchQuery)
+        assertEquals(null, fakeRepo.lastLabelFilter)
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/presentation/workflows/WorkflowJobStatusViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/presentation/workflows/WorkflowJobStatusViewModelTest.kt
@@ -1,0 +1,281 @@
+package com.example.aapremote.presentation.workflows
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.example.aapremote.MainDispatcherRule
+import com.example.aapremote.fakes.FakeJobRepository
+import com.example.aapremote.fakes.FakeWorkflowRepository
+import com.example.aapremote.model.AppError
+import com.example.aapremote.model.JobStatus
+import com.example.aapremote.testWorkflowJob
+import com.example.aapremote.testWorkflowNode
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WorkflowJobStatusViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeWorkflowRepo: FakeWorkflowRepository
+    private lateinit var fakeJobRepo: FakeJobRepository
+
+    @Before
+    fun setup() {
+        fakeWorkflowRepo = FakeWorkflowRepository()
+        fakeJobRepo = FakeJobRepository()
+    }
+
+    private fun createViewModel(workflowJobId: Int = 42): WorkflowJobStatusViewModel {
+        val savedStateHandle = SavedStateHandle(mapOf("workflowJobId" to workflowJobId))
+        return WorkflowJobStatusViewModel(savedStateHandle, fakeWorkflowRepo, fakeJobRepo)
+    }
+
+    // --- Initial state ---
+
+    @Test
+    fun `initial state is Loading`() = runTest {
+        val viewModel = createViewModel()
+        assertEquals(WorkflowJobStatusUiState.Loading, viewModel.uiState.value)
+    }
+
+    // --- Polling with active workflow job ---
+
+    @Test
+    fun `startPolling with running workflow job emits Active state`() = runTest {
+        val workflowJob = testWorkflowJob(id = 42, status = JobStatus.RUNNING)
+        val nodes = listOf(
+            testWorkflowNode(id = 1, jobId = 10, jobName = "Step 1", jobStatus = JobStatus.SUCCESSFUL),
+            testWorkflowNode(id = 2, jobId = 11, jobName = "Step 2", jobStatus = JobStatus.RUNNING)
+        )
+        fakeWorkflowRepo.workflowJob = workflowJob
+        fakeWorkflowRepo.nodes = nodes
+
+        val viewModel = createViewModel(workflowJobId = 42)
+        viewModel.startPolling()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is WorkflowJobStatusUiState.Active)
+            val active = state as WorkflowJobStatusUiState.Active
+            assertEquals(42, active.workflowJob.id)
+            assertEquals(JobStatus.RUNNING, active.workflowJob.status)
+            assertEquals(2, active.nodes.size)
+        }
+    }
+
+    // --- Polling with completed workflow job ---
+
+    @Test
+    fun `startPolling with completed workflow job emits Completed state`() = runTest {
+        val workflowJob = testWorkflowJob(
+            id = 42,
+            status = JobStatus.SUCCESSFUL,
+            finished = "2024-01-15T10:05:00Z"
+        )
+        val nodes = listOf(
+            testWorkflowNode(id = 1, jobId = 10, jobStatus = JobStatus.SUCCESSFUL)
+        )
+        fakeWorkflowRepo.workflowJob = workflowJob
+        fakeWorkflowRepo.nodes = nodes
+
+        val viewModel = createViewModel(workflowJobId = 42)
+        viewModel.startPolling()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is WorkflowJobStatusUiState.Completed)
+            val completed = state as WorkflowJobStatusUiState.Completed
+            assertEquals(JobStatus.SUCCESSFUL, completed.workflowJob.status)
+            assertEquals(1, completed.nodes.size)
+        }
+    }
+
+    @Test
+    fun `startPolling with failed workflow job emits Completed state`() = runTest {
+        val workflowJob = testWorkflowJob(id = 42, status = JobStatus.FAILED, failed = true)
+        fakeWorkflowRepo.workflowJob = workflowJob
+
+        val viewModel = createViewModel(workflowJobId = 42)
+        viewModel.startPolling()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is WorkflowJobStatusUiState.Completed)
+            assertEquals(JobStatus.FAILED, (state as WorkflowJobStatusUiState.Completed).workflowJob.status)
+        }
+    }
+
+    // --- Error handling ---
+
+    @Test
+    fun `startPolling error emits Error state`() = runTest {
+        fakeWorkflowRepo.shouldFail = true
+        fakeWorkflowRepo.failureException = RuntimeException("Connection failed")
+
+        val viewModel = createViewModel(workflowJobId = 42)
+        viewModel.startPolling()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is WorkflowJobStatusUiState.Error)
+            assertTrue((state as WorkflowJobStatusUiState.Error).error is AppError.Unknown)
+        }
+    }
+
+    // --- Invalid workflowJobId ---
+
+    @Test
+    fun `startPolling does nothing with invalid workflowJobId`() = runTest {
+        val viewModel = createViewModel(workflowJobId = -1)
+        viewModel.startPolling()
+
+        assertEquals(WorkflowJobStatusUiState.Loading, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `startPolling does nothing with zero workflowJobId`() = runTest {
+        val viewModel = createViewModel(workflowJobId = 0)
+        viewModel.startPolling()
+
+        assertEquals(WorkflowJobStatusUiState.Loading, viewModel.uiState.value)
+    }
+
+    // --- Node expansion ---
+
+    @Test
+    fun `toggleNodeExpansion sets expanded node id`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.toggleNodeExpansion(10)
+
+        assertEquals(10, viewModel.expandedNodeId.value)
+    }
+
+    @Test
+    fun `toggleNodeExpansion collapses when toggled again`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.toggleNodeExpansion(10)
+        viewModel.toggleNodeExpansion(10)
+
+        assertNull(viewModel.expandedNodeId.value)
+    }
+
+    @Test
+    fun `toggleNodeExpansion switches to new node`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.toggleNodeExpansion(10)
+        viewModel.toggleNodeExpansion(20)
+
+        assertEquals(20, viewModel.expandedNodeId.value)
+    }
+
+    // --- Node stdout ---
+
+    @Test
+    fun `expanding node fetches stdout`() = runTest {
+        fakeJobRepo.jobStdout = "PLAY [all] ***"
+
+        val viewModel = createViewModel()
+        viewModel.toggleNodeExpansion(10)
+
+        viewModel.nodeStdout.test {
+            val stdout = expectMostRecentItem()
+            assertTrue(stdout[10] is NodeStdoutState.Loaded)
+            assertEquals("PLAY [all] ***", (stdout[10] as NodeStdoutState.Loaded).stdout)
+        }
+    }
+
+    @Test
+    fun `expanding node with blank stdout shows no output message`() = runTest {
+        fakeJobRepo.jobStdout = ""
+
+        val viewModel = createViewModel()
+        viewModel.toggleNodeExpansion(10)
+
+        viewModel.nodeStdout.test {
+            val stdout = expectMostRecentItem()
+            assertTrue(stdout[10] is NodeStdoutState.Loaded)
+            assertEquals("No output available", (stdout[10] as NodeStdoutState.Loaded).stdout)
+        }
+    }
+
+    @Test
+    fun `expanding node with stdout error shows Error state`() = runTest {
+        fakeJobRepo.stdoutShouldFail = true
+        fakeJobRepo.failureException = RuntimeException("Failed to fetch")
+
+        val viewModel = createViewModel()
+        viewModel.toggleNodeExpansion(10)
+
+        viewModel.nodeStdout.test {
+            val stdout = expectMostRecentItem()
+            assertTrue(stdout[10] is NodeStdoutState.Error)
+            assertEquals("Failed to fetch", (stdout[10] as NodeStdoutState.Error).message)
+        }
+    }
+
+    @Test
+    fun `re-expanding cached node does not refetch stdout`() = runTest {
+        fakeJobRepo.jobStdout = "initial output"
+
+        val viewModel = createViewModel()
+        viewModel.toggleNodeExpansion(10)
+
+        // Verify stdout loaded
+        viewModel.nodeStdout.test {
+            assertTrue(expectMostRecentItem()[10] is NodeStdoutState.Loaded)
+        }
+
+        // Collapse
+        viewModel.toggleNodeExpansion(10)
+        // Change stdout
+        fakeJobRepo.jobStdout = "different output"
+        // Re-expand
+        viewModel.toggleNodeExpansion(10)
+
+        // Should still have cached value
+        viewModel.nodeStdout.test {
+            val loaded = expectMostRecentItem()[10] as NodeStdoutState.Loaded
+            assertEquals("initial output", loaded.stdout)
+        }
+    }
+
+    // --- Retry ---
+
+    @Test
+    fun `retry resets to Loading and restarts polling`() = runTest {
+        fakeWorkflowRepo.shouldFail = true
+        val viewModel = createViewModel(workflowJobId = 42)
+        viewModel.startPolling()
+
+        viewModel.uiState.test {
+            assertTrue(expectMostRecentItem() is WorkflowJobStatusUiState.Error)
+        }
+
+        fakeWorkflowRepo.shouldFail = false
+        fakeWorkflowRepo.workflowJob = testWorkflowJob(id = 42, status = JobStatus.SUCCESSFUL)
+        viewModel.retry()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is WorkflowJobStatusUiState.Completed)
+        }
+    }
+
+    // --- stopPolling ---
+
+    @Test
+    fun `stopPolling does not crash when no polling active`() {
+        val viewModel = createViewModel(workflowJobId = 42)
+        viewModel.stopPolling()
+        assertEquals(WorkflowJobStatusUiState.Loading, viewModel.uiState.value)
+    }
+}

--- a/app/src/test/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/presentation/workflows/WorkflowTemplatesViewModelTest.kt
@@ -1,0 +1,289 @@
+package com.example.aapremote.presentation.workflows
+
+import app.cash.turbine.test
+import com.example.aapremote.MainDispatcherRule
+import com.example.aapremote.fakes.FakeTokenManager
+import com.example.aapremote.fakes.FakeWorkflowRepository
+import com.example.aapremote.model.AppError
+import com.example.aapremote.testInstance
+import com.example.aapremote.testLabel1
+import com.example.aapremote.testLabel2
+import com.example.aapremote.testWorkflowJobTemplate
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WorkflowTemplatesViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeRepo: FakeWorkflowRepository
+    private lateinit var fakeTokenManager: FakeTokenManager
+    private lateinit var viewModel: WorkflowTemplatesViewModel
+
+    @Before
+    fun setup() {
+        fakeRepo = FakeWorkflowRepository()
+        fakeTokenManager = FakeTokenManager()
+    }
+
+    private fun createViewModel(): WorkflowTemplatesViewModel {
+        return WorkflowTemplatesViewModel(fakeRepo, fakeTokenManager)
+    }
+
+    // --- Init / active instance ---
+
+    @Test
+    fun `initial state is Idle when no active instance`() = runTest {
+        viewModel = createViewModel()
+        assertEquals(WorkflowTemplatesUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `auto-loads templates when active instance exists`() = runTest {
+        fakeRepo.templates = listOf(
+            testWorkflowJobTemplate(id = 1),
+            testWorkflowJobTemplate(id = 2, name = "CI Pipeline")
+        )
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is WorkflowTemplatesUiState.Success)
+            assertEquals(2, (state as WorkflowTemplatesUiState.Success).templates.size)
+        }
+    }
+
+    // --- loadTemplates ---
+
+    @Test
+    fun `loadTemplates success emits Success state`() = runTest {
+        fakeRepo.templates = listOf(testWorkflowJobTemplate(id = 1, name = "Full Deploy"))
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is WorkflowTemplatesUiState.Success)
+            val success = state as WorkflowTemplatesUiState.Success
+            assertEquals(1, success.templates.size)
+            assertEquals("Full Deploy", success.templates[0].name)
+        }
+    }
+
+    @Test
+    fun `loadTemplates error emits Error state`() = runTest {
+        fakeRepo.shouldFail = true
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is WorkflowTemplatesUiState.Error)
+            assertTrue((state as WorkflowTemplatesUiState.Error).error is AppError.Unknown)
+        }
+    }
+
+    // --- Search ---
+
+    @Test
+    fun `search passes query to repository`() = runTest {
+        fakeRepo.templates = listOf(testWorkflowJobTemplate())
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test { expectMostRecentItem() }
+
+        viewModel.search("pipeline")
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+            assertEquals("pipeline", fakeRepo.lastSearchQuery)
+        }
+    }
+
+    @Test
+    fun `search with blank query clears search`() = runTest {
+        fakeRepo.templates = listOf(testWorkflowJobTemplate())
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.search("pipeline")
+        viewModel.search("")
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+            assertEquals(null, fakeRepo.lastSearchQuery)
+        }
+    }
+
+    // --- filterByLabel ---
+
+    @Test
+    fun `filterByLabel passes label name to repository`() = runTest {
+        fakeRepo.templates = listOf(testWorkflowJobTemplate(labels = listOf(testLabel1)))
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.filterByLabel(testLabel1)
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+            assertEquals("production", fakeRepo.lastLabelFilter)
+        }
+    }
+
+    // --- Labels extraction ---
+
+    @Test
+    fun `Success state extracts available labels from templates`() = runTest {
+        fakeRepo.templates = listOf(
+            testWorkflowJobTemplate(id = 1, labels = listOf(testLabel1, testLabel2)),
+            testWorkflowJobTemplate(id = 2, labels = listOf(testLabel1))
+        )
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem() as WorkflowTemplatesUiState.Success
+            assertEquals(2, state.availableLabels.size)
+            assertEquals("production", state.availableLabels[0].name)
+            assertEquals("staging", state.availableLabels[1].name)
+        }
+    }
+
+    // --- Launch flow ---
+
+    @Test
+    fun `requestLaunch with no vars shows Confirming state`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        val template = testWorkflowJobTemplate(askVariablesOnLaunch = false)
+        viewModel.requestLaunch(template)
+
+        assertEquals(WorkflowLaunchState.Confirming(template), viewModel.launchState.value)
+    }
+
+    @Test
+    fun `requestLaunch with askVars shows EnteringVars state`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        val template = testWorkflowJobTemplate(askVariablesOnLaunch = true)
+        viewModel.requestLaunch(template)
+
+        assertEquals(WorkflowLaunchState.EnteringVars(template), viewModel.launchState.value)
+    }
+
+    @Test
+    fun `confirmLaunch success emits Launched state`() = runTest {
+        fakeRepo.launchResult = 77
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        val template = testWorkflowJobTemplate()
+        viewModel.requestLaunch(template)
+        viewModel.confirmLaunch()
+
+        viewModel.launchState.test {
+            val state = expectMostRecentItem()
+            assertEquals(WorkflowLaunchState.Launched(77), state)
+        }
+    }
+
+    @Test
+    fun `confirmLaunch error emits LaunchError state`() = runTest {
+        fakeRepo.shouldFail = true
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        val template = testWorkflowJobTemplate()
+        viewModel.requestLaunch(template)
+        viewModel.confirmLaunch()
+
+        viewModel.launchState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is WorkflowLaunchState.LaunchError)
+        }
+    }
+
+    @Test
+    fun `cancelLaunch resets to Idle`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.requestLaunch(testWorkflowJobTemplate())
+        viewModel.cancelLaunch()
+
+        assertEquals(WorkflowLaunchState.Idle, viewModel.launchState.value)
+    }
+
+    @Test
+    fun `resetLaunchState resets to Idle`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.requestLaunch(testWorkflowJobTemplate())
+        viewModel.confirmLaunch()
+        viewModel.resetLaunchState()
+
+        assertEquals(WorkflowLaunchState.Idle, viewModel.launchState.value)
+    }
+
+    // --- loadMore ---
+
+    @Test
+    fun `loadMore increments page when hasMore is true`() = runTest {
+        fakeRepo.templates = listOf(testWorkflowJobTemplate())
+        fakeRepo.hasMore = true
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue((state as WorkflowTemplatesUiState.Success).hasMore)
+        }
+
+        fakeRepo.hasMore = false
+        viewModel.loadMore()
+
+        viewModel.uiState.test {
+            expectMostRecentItem()
+            assertEquals(2, fakeRepo.lastRequestedPage)
+        }
+    }
+
+    @Test
+    fun `loadMore does nothing when hasMore is false`() = runTest {
+        fakeRepo.templates = listOf(testWorkflowJobTemplate())
+        fakeRepo.hasMore = false
+
+        fakeTokenManager.setInstances(listOf(testInstance))
+        viewModel = createViewModel()
+
+        viewModel.uiState.test { expectMostRecentItem() }
+
+        fakeRepo.lastRequestedPage = 0
+        viewModel.loadMore()
+        assertEquals(0, fakeRepo.lastRequestedPage)
+    }
+}


### PR DESCRIPTION
## Summary

- Extract interfaces for all 13 repositories + TokenManager + AapApiProvider to enable dependency injection of test fakes
- Create 11 fake repository implementations in test source set with error simulation and pagination controls
- Add 154 unit tests across 13 ViewModel test classes covering all presentation-layer ViewModels
- Add shared test infrastructure: MainDispatcherRule (coroutine testing), TestData (fixtures)
- Update Koin modules to bind both concrete and interface types (backward-compatible)
- All 14 ViewModel constructors now depend on interfaces instead of concrete types

## Test plan

- [x] `./gradlew compileDebugKotlin` passes
- [x] `./gradlew testDebugUnitTest` passes (all 289 tests: 135 existing + 154 new)
- [ ] CI passes

Closes #87

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>