### PR TITLE
Assistant pipeline: debug logging, tool reliability, history compaction

### DIFF
--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
@@ -330,11 +330,12 @@ class ChatEngine(
         private const val TAG = "ChatEngine"
         private const val DEFAULT_CONTEXT_CHARS = 16_000
         const val SYSTEM_PROMPT = """You are a concise AI assistant for Ansible Automation Platform (AAP). Rules:
-- NEVER fabricate, invent, or guess data. Only present information returned by tool calls. If you have no tool to answer a question, say so clearly.
+- NEVER fabricate, invent, or guess data. Only present information returned by tool calls. If a tool call fails, report the error — do not make up results. If you have no tool to answer a question, say so clearly.
+- You have local tools (list_jobs, launch_job, etc.) that connect directly to the AAP instance and MCP tools (controller.*, eda.*) for extended capabilities. Prefer local tools when available.
 - When results contain more than 10 items, show a summary with total count and the 5 most recent. Ask before listing all.
 - Use short structured formatting (bullets, bold labels). No lengthy prose.
 - Never repeat raw tool output verbatim — summarize it.
-- You have local tools (list_jobs, launch_job, etc.) that connect directly to the AAP instance and MCP tools (controller.*, eda.*) for extended capabilities. Prefer local tools when available.
-- For write operations (launch, cancel, toggle), explain what you will do and wait for confirmation."""
+- For write operations (launch, cancel, toggle), explain what you will do and wait for confirmation.
+- For optional tool parameters you don't need, omit them entirely — do not pass null or empty values."""
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
@@ -45,7 +45,8 @@ class ChatEngine(
         userMessage: String,
         history: List<ChatMessage>,
         tools: List<ToolSpec>,
-        maxTokens: Int? = null
+        maxTokens: Int? = null,
+        contextChars: Int = DEFAULT_CONTEXT_CHARS
     ): Flow<ChatEvent> = flow {
         try {
             val messages = mutableListOf<ChatMessage>()
@@ -67,6 +68,7 @@ class ChatEngine(
             var iterations = 0
             var totalToolCalls = 0
             val toolCallHistory = mutableListOf<List<String>>()
+            val softLimit = (contextChars * 0.9).toInt()
 
             loop@ while (iterations < maxIterations) {
                 iterations++
@@ -74,7 +76,8 @@ class ChatEngine(
                 val textBuilder = StringBuilder()
                 val pendingToolCalls = mutableMapOf<String, MutableToolCall>()
 
-                trimMessages(messages)
+                compactHistory(messages, softLimit)
+                trimMessages(messages, contextChars)
                 val prompt = buildPrompt(messages)
 
                 provider.generateStream(prompt, toolDescriptors, maxTokens).collect { frame ->
@@ -293,6 +296,52 @@ class ChatEngine(
         if (history.size < 3) return false
         val last = history.last()
         return history[history.size - 2] == last && history[history.size - 3] == last
+    }
+
+    private fun compactHistory(
+        messages: MutableList<ChatMessage>,
+        softLimit: Int
+    ) {
+        val totalChars = messages.sumOf { it.content.length }
+        if (totalChars <= softLimit) return
+
+        val systemCount = messages.takeWhile { it.role == Role.SYSTEM }.size
+        val keepTail = 4
+        if (messages.size <= systemCount + keepTail) return
+
+        val compactEnd = messages.size - keepTail
+        val toCompact = messages.subList(systemCount, compactEnd)
+        if (toCompact.isEmpty()) return
+
+        Log.d(TAG, "COMPACT: $totalChars chars > $softLimit soft limit, " +
+            "compacting ${toCompact.size} messages (keeping last $keepTail)")
+
+        val summaries = mutableListOf<String>()
+        var i = 0
+        while (i < toCompact.size) {
+            val msg = toCompact[i]
+            when (msg.role) {
+                Role.USER -> {
+                    val topic = msg.content.take(40).replace("\n", " ").trim()
+                    val nextAssistant = toCompact.getOrNull(i + 1)
+                    val result = if (nextAssistant?.role == Role.ASSISTANT && nextAssistant.toolCallsJson == null) {
+                        nextAssistant.content.take(40).replace("\n", " ").trim()
+                        .let { if (it.length >= 40) "${it}…" else it }
+                    } else null
+                    summaries.add(if (result != null) "$topic ($result)" else topic)
+                    i++
+                }
+                Role.TOOL, Role.ASSISTANT -> i++
+                else -> i++
+            }
+        }
+
+        toCompact.clear()
+        if (summaries.isNotEmpty()) {
+            val digest = "[Earlier: ${summaries.joinToString("; ")}]"
+            messages.add(systemCount, ChatMessage(role = Role.ASSISTANT, content = digest))
+            Log.d(TAG, "COMPACT: ${summaries.size} exchanges → ${digest.length} chars")
+        }
     }
 
     private fun trimMessages(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatEngine.kt
@@ -10,6 +10,7 @@ import com.example.aapremote.assistant.llm.LlmProvider
 import com.example.aapremote.assistant.llm.LlmRateLimitException
 import com.example.aapremote.assistant.llm.LlmServerException
 import com.example.aapremote.assistant.llm.LlmTimeoutException
+import com.example.aapremote.assistant.engine.DebugLog as Log
 import com.example.aapremote.assistant.tools.ToolSpec
 import com.example.aapremote.assistant.tools.toToolDescriptor
 import kotlinx.coroutines.CancellationException
@@ -54,6 +55,15 @@ class ChatEngine(
             messages.add(ChatMessage(role = Role.USER, content = userMessage))
 
             val toolDescriptors = tools.map { it.toToolDescriptor() }
+            val toolSchemaChars = toolDescriptors.sumOf {
+                it.name.length + it.description.length +
+                    it.requiredParameters.sumOf { p -> p.name.length + p.description.length + 20 } +
+                    it.optionalParameters.sumOf { p -> p.name.length + p.description.length + 20 }
+            }
+            val msgChars = messages.sumOf { it.content.length }
+            Log.d(TAG, "PAYLOAD: ${tools.size} tools (~${toolSchemaChars} schema chars), " +
+                "${messages.size} messages (~${msgChars} msg chars), total ~${toolSchemaChars + msgChars} chars")
+            Log.d(TAG, "PAYLOAD tools: ${tools.map { it.name }}")
             var iterations = 0
             var totalToolCalls = 0
             val toolCallHistory = mutableListOf<List<String>>()
@@ -105,12 +115,15 @@ class ChatEngine(
                 val responseText = textBuilder.toString().ifEmpty { null }
 
                 if (completedCalls.isNotEmpty() && iterations < maxIterations) {
+                    Log.d(TAG, "ITER $iterations: ${completedCalls.size} tool calls: " +
+                        "${completedCalls.map { it.tool }}")
                     val currentSignature = completedCalls.map {
                         "${it.tool}:${it.content.hashCode()}"
                     }
                     toolCallHistory.add(currentSignature)
 
                     if (isRepeatingToolCalls(toolCallHistory)) {
+                        Log.w(TAG, "ITER $iterations: repeat detected, stopping")
                         emit(ChatEvent.AssistantMessage(
                             (responseText ?: "") + "\n\nStopped: the same tools were being called repeatedly.",
                             totalToolCalls
@@ -162,6 +175,8 @@ class ChatEngine(
                         compactToolMessages(messages, toolSummaries)
                     }
                 } else {
+                    Log.d(TAG, "DONE: $iterations iterations, $totalToolCalls total tool calls, " +
+                        "response=${responseText?.length ?: 0} chars")
                     val finalText = if (completedCalls.isNotEmpty() && iterations >= maxIterations) {
                         (responseText ?: "") + "\n\nI wasn't able to complete this request within the tool call limit."
                     } else {
@@ -179,14 +194,19 @@ class ChatEngine(
         } catch (e: CancellationException) {
             throw e
         } catch (e: LlmAuthException) {
+            Log.e(TAG, "AUTH error: ${e.message}", e)
             emit(ChatEvent.Error(e.message ?: "Authentication failed — check API key", e))
         } catch (e: LlmRateLimitException) {
+            Log.w(TAG, "RATE_LIMIT: ${e.message}")
             emit(ChatEvent.Error(e.message ?: "Rate limited — try again later", e))
         } catch (e: LlmTimeoutException) {
+            Log.w(TAG, "TIMEOUT: ${e.message}")
             emit(ChatEvent.Error("Response timed out", e))
         } catch (e: IOException) {
+            Log.e(TAG, "IO error: ${e.message}", e)
             emit(ChatEvent.Error("Unable to reach LLM server: ${e.message}", e))
         } catch (e: Exception) {
+            Log.e(TAG, "Unexpected error: ${e.message}", e)
             emit(ChatEvent.Error("Error: ${e.message}", e))
         }
     }
@@ -281,6 +301,7 @@ class ChatEngine(
     ) {
         val totalChars = messages.sumOf { it.content.length }
         if (totalChars <= maxChars) return
+        Log.d(TAG, "TRIM: $totalChars chars > $maxChars limit, trimming ${messages.size} messages")
 
         val systemMessages = messages.takeWhile { it.role == Role.SYSTEM }
         val systemChars = systemMessages.sumOf { it.content.length }
@@ -306,6 +327,7 @@ class ChatEngine(
     }
 
     companion object {
+        private const val TAG = "ChatEngine"
         private const val DEFAULT_CONTEXT_CHARS = 16_000
         const val SYSTEM_PROMPT = """You are a concise AI assistant for Ansible Automation Platform (AAP). Rules:
 - NEVER fabricate, invent, or guess data. Only present information returned by tool calls. If you have no tool to answer a question, say so clearly.

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/DebugLog.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/DebugLog.kt
@@ -1,0 +1,16 @@
+package com.example.aapremote.assistant.engine
+
+object DebugLog {
+    fun d(tag: String, msg: String) {
+        try { android.util.Log.d(tag, msg) } catch (_: RuntimeException) { }
+    }
+    fun w(tag: String, msg: String) {
+        try { android.util.Log.w(tag, msg) } catch (_: RuntimeException) { }
+    }
+    fun e(tag: String, msg: String, t: Throwable? = null) {
+        try {
+            if (t != null) android.util.Log.e(tag, msg, t)
+            else android.util.Log.e(tag, msg)
+        } catch (_: RuntimeException) { }
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolExecutor.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolExecutor.kt
@@ -77,6 +77,7 @@ class ToolExecutor(
         val finalLen = finalResult.data?.length ?: 0
         Log.d(TAG, "EXEC: ${toolCall.tool} ${if (finalResult.success) "OK" else "FAIL"} " +
             "in ${elapsedMs}ms, result=${rawLen}→${if (cappedLen != rawLen) "${cappedLen}→" else ""}${finalLen} chars")
+        Log.d(TAG, "EXEC DATA: ${finalResult.data?.take(500)}")
 
         if (finalResult.success) {
             resultCache[cacheKey] = System.currentTimeMillis() to finalResult

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolExecutor.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolExecutor.kt
@@ -1,6 +1,7 @@
 package com.example.aapremote.assistant.engine
 
 import ai.koog.prompt.message.Message
+import com.example.aapremote.assistant.engine.DebugLog as Log
 import com.example.aapremote.assistant.tools.ErrorType
 import com.example.aapremote.assistant.tools.Tool
 import com.example.aapremote.assistant.tools.ToolResult
@@ -23,15 +24,19 @@ class ToolExecutor(
 
     suspend fun execute(toolCall: Message.Tool.Call): ToolResult {
         val tool = tools.find { it.spec.name == toolCall.tool }
-            ?: return ToolResult(
-                success = false,
-                data = "Tool '${toolCall.tool}' not found",
-                errorType = ErrorType.NOT_FOUND
-            )
+            ?: run {
+                Log.w(TAG, "EXEC: tool '${toolCall.tool}' not found in ${tools.size} registered tools")
+                return ToolResult(
+                    success = false,
+                    data = "Tool '${toolCall.tool}' not found",
+                    errorType = ErrorType.NOT_FOUND
+                )
+            }
 
         val cacheKey = "${toolCall.tool}:${toolCall.content.hashCode()}"
         val cached = resultCache[cacheKey]
         if (cached != null && System.currentTimeMillis() - cached.first < CACHE_TTL_MS) {
+            Log.d(TAG, "EXEC: cache hit for ${toolCall.tool}")
             return cached.second
         }
 
@@ -42,27 +47,37 @@ class ToolExecutor(
             JsonObject(emptyMap())
         }
 
+        Log.d(TAG, "EXEC: ${toolCall.tool}(${toolCall.content.take(200)})")
+        val startMs = System.currentTimeMillis()
         val result = try {
             withTimeout(30_000L) {
                 tool.execute(argsJson)
             }
         } catch (_: TimeoutCancellationException) {
+            Log.w(TAG, "EXEC: ${toolCall.tool} timed out after 30s")
             return ToolResult(
                 success = false,
                 data = "Tool '${toolCall.tool}' timed out after 30s",
                 errorType = ErrorType.TIMEOUT
             )
         }
+        val elapsedMs = System.currentTimeMillis() - startMs
+        val rawLen = result.data?.length ?: 0
 
         val capped = if (result.data != null) {
             result.copy(data = capResultArray(result.data))
         } else result
+        val cappedLen = capped.data?.length ?: 0
 
         val finalResult = if (capped.data != null && capped.data.length > maxResultChars) {
             capped.copy(data = smartTruncate(capped.data, maxResultChars))
         } else {
             capped
         }
+        val finalLen = finalResult.data?.length ?: 0
+        Log.d(TAG, "EXEC: ${toolCall.tool} ${if (finalResult.success) "OK" else "FAIL"} " +
+            "in ${elapsedMs}ms, result=${rawLen}→${if (cappedLen != rawLen) "${cappedLen}→" else ""}${finalLen} chars")
+
         if (finalResult.success) {
             resultCache[cacheKey] = System.currentTimeMillis() to finalResult
         }
@@ -70,6 +85,7 @@ class ToolExecutor(
     }
 
     companion object {
+        private const val TAG = "ToolExecutor"
         private const val CACHE_TTL_MS = 120_000L
         private const val MAX_ARRAY_ITEMS = 10
         private val json = Json { ignoreUnknownKeys = true }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ToolRouter.kt
@@ -1,5 +1,6 @@
 package com.example.aapremote.assistant.engine
 
+import com.example.aapremote.assistant.engine.DebugLog as Log
 import com.example.aapremote.assistant.tools.LocalTool
 import com.example.aapremote.assistant.tools.Tool
 import com.example.aapremote.assistant.tools.ToolSource
@@ -98,6 +99,8 @@ class ToolRouter {
     }
 
     companion object {
+        private const val TAG = "ToolRouter"
+
         val OVERLAP_MAPPING = mapOf(
             "list_job_templates" to setOf("controller.job_templates_list"),
             "launch_job" to setOf("controller.job_templates_launch_create"),
@@ -185,12 +188,17 @@ class ToolRouter {
     ): QueryResult {
         val queryWords = query.lowercase().split(Regex("\\W+")).toSet()
         val stemmedQuery = (queryWords - STOP_WORDS).map { stem(it) }.toSet()
+        Log.d(TAG, "QUERY: words=$queryWords, stemmed=$stemmedQuery")
 
         val matchedCategories = Category.entries.filter { category ->
             category.stemmedKeywords.any { it in stemmedQuery }
         }
 
-        if (matchedCategories.isEmpty()) return QueryResult(emptyList(), categoryMatched = false)
+        if (matchedCategories.isEmpty()) {
+            Log.d(TAG, "QUERY: no categories matched")
+            return QueryResult(emptyList(), categoryMatched = false)
+        }
+        Log.d(TAG, "QUERY: matched categories=${matchedCategories.map { it.name }}")
 
         val matchedLocalNames = matchedCategories.flatMap { it.localToolNames }.toSet()
         val matchedPrefixes = matchedCategories.flatMap { it.resourcePrefixes }.toSet()
@@ -228,14 +236,17 @@ class ToolRouter {
             matchesCategory && isEnabled && passesReadOnly
         }
 
+        Log.d(TAG, "FILTER: ${filteredLocal.size} local, ${filteredMcp.size} mcp after category+enable+readOnly filter")
         val cherryPickedLocal = cherryPick(filteredLocal, stemmedQuery)
         val cherryPickedMcp = cherryPick(filteredMcp, stemmedQuery)
+        Log.d(TAG, "CHERRY: ${cherryPickedLocal.size} local [${cherryPickedLocal.map { it.spec.name }}], " +
+            "${cherryPickedMcp.size} mcp [${cherryPickedMcp.map { it.spec.name }}]")
 
         return QueryResult(cherryPickedLocal + cherryPickedMcp, categoryMatched = true)
     }
 
     private fun cherryPick(tools: List<Tool>, stemmedQuery: Set<String>): List<Tool> {
-        return tools.map { tool ->
+        val scored = tools.map { tool ->
             val nameParts = tool.spec.name
                 .split(".", "_")
                 .map { stem(it) }
@@ -247,6 +258,8 @@ class ToolRouter {
             if (overlap > 0 && tool is LocalTool && tool.destructive) score -= 5
             tool to score
         }
+        Log.d(TAG, "SCORES: ${scored.map { "${it.first.spec.name}=${it.second}" }}")
+        return scored
             .filter { it.second > 0 }
             .sortedByDescending { it.second }
             .map { it.first }
@@ -261,11 +274,17 @@ class ToolRouter {
 
     private fun autoDisableOverlappingMcpTools() {
         val activeLocalNames = localTools.map { it.spec.name }.toSet()
+        var disabledCount = 0
         for (localName in activeLocalNames) {
             val overlappingMcpNames = OVERLAP_MAPPING[localName] ?: continue
             for (mcpName in overlappingMcpNames) {
                 disabledTools.add(mcpName to ToolSource.MCP)
+                disabledCount++
             }
         }
+        if (disabledCount > 0) {
+            Log.d(TAG, "OVERLAP: disabled $disabledCount MCP tools overlapping with ${activeLocalNames.size} local tools")
+        }
     }
+
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
@@ -20,6 +20,7 @@ import com.example.aapremote.data.ITokenManager
 import com.example.aapremote.model.McpServerConfig
 import com.example.aapremote.network.CertTrustManager
 import com.example.aapremote.network.mcp.McpServerManager
+import com.example.aapremote.assistant.engine.DebugLog as Log
 
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -59,6 +60,8 @@ class AssistantViewModel(
     val modelFetchState: StateFlow<ModelFetchState> = _modelFetchState.asStateFlow()
 
     init {
+        Log.d(TAG, "INIT: ${localTools.size} local tools: ${localTools.map { it.spec.name }}")
+
         viewModelScope.launch {
             _llmConfig.value = repository.loadLlmConfig()
         }
@@ -123,17 +126,23 @@ class AssistantViewModel(
         val provider = getOrCreateProvider(config as LlmProviderConfig.OpenAiCompatible, trustSelfSigned)
 
         mcpServerManager.refreshConnections()
+        val mcpTools = mcpServerManager.getAllTools()
         val serverConfigs = tokenManager.activeInstance.value?.mcpServerUrls ?: emptyList()
         val toolRouter = ToolRouter()
         toolRouter.registerLocalTools(localTools)
-        toolRouter.registerMcpTools(mcpServerManager.getAllTools())
+        toolRouter.registerMcpTools(mcpTools)
+        Log.d(TAG, "ROUTE: query=\"$text\", ${localTools.size} local, ${mcpTools.size} mcp tools available")
         val queryResult = toolRouter.getToolsForQuery(text, serverConfigs)
         val mode = config.tokenSavingMode
+        Log.d(TAG, "ROUTE: categoryMatched=${queryResult.categoryMatched}, " +
+            "${queryResult.tools.size} tools selected, mode=$mode")
 
         val noToolsForCategory = queryResult.categoryMatched && queryResult.tools.isEmpty()
         val generalQueryInToolsOnly = !queryResult.categoryMatched && mode == TokenSavingMode.TOOLS_ONLY
 
         if (noToolsForCategory || generalQueryInToolsOnly) {
+            Log.d(TAG, "ROUTE: no tools path — noToolsForCategory=$noToolsForCategory, " +
+                "generalQueryInToolsOnly=$generalQueryInToolsOnly")
             val hasMcp = mcpServerManager.getAllTools().isNotEmpty()
             val content = if (generalQueryInToolsOnly) {
                 "I can help you query your AAP instance. Try asking about:\n\n" +
@@ -174,6 +183,8 @@ class AssistantViewModel(
         val matchedLocal = queryResult.tools.filterIsInstance<LocalTool>()
         val matchedMcp = queryResult.tools.filter { it !is LocalTool }.take(mcpLimit)
         val budgetedTools = matchedLocal + matchedMcp
+        Log.d(TAG, "BUDGET: ${matchedLocal.size} local [${matchedLocal.map { it.spec.name }}], " +
+            "${matchedMcp.size} mcp (limit=$mcpLimit) [${matchedMcp.map { it.spec.name }}]")
         val toolSpecs = budgetedTools.map { it.spec }
         val toolExecutor = ToolExecutor(budgetedTools)
         val engine = ChatEngine(provider, toolExecutor)
@@ -387,5 +398,9 @@ class AssistantViewModel(
             if (current is AssistantUiState.Active) current.transform()
             else current
         }
+    }
+
+    companion object {
+        private const val TAG = "AssistantVM"
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
@@ -16,6 +16,7 @@ import com.example.aapremote.assistant.llm.GeminiLlmProvider
 import com.example.aapremote.assistant.llm.KoogLlmProvider
 import com.example.aapremote.assistant.llm.LlmProvider
 import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.local.ListToolsLocalTool
 import com.example.aapremote.data.ITokenManager
 import com.example.aapremote.model.McpServerConfig
 import com.example.aapremote.network.CertTrustManager
@@ -182,9 +183,14 @@ class AssistantViewModel(
         }
         val matchedLocal = queryResult.tools.filterIsInstance<LocalTool>()
         val matchedMcp = queryResult.tools.filter { it !is LocalTool }.take(mcpLimit)
-        val budgetedTools = matchedLocal + matchedMcp
-        Log.d(TAG, "BUDGET: ${matchedLocal.size} local [${matchedLocal.map { it.spec.name }}], " +
-            "${matchedMcp.size} mcp (limit=$mcpLimit) [${matchedMcp.map { it.spec.name }}]")
+        val budgetedTools = if (matchedLocal.isEmpty() && matchedMcp.isEmpty()) {
+            val listTool = ListToolsLocalTool { toolRouter.getAllRegisteredTools() }
+            listOf(listTool)
+        } else {
+            matchedLocal + matchedMcp
+        }
+        Log.d(TAG, "BUDGET: ${budgetedTools.size} tools [${budgetedTools.map { it.spec.name }}]" +
+            if (matchedLocal.isEmpty() && matchedMcp.isEmpty()) " (fallback: list_tools)" else "")
         val toolSpecs = budgetedTools.map { it.spec }
         val toolExecutor = ToolExecutor(budgetedTools)
         val engine = ChatEngine(provider, toolExecutor)

--- a/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
@@ -195,6 +195,11 @@ class AssistantViewModel(
         val toolExecutor = ToolExecutor(budgetedTools)
         val engine = ChatEngine(provider, toolExecutor)
         val maxTokens: Int? = null
+        val contextChars = when (mode) {
+            TokenSavingMode.STANDARD -> 16_000
+            TokenSavingMode.TOKEN_SAVER -> 8_000
+            TokenSavingMode.TOOLS_ONLY -> 4_000
+        }
 
         generateJob?.cancel()
         generateJob = viewModelScope.launch {
@@ -213,7 +218,7 @@ class AssistantViewModel(
 
             replaceOrAddAssistant("Thinking...")
 
-            engine.processMessage(text, repository.getHistory(), toolSpecs, maxTokens)
+            engine.processMessage(text, repository.getHistory(), toolSpecs, maxTokens, contextChars)
                 .collect { event ->
                     when (event) {
                         is ChatEvent.TextDelta -> {

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/LocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/LocalTool.kt
@@ -23,7 +23,13 @@ abstract class LocalTool(
         this[name]?.jsonPrimitive?.intOrNull
 
     protected fun JsonObject.stringArg(name: String): String? =
-        this[name]?.jsonPrimitive?.contentOrNull
+        this[name]?.jsonPrimitive?.contentOrNull?.takeUnless { it in NULL_SENTINELS }
+
+    companion object {
+        private val NULL_SENTINELS = setOf(
+            "<nil>", "null", "none", "nil", "", "undefined", "N/A"
+        )
+    }
 
     protected fun JsonObject.booleanArg(name: String): Boolean? =
         this[name]?.jsonPrimitive?.booleanOrNull

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/LocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/LocalTool.kt
@@ -22,6 +22,9 @@ abstract class LocalTool(
     protected fun JsonObject.intArg(name: String): Int? =
         this[name]?.jsonPrimitive?.intOrNull
 
+    protected fun JsonObject.pageArg(name: String = "page"): Int =
+        (intArg(name) ?: 1).coerceAtLeast(1)
+
     protected fun JsonObject.stringArg(name: String): String? =
         this[name]?.jsonPrimitive?.contentOrNull?.takeUnless { it in NULL_SENTINELS }
 

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListCredentialsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListCredentialsLocalTool.kt
@@ -24,7 +24,7 @@ class ListCredentialsLocalTool(
     override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
         val result = repository.getCredentials(
-            page = args.intArg("page") ?: 1,
+            page = args.pageArg(),
             pageSize = pageSize,
             search = args.stringArg("search")
         ).getOrThrow()

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaActivationsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaActivationsLocalTool.kt
@@ -23,7 +23,7 @@ class ListEdaActivationsLocalTool(
     override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 20
         val result = repository.getActivations(
-            page = args.intArg("page") ?: 1,
+            page = args.pageArg(),
             pageSize = pageSize
         ).getOrThrow()
         ToolResult(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaAuditRulesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListEdaAuditRulesLocalTool.kt
@@ -23,7 +23,7 @@ class ListEdaAuditRulesLocalTool(
     override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 10
         val result = repository.getAuditRules(
-            page = args.intArg("page") ?: 1,
+            page = args.pageArg(),
             pageSize = pageSize
         ).getOrThrow()
         ToolResult(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListExecutionEnvironmentsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListExecutionEnvironmentsLocalTool.kt
@@ -23,7 +23,7 @@ class ListExecutionEnvironmentsLocalTool(
     override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
         val result = repository.getExecutionEnvironments(
-            page = args.intArg("page") ?: 1,
+            page = args.pageArg(),
             pageSize = pageSize
         ).getOrThrow()
         ToolResult(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListHostsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListHostsLocalTool.kt
@@ -23,7 +23,7 @@ class ListHostsLocalTool(
 ) {
     override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val inventoryId = args.intArg("inventory_id")
-        val page = args.intArg("page") ?: 1
+        val page = args.pageArg()
         val search = args.stringArg("search")
 
         val result = if (inventoryId != null) {

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstanceGroupsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstanceGroupsLocalTool.kt
@@ -23,7 +23,7 @@ class ListInstanceGroupsLocalTool(
     override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
         val result = repository.getInstanceGroups(
-            page = args.intArg("page") ?: 1,
+            page = args.pageArg(),
             pageSize = pageSize
         ).getOrThrow()
         ToolResult(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstancesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInstancesLocalTool.kt
@@ -23,7 +23,7 @@ class ListInstancesLocalTool(
     override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
         val result = repository.getInstances(
-            page = args.intArg("page") ?: 1,
+            page = args.pageArg(),
             pageSize = pageSize
         ).getOrThrow()
         ToolResult(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInventoriesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListInventoriesLocalTool.kt
@@ -22,7 +22,7 @@ class ListInventoriesLocalTool(
 ) {
     override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val result = repository.getInventories(
-            page = args.intArg("page") ?: 1,
+            page = args.pageArg(),
             search = args.stringArg("search")
         ).getOrThrow()
         ToolResult(

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListJobTemplatesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListJobTemplatesLocalTool.kt
@@ -23,7 +23,7 @@ class ListJobTemplatesLocalTool(
 ) {
     override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val result = repository.getTemplates(
-            page = args.intArg("page") ?: 1,
+            page = args.pageArg(),
             search = args.stringArg("search"),
             labelFilter = args.stringArg("labels")
         ).getOrThrow()

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListJobsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListJobsLocalTool.kt
@@ -28,7 +28,7 @@ class ListJobsLocalTool(
         } ?: emptySet()
         val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 10
         val result = repository.getRecentJobs(
-            page = args.intArg("page") ?: 1,
+            page = args.pageArg(),
             pageSize = pageSize,
             statusFilters = statusFilter
         ).getOrThrow()

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListProjectsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListProjectsLocalTool.kt
@@ -24,7 +24,7 @@ class ListProjectsLocalTool(
     override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
         val result = repository.getProjects(
-            page = args.intArg("page") ?: 1,
+            page = args.pageArg(),
             pageSize = pageSize,
             search = args.stringArg("search")
         ).getOrThrow()

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListSchedulesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListSchedulesLocalTool.kt
@@ -21,7 +21,7 @@ class ListSchedulesLocalTool(
 ) {
     override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val result = repository.getSchedules(
-            page = args.intArg("page") ?: 1
+            page = args.pageArg()
         ).getOrThrow()
         ToolResult(
             success = true,

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListToolsLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListToolsLocalTool.kt
@@ -1,0 +1,39 @@
+package com.example.aapremote.assistant.tools.local
+
+import com.example.aapremote.assistant.tools.LocalTool
+import com.example.aapremote.assistant.tools.Tool
+import com.example.aapremote.assistant.tools.ToolResult
+import com.example.aapremote.assistant.tools.ToolSource
+import com.example.aapremote.assistant.tools.ToolSpec
+import kotlinx.serialization.json.JsonObject
+
+class ListToolsLocalTool(
+    private val toolsProvider: () -> List<Pair<Tool, ToolSource>>
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_tools",
+        description = "List all available tools and their capabilities",
+        parametersSchema = buildToolSchema()
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val tools = toolsProvider()
+        val local = tools.filter { it.second == ToolSource.LOCAL }
+        val mcp = tools.filter { it.second == ToolSource.MCP }
+        val sb = StringBuilder()
+        sb.appendLine("Available tools (${tools.size} total):")
+        if (local.isNotEmpty()) {
+            sb.appendLine("\nLocal tools (${local.size}):")
+            local.forEach { (tool, _) ->
+                sb.appendLine("- ${tool.spec.name}: ${tool.spec.description}")
+            }
+        }
+        if (mcp.isNotEmpty()) {
+            sb.appendLine("\nMCP tools (${mcp.size}):")
+            mcp.forEach { (tool, _) ->
+                sb.appendLine("- ${tool.spec.name}: ${tool.spec.description}")
+            }
+        }
+        ToolResult(success = true, data = sb.toString())
+    }
+}

--- a/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListWorkflowTemplatesLocalTool.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/tools/local/ListWorkflowTemplatesLocalTool.kt
@@ -23,7 +23,7 @@ class ListWorkflowTemplatesLocalTool(
 ) {
     override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
         val result = repository.getWorkflowTemplates(
-            page = args.intArg("page") ?: 1,
+            page = args.pageArg(),
             search = args.stringArg("search"),
             labelFilter = args.stringArg("labels")
         ).getOrThrow()

--- a/app/src/main/kotlin/com/example/aapremote/assistant/ui/ChatBubble.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/ui/ChatBubble.kt
@@ -82,7 +82,14 @@ fun ChatBubble(
                     Markdown(
                         content = message.content,
                         colors = markdownColor(),
-                        typography = markdownTypography(),
+                        typography = markdownTypography(
+                            h1 = MaterialTheme.typography.titleLarge,
+                            h2 = MaterialTheme.typography.titleMedium,
+                            h3 = MaterialTheme.typography.titleSmall,
+                            h4 = MaterialTheme.typography.labelLarge,
+                            h5 = MaterialTheme.typography.labelMedium,
+                            h6 = MaterialTheme.typography.labelSmall,
+                        ),
                         components = markdownComponents(
                             codeBlock = {
                                 MarkdownHighlightedCodeBlock(


### PR DESCRIPTION
## Summary
- Adds end-to-end debug logging across the assistant pipeline: `AssistantVM`, `ToolRouter`, `ChatEngine`, `ToolExecutor` (#104)
- Fixes small-model null sentinel args (`<nil>`, `""`, `null`) breaking tool calls (#102)
- Adds `pageArg()` clamping (min 1) for AAP's 1-based pagination (#102)
- Scales down markdown headings in chat bubbles for proper chat sizing (#58)
- Adds `list_tools` fallback tool for meta queries ("what can you do?") (#102)
- Adds context-aware history compaction per token saving mode (#102)

## Debug logging (temporary, tracked in #104)
Uses `DebugLog` wrapper so unit tests pass without Robolectric. Filter with:
```
adb logcat -s AssistantVM ToolRouter ChatEngine ToolExecutor
```

## Fixes (permanent)
- `LocalTool.stringArg()` filters null sentinel values that small LLMs send as optional params
- `LocalTool.pageArg()` clamps page to minimum 1 (AAP returns 404 for page=0)
- `ChatBubble` markdown typography overridden from `displayLarge` to `titleLarge..labelSmall`
- `ListToolsLocalTool` injected as fallback when no ToolRouter category matches
- `compactHistory()` summarizes older exchanges at 90% of context limit; `trimMessages()` drops at hard limit

## Context limits by mode
| Mode | Soft (compact) | Hard (trim) |
|------|---------------|-------------|
| Standard | 14,400 | 16,000 |
| Token Saver | 7,200 | 8,000 |
| Tools Only | 3,600 | 4,000 |

## Test plan
- [x] `./gradlew compileDebugKotlin` passes
- [x] `./gradlew testDebugUnitTest` passes
- [x] Emulator: 26 local tools loaded via logcat
- [x] Emulator: "list job templates" returns 4 real templates (was 0 with `<nil>` args)
- [x] Emulator: heading renders at chat-appropriate size
- [x] Emulator: compaction triggers in Tools Only mode after ~6 exchanges
- [x] Emulator: Standard mode does not compact at same history size

Closes #102, closes #58
Parent: #104

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>