### PR TITLE
Reorganize settings, default to Activity tab, fix IME

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/navigation/MainNavigation.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/navigation/MainNavigation.kt
@@ -43,7 +43,7 @@ fun TabContent(
                     onNavigateToJobStatus = onNavigateToJobStatus
                 )
                 "Schedules" -> SchedulesScreen()
-                "EDA Audit" -> EdaAuditScreen()
+                "EDA" -> EdaAuditScreen()
                 else -> PlaceholderScreen(title = segment.label)
             }
         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -58,8 +59,8 @@ fun MainScreen(
     val activeProviderKey by assistantRepository.activeProviderKeyFlow.collectAsStateWithLifecycle(null)
 
     val tabs = TopLevelTab.entries
-    val janeTabIndex = tabs.indexOfFirst { it is TopLevelTab.Assistant }.coerceAtLeast(0)
-    var selectedTabIndex by rememberSaveable { mutableIntStateOf(janeTabIndex) }
+    val activityTabIndex = tabs.indexOfFirst { it is TopLevelTab.Activity }.coerceAtLeast(0)
+    var selectedTabIndex by rememberSaveable { mutableIntStateOf(activityTabIndex) }
     val selectedTab = tabs[selectedTabIndex]
 
     val defaultSegmentIndex = selectedTab.segments.indexOfFirst { it.isDefault }.coerceAtLeast(0)
@@ -154,7 +155,8 @@ fun MainScreen(
                 }
             }
         },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        contentWindowInsets = WindowInsets(0, 0, 0, 0)
     ) { padding ->
         Column(
             modifier = Modifier

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/TabDefinitions.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/TabDefinitions.kt
@@ -54,7 +54,7 @@ sealed class TopLevelTab(
         segments = listOf(
             Segment(label = "Jobs", isDefault = true, isImplemented = true),
             Segment(label = "Schedules", isImplemented = true),
-            Segment(label = "EDA Audit", isImplemented = true)
+            Segment(label = "EDA", isImplemented = true)
         )
     )
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/AgentTab.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/AgentTab.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -41,11 +42,13 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -76,9 +79,11 @@ fun AgentTab(
     onClearFetchedModels: () -> Unit,
     onSaveProviderConfig: (providerKey: String, LlmProviderConfig) -> Unit,
     onSwitchActiveProvider: (String) -> Unit,
+    onClearHistory: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var expandedProvider by remember { mutableStateOf<KnownProvider?>(null) }
+    var showClearHistoryConfirm by remember { mutableStateOf(false) }
 
     Column(
         modifier = modifier
@@ -162,7 +167,39 @@ fun AgentTab(
             }
         }
 
+        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+        OutlinedButton(
+            onClick = { showClearHistoryConfirm = true },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("button_clear_history")
+        ) {
+            Text("Clear Chat History")
+        }
+
         Spacer(modifier = Modifier.height(8.dp))
+    }
+
+    if (showClearHistoryConfirm) {
+        AlertDialog(
+            onDismissRequest = { showClearHistoryConfirm = false },
+            title = { Text("Clear Chat History") },
+            text = {
+                Text("This will remove all messages from the assistant chat. This cannot be undone.")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showClearHistoryConfirm = false
+                        onClearHistory()
+                    }
+                ) { Text("Clear") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearHistoryConfirm = false }) { Text("Cancel") }
+            }
+        )
     }
 }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/GeneralTab.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/GeneralTab.kt
@@ -15,13 +15,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -30,10 +27,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -59,13 +54,8 @@ fun GeneralTab(
     onTimezoneSelected: (String?) -> Unit,
     onTimeFormatSelected: (TimeFormat) -> Unit,
     onThemeModeSelected: (ThemeMode) -> Unit,
-    onClearHistory: () -> Unit,
-    onLogout: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var showLogoutConfirm by remember { mutableStateOf(false) }
-    var showClearHistoryConfirm by remember { mutableStateOf(false) }
-
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -87,76 +77,7 @@ fun GeneralTab(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        OutlinedButton(
-            onClick = { showClearHistoryConfirm = true },
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag("button_clear_history")
-        ) {
-            Text("Clear Chat History")
-        }
-
-        Spacer(modifier = Modifier.height(24.dp))
-
         AboutSection()
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        FilledTonalButton(
-            onClick = { showLogoutConfirm = true },
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag("button_logout_all")
-        ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.ExitToApp,
-                contentDescription = null,
-                modifier = Modifier.padding(end = 8.dp)
-            )
-            Text("Logout All")
-        }
-    }
-
-    if (showLogoutConfirm) {
-        AlertDialog(
-            onDismissRequest = { showLogoutConfirm = false },
-            title = { Text("Logout All") },
-            text = {
-                Text("Remove all instances and log out? You will need to re-authenticate each instance.")
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        showLogoutConfirm = false
-                        onLogout()
-                    }
-                ) { Text("Logout All") }
-            },
-            dismissButton = {
-                TextButton(onClick = { showLogoutConfirm = false }) { Text("Cancel") }
-            }
-        )
-    }
-
-    if (showClearHistoryConfirm) {
-        AlertDialog(
-            onDismissRequest = { showClearHistoryConfirm = false },
-            title = { Text("Clear Chat History") },
-            text = {
-                Text("This will remove all messages from the assistant chat. This cannot be undone.")
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        showClearHistoryConfirm = false
-                        onClearHistory()
-                    }
-                ) { Text("Clear") }
-            },
-            dismissButton = {
-                TextButton(onClick = { showClearHistoryConfirm = false }) { Text("Cancel") }
-            }
-        )
     }
 }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/InstancesTab.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/InstancesTab.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -56,9 +57,11 @@ fun InstancesTab(
     onShowDetails: (String) -> Unit,
     onDismissDetails: () -> Unit,
     onAddInstance: () -> Unit,
+    onLogout: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var instanceToRemove by remember { mutableStateOf<AapInstance?>(null) }
+    var showLogoutConfirm by remember { mutableStateOf(false) }
 
     Column(
         modifier = modifier
@@ -94,6 +97,22 @@ fun InstancesTab(
             )
             Text("Add Instance")
         }
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+        FilledTonalButton(
+            onClick = { showLogoutConfirm = true },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("button_logout_all")
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ExitToApp,
+                contentDescription = null,
+                modifier = Modifier.padding(end = 8.dp)
+            )
+            Text("Logout All")
+        }
     }
 
     selectedInstanceForDetails?.let { instance ->
@@ -126,6 +145,27 @@ fun InstancesTab(
             },
             dismissButton = {
                 TextButton(onClick = { instanceToRemove = null }) { Text("Cancel") }
+            }
+        )
+    }
+
+    if (showLogoutConfirm) {
+        AlertDialog(
+            onDismissRequest = { showLogoutConfirm = false },
+            title = { Text("Logout All") },
+            text = {
+                Text("Remove all AAP instances and log out? You will need to re-authenticate each instance.")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showLogoutConfirm = false
+                        onLogout()
+                    }
+                ) { Text("Logout All") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showLogoutConfirm = false }) { Text("Cancel") }
             }
         )
     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
@@ -130,8 +130,6 @@ private fun SettingsContent(
                 onTimezoneSelected = onTimezoneSelected,
                 onTimeFormatSelected = onTimeFormatSelected,
                 onThemeModeSelected = onThemeModeSelected,
-                onClearHistory = onClearHistory,
-                onLogout = onLogout,
                 modifier = Modifier.weight(1f)
             )
             SettingsTab.Instances -> InstancesTab(
@@ -143,6 +141,7 @@ private fun SettingsContent(
                 onShowDetails = onShowDetails,
                 onDismissDetails = onDismissDetails,
                 onAddInstance = onAddInstance,
+                onLogout = onLogout,
                 modifier = Modifier.weight(1f)
             )
             SettingsTab.Agent -> AgentTab(
@@ -155,6 +154,7 @@ private fun SettingsContent(
                 onClearFetchedModels = onClearFetchedModels,
                 onSaveProviderConfig = onSaveProviderConfig,
                 onSwitchActiveProvider = onSwitchActiveProvider,
+                onClearHistory = onClearHistory,
                 modifier = Modifier.weight(1f)
             )
             SettingsTab.Tools -> ToolsTab(

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
@@ -116,22 +116,28 @@ class SettingsScreenTest {
     }
 
     @Test
-    fun `shows Logout All button on General tab`() {
+    fun `shows Logout All button on Instances tab`() {
         fakeTokenManager.setInstances(listOf(instance1))
         setUpScreen()
+
+        composeTestRule.onNodeWithText("Instances").performClick()
+        composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText("Logout All").performScrollTo().assertIsDisplayed()
     }
 
     @Test
-    fun `logout all shows confirmation dialog`() {
+    fun `logout all shows confirmation dialog on Instances tab`() {
         fakeTokenManager.setInstances(listOf(instance1))
         setUpScreen()
+
+        composeTestRule.onNodeWithText("Instances").performClick()
+        composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText("Logout All").performScrollTo().performClick()
         composeTestRule.waitForIdle()
 
-        composeTestRule.onNodeWithText("Remove all instances and log out?", substring = true)
+        composeTestRule.onNodeWithText("Remove all AAP instances and log out?", substring = true)
             .assertIsDisplayed()
     }
 


### PR DESCRIPTION
## Summary
- Move "Clear Chat History" from General to Agent tab (below Persona, with divider)
- Move "Logout All" from General to Instances tab (below Add Instance, with divider)
- Default landing tab changed from Jane to Activity
- Rename "EDA Audit" segment to "EDA"
- Fix IME input field positioning on edge-to-edge devices (Android 15+) by preventing Scaffold from consuming IME insets

## Test plan
- [ ] Settings > General: no Logout or Clear History buttons
- [ ] Settings > Instances: Logout All below Add Instance with divider
- [ ] Settings > Agent: Clear Chat History below Persona with divider
- [ ] App opens to Activity tab by default
- [ ] Activity tab shows "EDA" instead of "EDA Audit"
- [ ] On real phone: Jane input field stays above keyboard when typing

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>