### PR TITLE
Fix chat UI: IME padding, Enter key, reverse layout

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.AAPRemoteControl">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/kotlin/com/example/aapremote/assistant/ui/AssistantScreen.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/ui/AssistantScreen.kt
@@ -1,11 +1,16 @@
 package com.example.aapremote.assistant.ui
 
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -35,6 +40,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
@@ -133,6 +139,7 @@ fun AssistantScreen(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ActiveChatContent(
     state: AssistantUiState.Active,
@@ -154,9 +161,17 @@ private fun ActiveChatContent(
         }
     }
 
+    val imeVisible = WindowInsets.isImeVisible
+
     LaunchedEffect(state.messages.size) {
         if (state.messages.isNotEmpty()) {
-            listState.animateScrollToItem(state.messages.size - 1)
+            listState.animateScrollToItem(0)
+        }
+    }
+
+    LaunchedEffect(imeVisible) {
+        if (imeVisible && state.messages.isNotEmpty()) {
+            listState.animateScrollToItem(0)
         }
     }
 
@@ -164,7 +179,7 @@ private fun ActiveChatContent(
         focusRequester.requestFocus()
     }
 
-    Column(modifier = modifier) {
+    Column(modifier = modifier.imePadding()) {
         if (state.connections.isNotEmpty()) {
             val connected = state.connections.count { it.value is McpConnectionState.Connected }
             val total = state.connections.size
@@ -199,11 +214,13 @@ private fun ActiveChatContent(
 
         LazyColumn(
             state = listState,
+            reverseLayout = true,
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            contentPadding = PaddingValues(top = 8.dp, bottom = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom)
         ) {
             if (state.messages.isEmpty()) {
                 item {
@@ -223,7 +240,7 @@ private fun ActiveChatContent(
             }
 
             items(
-                items = state.messages,
+                items = state.messages.asReversed(),
                 key = { it.id },
                 contentType = { it.role }
             ) { message ->
@@ -246,7 +263,10 @@ private fun ActiveChatContent(
                     .testTag("field_assistant_input")
                     .focusRequester(focusRequester)
                     .onPreviewKeyEvent {
-                        if (it.type == KeyEventType.KeyUp && it.key == Key.Enter) {
+                        if (it.type == KeyEventType.KeyUp &&
+                            it.key == Key.Enter &&
+                            it.isCtrlPressed
+                        ) {
                             submit()
                             true
                         } else false

--- a/app/src/main/kotlin/com/example/aapremote/ui/main/MainScreen.kt
+++ b/app/src/main/kotlin/com/example/aapremote/ui/main/MainScreen.kt
@@ -6,12 +6,9 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.union
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Settings
@@ -20,7 +17,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
@@ -117,9 +113,7 @@ fun MainScreen(
             )
         },
         bottomBar = {
-            NavigationBar(
-                windowInsets = NavigationBarDefaults.windowInsets.union(WindowInsets.ime)
-            ) {
+            NavigationBar {
                 tabs.forEachIndexed { index, tab ->
                     NavigationBarItem(
                         modifier = Modifier.testTag("nav_${tab.route.substringAfterLast("/")}"),


### PR DESCRIPTION
## Summary

- **IME handling**: Added `adjustResize` to manifest and `imePadding()` to chat content — keyboard no longer covers the input field
- **Enter key**: Require Ctrl+Enter to send from hardware keyboard, plain Enter inserts newline (soft keyboard Send button still works)
- **Reverse layout**: LazyColumn uses `reverseLayout = true` so messages anchor at bottom — last message is always fully visible
- **Auto-scroll**: Scrolls to latest message when keyboard opens
- **NavigationBar**: Removed IME inset union to prevent double padding

Closes #58

## Test plan

- [ ] Open Assistant tab, tap text field — keyboard opens, input stays visible above keyboard
- [ ] Type with Enter — inserts newlines, does not send
- [ ] Tap soft keyboard Send button — sends message
- [ ] Ctrl+Enter on hardware keyboard — sends message
- [ ] Last message bubble is fully visible (not cut off by input field)
- [ ] Messages auto-scroll when keyboard opens
- [ ] Switch tabs while keyboard open — no NavigationBar glitch
- [ ] Unit tests pass: `./gradlew testDebugUnitTest`

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>