### PR TITLE
Add native Gemini client to fix tool call deserialization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,6 +107,7 @@ dependencies {
     implementation(libs.okhttp.sse)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.koog.openai.client)
+    implementation(libs.koog.google.client)
     implementation(libs.ktor.client.cio)
 
     implementation(libs.koin.core)

--- a/app/src/main/kotlin/com/example/aapremote/assistant/llm/GeminiLlmProvider.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/llm/GeminiLlmProvider.kt
@@ -1,0 +1,88 @@
+package com.example.aapremote.assistant.llm
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.google.GoogleLLMClient
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.llm.LLMProvider as KoogLLMProvider
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.http.client.KoogHttpClientException
+import ai.koog.prompt.executor.clients.LLMClientException
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.ServerResponseException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import java.net.SocketTimeoutException
+
+class GeminiLlmProvider(
+    apiKey: String,
+    modelId: String
+) : LlmProvider {
+
+    private val client = GoogleLLMClient(apiKey = apiKey)
+
+    private val model = LLModel(
+        provider = KoogLLMProvider.Google,
+        id = modelId,
+        capabilities = listOf(
+            LLMCapability.Completion,
+            LLMCapability.Tools,
+            LLMCapability.Temperature
+        )
+    )
+
+    override fun generateStream(
+        prompt: Prompt,
+        tools: List<ToolDescriptor>,
+        maxTokens: Int?
+    ): Flow<StreamFrame> = flow {
+        client.executeStreaming(prompt, model, tools).collect { frame ->
+            emit(frame)
+        }
+    }.catch { e ->
+        throw mapException(e)
+    }
+
+    override fun isAvailable(): Boolean = true
+
+    override fun modelInfo(): ModelInfo = ModelInfo(
+        name = model.id,
+        isLocal = false
+    )
+
+    override fun close() {
+        client.close()
+    }
+
+    internal fun mapException(e: Throwable): Throwable = when (e) {
+        is LlmAuthException, is LlmRateLimitException,
+        is LlmServerException, is LlmTimeoutException -> e
+        is LLMClientException -> {
+            val cause = e.cause
+            if (cause != null) mapException(cause) else LlmServerException("LLM error: ${e.message}")
+        }
+        is KoogHttpClientException -> {
+            val code = e.statusCode
+            when {
+                code == 401 || code == 403 -> LlmAuthException("Authentication failed — check your Google API key")
+                code == 429 -> LlmRateLimitException("Rate limited — try again later")
+                code != null && code >= 500 -> LlmServerException("Gemini server error ($code): ${e.message}")
+                code != null -> LlmServerException("Gemini error ($code): ${e.message}")
+                else -> LlmServerException("Gemini error: ${e.message}")
+            }
+        }
+        is ClientRequestException -> {
+            val code = e.response.status.value
+            when (code) {
+                401, 403 -> LlmAuthException("Authentication failed — check your Google API key")
+                429 -> LlmRateLimitException("Rate limited — try again later")
+                else -> LlmServerException("Gemini error ($code): ${e.message}")
+            }
+        }
+        is ServerResponseException -> LlmServerException("Gemini server error: ${e.message}")
+        is SocketTimeoutException -> LlmTimeoutException("Request timed out")
+        else -> e
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/llm/LlmProvider.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/llm/LlmProvider.kt
@@ -5,7 +5,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.streaming.StreamFrame
 import kotlinx.coroutines.flow.Flow
 
-interface LlmProvider {
+interface LlmProvider : java.io.Closeable {
     fun generateStream(prompt: Prompt, tools: List<ToolDescriptor>, maxTokens: Int? = null): Flow<StreamFrame>
     fun isAvailable(): Boolean
     fun modelInfo(): ModelInfo

--- a/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
@@ -12,7 +12,9 @@ import com.example.aapremote.assistant.engine.ChatMessage
 import com.example.aapremote.assistant.engine.Role
 import com.example.aapremote.assistant.engine.ToolExecutor
 import com.example.aapremote.assistant.engine.ToolRouter
+import com.example.aapremote.assistant.llm.GeminiLlmProvider
 import com.example.aapremote.assistant.llm.KoogLlmProvider
+import com.example.aapremote.assistant.llm.LlmProvider
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.data.ITokenManager
 import com.example.aapremote.model.McpServerConfig
@@ -44,7 +46,7 @@ class AssistantViewModel(
     val activeInstance get() = tokenManager.activeInstance.value
 
     private var generateJob: Job? = null
-    private var cachedProvider: KoogLlmProvider? = null
+    private var cachedProvider: LlmProvider? = null
     private var cachedProviderKey: String? = null
 
     private val _llmConfig = MutableStateFlow<LlmProviderConfig?>(null)
@@ -345,11 +347,17 @@ class AssistantViewModel(
     private fun getOrCreateProvider(
         config: LlmProviderConfig.OpenAiCompatible,
         trustSelfSigned: Boolean
-    ): KoogLlmProvider {
+    ): LlmProvider {
         val key = "${config.url}|${config.model}|${config.apiKey}|$trustSelfSigned"
         cachedProvider?.let { if (cachedProviderKey == key) return it }
         cachedProvider?.close()
-        return KoogLlmProvider(config, trustSelfSigned).also {
+        val isGemini = config.url.contains("generativelanguage.googleapis.com")
+        val provider: LlmProvider = if (isGemini) {
+            GeminiLlmProvider(apiKey = config.apiKey ?: "", modelId = config.model)
+        } else {
+            KoogLlmProvider(config, trustSelfSigned)
+        }
+        return provider.also {
             cachedProvider = it
             cachedProviderKey = key
         }

--- a/app/src/test/kotlin/com/example/aapremote/assistant/engine/ChatEngineTest.kt
+++ b/app/src/test/kotlin/com/example/aapremote/assistant/engine/ChatEngineTest.kt
@@ -160,6 +160,7 @@ private class FakeLlmProvider(
 
     override fun isAvailable(): Boolean = true
     override fun modelInfo(): ModelInfo = ModelInfo("fake-model")
+    override fun close() {}
 }
 
 private class FakeTool(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ androidx-test-runner = { group = "androidx.test", name = "runner", version.ref =
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidx-test-rules" }
 screenshot-validation-api = { group = "com.android.tools.screenshot", name = "screenshot-validation-api", version.ref = "screenshot" }
 koog-openai-client = { group = "ai.koog", name = "prompt-executor-openai-client", version.ref = "koog" }
+koog-google-client = { group = "ai.koog", name = "prompt-executor-google-client", version.ref = "koog" }
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
 markdown-renderer = { group = "com.mikepenz", name = "multiplatform-markdown-renderer", version.ref = "markdownRenderer" }
 markdown-renderer-m3 = { group = "com.mikepenz", name = "multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }

--- a/scripts/ollama-proxy.sh
+++ b/scripts/ollama-proxy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Caddy reverse proxy for Ollama with TLS (self-signed)
+# Usage: ./ollama-proxy.sh [port] [ollama_port]
+
+PORT="${1:-8443}"
+OLLAMA_PORT="${2:-11434}"
+IP=$(hostname -I | awk '{print $1}')
+CADDYFILE=$(mktemp)
+
+cat > "$CADDYFILE" <<EOF
+{
+	auto_https disable_redirects
+}
+
+https://${IP}:${PORT} {
+	tls internal
+	reverse_proxy localhost:${OLLAMA_PORT}
+}
+EOF
+
+echo "Ollama TLS proxy: https://${IP}:${PORT}/v1"
+echo "Model list:       https://${IP}:${PORT}/v1/models"
+echo "Ollama backend:   http://localhost:${OLLAMA_PORT}"
+echo ""
+echo "For AAPdroid LLM config:"
+echo "  URL:   https://${IP}:${PORT}/v1"
+echo "  Cert:  Enable 'Accept self-signed certificate'"
+echo ""
+
+caddy run --config "$CADDYFILE" --adapter caddyfile


### PR DESCRIPTION
## Summary

- Adds `GeminiLlmProvider` using Koog's native `GoogleLLMClient` — bypasses the OpenAI-compatible endpoint that fails on Gemini's missing `index` field in streaming tool calls
- Auto-detects Gemini URLs in the provider factory (`generativelanguage.googleapis.com`) and routes to the native client
- Adds `LlmProvider.close()` to the interface (both providers implement `Closeable`)
- Versions `scripts/ollama-proxy.sh` (Caddy HTTPS proxy for local Ollama testing)

Closes #98

## Test plan

- [ ] Configure Google Gemini with API key, send tool-calling query (e.g., "list job templates") — no deserialization error
- [ ] Configure OpenRouter/OpenAI, verify still works via OpenAI client
- [ ] Unit tests pass: `./gradlew testDebugUnitTest`

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>