### PR TITLE
Fix chat UI flickering and restyle messages (#103)

### DIFF
--- a/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatMessage.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/engine/ChatMessage.kt
@@ -4,16 +4,21 @@ import java.util.concurrent.atomic.AtomicLong
 
 enum class Role { USER, ASSISTANT, TOOL, SYSTEM }
 
+enum class ResponseSource { LOCAL, MCP, LLM, MIXED }
+
 data class ChatMessage(
     val role: Role,
     val content: String,
     val toolCallsJson: String? = null,
     val toolCallId: String? = null,
     val toolName: String? = null,
+    val source: ResponseSource? = null,
+    val toolsUsed: List<String> = emptyList(),
     val timestamp: Long = System.currentTimeMillis(),
-    val id: Long = nextId.getAndIncrement()
+    val id: Long = nextId()
 ) {
     companion object {
-        private val nextId = AtomicLong(0)
+        private val counter = AtomicLong(0)
+        fun nextId(): Long = counter.getAndIncrement()
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantUiState.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantUiState.kt
@@ -10,6 +10,7 @@ sealed interface AssistantUiState {
     data class Active(
         val messages: List<ChatMessage> = emptyList(),
         val isGenerating: Boolean = false,
+        val streamingText: String? = null,
         val connections: Map<String, McpConnectionState> = emptyMap()
     ) : AssistantUiState
     data class Error(val error: AppError) : AssistantUiState

--- a/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/presentation/AssistantViewModel.kt
@@ -9,6 +9,7 @@ import com.example.aapremote.assistant.data.TokenSavingMode
 import com.example.aapremote.assistant.engine.ChatEngine
 import com.example.aapremote.assistant.engine.ChatEvent
 import com.example.aapremote.assistant.engine.ChatMessage
+import com.example.aapremote.assistant.engine.ResponseSource
 import com.example.aapremote.assistant.engine.Role
 import com.example.aapremote.assistant.engine.ToolExecutor
 import com.example.aapremote.assistant.engine.ToolRouter
@@ -107,7 +108,8 @@ class AssistantViewModel(
                     current.copy(
                         messages = current.messages + ChatMessage(
                             role = Role.ASSISTANT,
-                            content = "Please configure an LLM provider in settings first."
+                            content = "Please configure an LLM provider in settings first.",
+                            source = ResponseSource.LLM
                         )
                     )
                 } else current
@@ -170,7 +172,7 @@ class AssistantViewModel(
                     "- **Monitoring** — system health, instance status\n" +
                     "- **Configuration** — projects, settings, notifications"
             }
-            val guidanceMsg = ChatMessage(role = Role.ASSISTANT, content = content)
+            val guidanceMsg = ChatMessage(role = Role.ASSISTANT, content = content, source = ResponseSource.LLM)
             repository.addMessage(guidanceMsg)
             updateState { copy(messages = repository.getHistory(), isGenerating = false) }
             return
@@ -204,60 +206,52 @@ class AssistantViewModel(
         generateJob?.cancel()
         generateJob = viewModelScope.launch {
             val textBuilder = StringBuilder()
-            var hasPlaceholder = false
+            val usedSources = mutableSetOf<String>()
+            val usedToolNames = mutableListOf<String>()
+            val localNames = matchedLocal.map { it.spec.name }.toSet()
 
-            fun replaceOrAddAssistant(content: String) {
-                updateState {
-                    val msg = ChatMessage(role = Role.ASSISTANT, content = content)
-                    val msgs = if (hasPlaceholder) messages.dropLast(1) + msg
-                        else messages + msg
-                    copy(messages = msgs)
-                }
-                hasPlaceholder = true
-            }
-
-            replaceOrAddAssistant("Thinking...")
+            updateState { copy(streamingText = "Thinking...") }
 
             engine.processMessage(text, repository.getHistory(), toolSpecs, maxTokens, contextChars)
                 .collect { event ->
                     when (event) {
                         is ChatEvent.TextDelta -> {
                             textBuilder.append(event.text)
-                            replaceOrAddAssistant(textBuilder.toString())
+                            updateState { copy(streamingText = "Generating response...") }
                         }
                         is ChatEvent.ToolExecuting -> {
-                            val localNames = matchedLocal.map { it.spec.name }.toSet()
-                            val source = if (event.toolName in localNames) "local" else "mcp"
-                            replaceOrAddAssistant("Querying [$source]: ${event.toolName}...")
+                            val toolSource = if (event.toolName in localNames) "local" else "mcp"
+                            usedSources.add(toolSource)
+                            usedToolNames.add(event.toolName)
+                            updateState { copy(streamingText = "Querying [$toolSource]: ${event.toolName}...") }
                         }
                         is ChatEvent.ToolResult -> {
-                            replaceOrAddAssistant("Processing results...")
+                            updateState { copy(streamingText = "Processing results...") }
                             textBuilder.clear()
                         }
                         is ChatEvent.AssistantMessage -> {
-                            hasPlaceholder = false
-                            updateState {
-                                val msgs = messages.dropLast(1)
-                                copy(messages = msgs)
+                            val responseSource = when {
+                                usedSources.isEmpty() -> ResponseSource.LLM
+                                usedSources.size > 1 -> ResponseSource.MIXED
+                                "local" in usedSources -> ResponseSource.LOCAL
+                                else -> ResponseSource.MCP
                             }
                             val finalMsg = ChatMessage(
                                 role = Role.ASSISTANT,
-                                content = event.fullText
+                                content = event.fullText,
+                                source = responseSource,
+                                toolsUsed = usedToolNames.distinct()
                             )
                             repository.addMessage(finalMsg)
                             updateState {
                                 copy(
                                     messages = repository.getHistory(),
-                                    isGenerating = false
+                                    isGenerating = false,
+                                    streamingText = null
                                 )
                             }
                         }
                         is ChatEvent.Error -> {
-                            hasPlaceholder = false
-                            updateState {
-                                val msgs = messages.dropLast(1)
-                                copy(messages = msgs)
-                            }
                             val errorMsg = ChatMessage(
                                 role = Role.ASSISTANT,
                                 content = "Error: ${event.message}"
@@ -266,7 +260,8 @@ class AssistantViewModel(
                             updateState {
                                 copy(
                                     messages = repository.getHistory(),
-                                    isGenerating = false
+                                    isGenerating = false,
+                                    streamingText = null
                                 )
                             }
                         }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/ui/AssistantScreen.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/ui/AssistantScreen.kt
@@ -1,20 +1,31 @@
 package com.example.aapremote.assistant.ui
 
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material3.CircularProgressIndicator
@@ -22,7 +33,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.ui.platform.testTag
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -34,20 +44,25 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.aapremote.assistant.engine.ChatMessage
+import com.example.aapremote.assistant.engine.Role
 import com.example.aapremote.assistant.presentation.AssistantUiState
 import com.example.aapremote.assistant.presentation.AssistantViewModel
 import com.example.aapremote.network.mcp.McpConnectionState
@@ -162,16 +177,20 @@ private fun ActiveChatContent(
     }
 
     val imeVisible = WindowInsets.isImeVisible
+    val messageCount = state.messages.size
+    val hasStreamingSection = state.isGenerating
+    val totalItems = messageCount + (if (hasStreamingSection) 1 else 0) +
+        (if (messageCount == 0 && !hasStreamingSection) 1 else 0)
 
-    LaunchedEffect(state.messages.size) {
-        if (state.messages.isNotEmpty()) {
-            listState.animateScrollToItem(0)
+    LaunchedEffect(messageCount, state.isGenerating) {
+        if (totalItems > 0) {
+            listState.animateScrollToItem(totalItems - 1)
         }
     }
 
     LaunchedEffect(imeVisible) {
-        if (imeVisible && state.messages.isNotEmpty()) {
-            listState.animateScrollToItem(0)
+        if (imeVisible && totalItems > 0) {
+            listState.animateScrollToItem(totalItems - 1)
         }
     }
 
@@ -214,16 +233,15 @@ private fun ActiveChatContent(
 
         LazyColumn(
             state = listState,
-            reverseLayout = true,
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
             contentPadding = PaddingValues(top = 8.dp, bottom = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom)
+            verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
-            if (state.messages.isEmpty()) {
-                item {
+            if (state.messages.isEmpty() && state.streamingText == null) {
+                item(key = "empty_placeholder") {
                     Box(
                         modifier = Modifier
                             .fillParentMaxSize()
@@ -240,11 +258,25 @@ private fun ActiveChatContent(
             }
 
             items(
-                items = state.messages.asReversed(),
+                items = state.messages,
                 key = { it.id },
                 contentType = { it.role }
             ) { message ->
-                ChatBubble(message = message, modifier = Modifier.padding(vertical = 2.dp))
+                when (message.role) {
+                    Role.USER -> UserBubble(message = message)
+                    Role.ASSISTANT -> AssistantMessage(
+                        content = message.content,
+                        source = message.source,
+                        toolsUsed = message.toolsUsed
+                    )
+                    else -> AssistantMessage(content = message.content)
+                }
+            }
+
+            if (state.isGenerating) {
+                item(key = "streaming", contentType = "streaming") {
+                    StreamingIndicator(statusText = state.streamingText ?: "Thinking...")
+                }
             }
         }
 
@@ -292,5 +324,56 @@ private fun ActiveChatContent(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun StreamingIndicator(
+    statusText: String,
+    modifier: Modifier = Modifier
+) {
+    val infiniteTransition = rememberInfiniteTransition(label = "pulse")
+    val scale by infiniteTransition.animateFloat(
+        initialValue = 0.6f,
+        targetValue = 1.0f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 800, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "pulseScale",
+    )
+    val alpha by infiniteTransition.animateFloat(
+        initialValue = 0.4f,
+        targetValue = 1.0f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 800, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "pulseAlpha",
+    )
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                    this.alpha = alpha
+                }
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary)
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = statusText,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/aapremote/assistant/ui/ChatBubble.kt
+++ b/app/src/main/kotlin/com/example/aapremote/assistant/ui/ChatBubble.kt
@@ -1,15 +1,18 @@
 package com.example.aapremote.assistant.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -17,78 +20,119 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.aapremote.assistant.engine.ChatMessage
-import com.example.aapremote.assistant.engine.Role
+import com.example.aapremote.assistant.engine.ResponseSource
+import com.mikepenz.markdown.compose.LocalBulletListHandler
 import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.compose.elements.MarkdownHighlightedCodeBlock
 import com.mikepenz.markdown.compose.elements.MarkdownHighlightedCodeFence
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
+import com.mikepenz.markdown.model.BulletHandler
+import com.mikepenz.markdown.model.markdownDimens
+import com.mikepenz.markdown.model.markdownPadding
 import dev.snipme.highlights.Highlights
+import dev.snipme.highlights.model.SyntaxLanguage
 import dev.snipme.highlights.model.SyntaxThemes
 
 @Composable
-fun ChatBubble(
+fun UserBubble(
     message: ChatMessage,
     modifier: Modifier = Modifier
 ) {
-    val isUser = message.role == Role.USER
-    val isToolIndicator = message.content.startsWith("Querying [")
-    val isError = message.content.startsWith("Error:")
+    SelectionContainer {
+        Row(modifier = modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+            Spacer(Modifier.weight(1f))
+            Column(
+                modifier = Modifier
+                    .background(
+                        MaterialTheme.colorScheme.onBackground.copy(alpha = 0.15f),
+                        RoundedCornerShape(12.dp),
+                    )
+                    .padding(12.dp)
+            ) {
+                Text(
+                    text = message.content,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+            }
+        }
+    }
+}
 
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start
-    ) {
+@Composable
+fun AssistantMessage(
+    content: String,
+    source: ResponseSource? = null,
+    toolsUsed: List<String> = emptyList(),
+    modifier: Modifier = Modifier
+) {
+    val isError = content.startsWith("Error:")
+
+    if (isError) {
         Surface(
-            shape = RoundedCornerShape(
-                topStart = 16.dp,
-                topEnd = 16.dp,
-                bottomStart = if (isUser) 16.dp else 4.dp,
-                bottomEnd = if (isUser) 4.dp else 16.dp
-            ),
-            color = when {
-                isUser -> MaterialTheme.colorScheme.primaryContainer
-                isError -> MaterialTheme.colorScheme.errorContainer
-                isToolIndicator -> MaterialTheme.colorScheme.tertiaryContainer
-                else -> MaterialTheme.colorScheme.surfaceVariant
-            },
-            modifier = Modifier.widthIn(max = 300.dp)
+            shape = RoundedCornerShape(12.dp),
+            color = MaterialTheme.colorScheme.errorContainer,
+            modifier = modifier
         ) {
-            Column(modifier = Modifier.padding(12.dp)) {
-                if (isToolIndicator) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(16.dp),
-                            strokeWidth = 2.dp,
-                            color = MaterialTheme.colorScheme.onTertiaryContainer
-                        )
-                        Text(
-                            text = message.content,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onTertiaryContainer
-                        )
-                    }
-                } else if (!isUser && !isError) {
-                    val isDarkTheme = isSystemInDarkTheme()
-                    val highlightsBuilder = remember(isDarkTheme) {
-                        Highlights.Builder().theme(SyntaxThemes.atom(darkMode = isDarkTheme))
-                    }
+            Text(
+                text = content,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.padding(12.dp)
+            )
+        }
+    } else {
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp)
+        ) {
+            if (source != null) {
+                SourceBand(source = source, toolsUsed = toolsUsed)
+            }
+            SelectionContainer {
+                val isDarkTheme = isSystemInDarkTheme()
+                val highlightsBuilder = remember(isDarkTheme) {
+                    Highlights.Builder().theme(SyntaxThemes.monokai(darkMode = isDarkTheme))
+                }
+                val noBullet = BulletHandler { _, _, _, _, _ -> "" }
+                CompositionLocalProvider(LocalBulletListHandler provides noBullet) {
                     Markdown(
-                        content = message.content,
-                        colors = markdownColor(),
+                        content = content,
+                        colors = markdownColor(
+                            codeBackground = MaterialTheme.colorScheme.surfaceVariant,
+                            inlineCodeBackground = MaterialTheme.colorScheme.surfaceVariant,
+                        ),
                         typography = markdownTypography(
                             h1 = MaterialTheme.typography.titleLarge,
                             h2 = MaterialTheme.typography.titleMedium,
                             h3 = MaterialTheme.typography.titleSmall,
-                            h4 = MaterialTheme.typography.labelLarge,
-                            h5 = MaterialTheme.typography.labelMedium,
-                            h6 = MaterialTheme.typography.labelSmall,
+                            h4 = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
+                            h5 = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                            h6 = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+                            paragraph = MaterialTheme.typography.bodyMedium,
+                            bullet = MaterialTheme.typography.bodyMedium,
+                            list = MaterialTheme.typography.bodyMedium,
+                            code = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                        ),
+                        padding = markdownPadding(
+                            block = 8.dp,
+                            list = 8.dp,
+                            listItemTop = 6.dp,
+                            listItemBottom = 6.dp,
+                            listIndent = 8.dp,
+                            codeBlock = PaddingValues(12.dp),
+                            blockQuote = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+                        ),
+                        dimens = markdownDimens(
+                            codeBackgroundCornerSize = 8.dp,
+                            blockQuoteThickness = 3.dp,
                         ),
                         components = markdownComponents(
                             codeBlock = {
@@ -96,29 +140,76 @@ fun ChatBubble(
                                     content = it.content,
                                     node = it.node,
                                     highlightsBuilder = highlightsBuilder,
+                                    showHeader = true,
                                 )
                             },
-                            codeFence = {
+                            codeFence = { model ->
+                                val firstLine = model.content.lineSequence().firstOrNull { it.startsWith("```") }
+                                val lang = firstLine?.removePrefix("```")?.trim()?.lowercase()?.ifEmpty { null }
+                                val isSupported = lang != null && SyntaxLanguage.getByName(lang) != null
                                 MarkdownHighlightedCodeFence(
-                                    content = it.content,
-                                    node = it.node,
-                                    highlightsBuilder = highlightsBuilder,
+                                    content = model.content,
+                                    node = model.node,
+                                    highlightsBuilder = if (isSupported) highlightsBuilder else Highlights.Builder(),
+                                    showHeader = true,
                                 )
                             },
-                        )
-                    )
-                } else {
-                    Text(
-                        text = message.content,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = when {
-                            isUser -> MaterialTheme.colorScheme.onPrimaryContainer
-                            isError -> MaterialTheme.colorScheme.onErrorContainer
-                            else -> MaterialTheme.colorScheme.onSurfaceVariant
-                        }
+                        ),
+                        modifier = Modifier.fillMaxWidth(),
                     )
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun SourceBand(
+    source: ResponseSource,
+    toolsUsed: List<String>,
+    modifier: Modifier = Modifier
+) {
+    val sourceLabel = when (source) {
+        ResponseSource.LOCAL -> "local"
+        ResponseSource.MCP -> "mcp"
+        ResponseSource.LLM -> "llm"
+        ResponseSource.MIXED -> "local + mcp"
+    }
+    val color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+
+    Column(modifier = modifier.fillMaxWidth().padding(bottom = 4.dp)) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = sourceLabel,
+                style = MaterialTheme.typography.labelSmall,
+                color = color,
+            )
+            if (toolsUsed.isNotEmpty()) {
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = "·",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = color,
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = toolsUsed.joinToString(", "),
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        fontFamily = FontFamily.Monospace
+                    ),
+                    color = color,
+                    maxLines = 1,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+            }
+        }
+        HorizontalDivider(
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+            thickness = 0.5.dp,
+            modifier = Modifier.padding(top = 4.dp),
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Drop `reverseLayout` from LazyColumn — eliminates thrashing during LLM streaming
- Separate streaming state from message list — pulsing status indicator ("Thinking...", "Querying [local]: tool_name...") while generating, then render complete formatted message at once (no intermediate plain text)
- Restyle messages: user bubbles right-aligned with subtle background, assistant messages full-width markdown with no Surface wrapper
- Add source band at top of each assistant response showing `local · tool_names` / `mcp · tool_names` / `llm`
- Track `ResponseSource` and `toolsUsed` in ChatMessage for response provenance
- Improve markdown: proper list spacing, no bullet characters, code blocks with language headers + copy buttons, skip syntax highlighting for unsupported languages (YAML, JSON)

## Files changed
- `ChatMessage.kt` — add `ResponseSource` enum, `source` and `toolsUsed` fields, expose `nextId()`
- `AssistantUiState.kt` — add `streamingText` field to Active state
- `AssistantViewModel.kt` — streaming via status updates instead of list manipulation, track tool sources
- `AssistantScreen.kt` — drop reverseLayout, add `StreamingIndicator` composable, scroll to bottom
- `ChatBubble.kt` — split into `UserBubble` + `AssistantMessage` with source band, improved markdown config

## Test plan
- [x] Build compiles (`./gradlew compileDebugKotlin`)
- [x] Unit tests pass (`./gradlew testDebugUnitTest`)
- [x] Deploy to emulator — no flickering during streaming
- [x] User message right-aligned with subtle background
- [x] Assistant response full-width with markdown formatting
- [x] "Thinking..." pulsing indicator visible on every message
- [x] Source band shows `local · tool_name` / `llm` correctly
- [x] Code blocks render with language header + copy button
- [x] YAML/JSON code blocks render without garbled colors

Closes #103

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>