### PR TITLE
Add reference projects, skills, and ADK/MCP research

### DIFF
--- a/docs/mcp-proxy-research.md
+++ b/docs/mcp-proxy-research.md
@@ -277,6 +277,52 @@ User Query (LLM always configured)
 
 ---
 
+## Round 3: ADK for Kotlin/Android + Official Kotlin MCP SDK (May 2026)
+
+### ADK for Kotlin 0.1.0 — MCP Status
+
+Google's [ADK for Kotlin](https://github.com/google/adk-kotlin) (v0.1.0, released May 21, 2026) includes a full `McpToolset` with connection management, schema conversion, and tool filtering. However, **MCP is currently JVM-only in ADK** — the `libs.mcp` dependency (`io.modelcontextprotocol.sdk:mcp:1.1.2`) is declared only in `jvmMain`, not in `commonJvmAndroidMain` or `androidMain`.
+
+This is a **stale dependency problem, not a design decision.** ADK is pinned to the old monolithic JVM artifact (`mcp:1.1.2`) instead of the current KMP-enabled SDK (`io.modelcontextprotocol:kotlin-sdk-client:0.12.0`). The `google-adk-kotlin-core-android` artifact ships without MCP classes.
+
+### Official Kotlin MCP SDK — Android Support Confirmed
+
+The official [Kotlin MCP SDK](https://github.com/modelcontextprotocol/kotlin-sdk) (maintained by Anthropic + JetBrains) **already supports Android**:
+
+- Issue [#188](https://github.com/modelcontextprotocol/kotlin-sdk/issues/188) ("Support more targets") — **COMPLETED**, lists Android as a client target
+- Issue [#272](https://github.com/modelcontextprotocol/kotlin-sdk/issues/272) ("Duplicate LibVersionKt causing Android build failure") — **FIXED**
+- Current version: **0.12.0** (April 29, 2026)
+- Stack: Kotlin 2.3.21, Ktor, kotlinx-serialization (not OkHttp)
+- KMP targets: JVM, JS, WasmJs, Android, Apple, desktop
+
+### MCP Client Replacement Options
+
+Three options for replacing our custom MCP client (`McpClient.kt` ~260 LOC + `McpTransport.kt` ~300 LOC):
+
+| Option | Artifact | Android? | Transport | Dependencies | Status |
+|--------|----------|----------|-----------|-------------|--------|
+| **Koog agents-mcp** (#74) | `ai.koog:agents-mcp` | Unverified (JVM module) | Wraps official SDK | Koog + official SDK | Blocked on Android verification |
+| **Official Kotlin MCP SDK** | `io.modelcontextprotocol:kotlin-sdk-client:0.12.0` | **Yes** (KMP) | SSE, Streamable HTTP, stdio | Ktor, kotlinx-serialization | Production-ready |
+| **ADK McpToolset** | `com.google.adk:google-adk-kotlin-core:0.1.0` | **No** (JVM-only dep) | SSE, Streamable HTTP, stdio | Old MCP SDK 1.1.2, Gemini-only models | Experimental, will fix dep eventually |
+
+**Recommendation:** The official Kotlin MCP SDK (option 2) is the most viable path. It's KMP-native, supports Android, uses Ktor (aligns with KMP migration #37), and doesn't lock us into Gemini-only models (ADK) or require adopting an entire agent framework (Koog). Our custom `McpTool` wrapper would still be needed to bridge MCP tools into our `Tool` interface.
+
+### ADK Patterns Worth Borrowing
+
+**`@Tool` + KSP codegen** — ADK uses `@Tool` / `@Param` annotations on Kotlin functions + a KSP processor to generate tool schemas at compile time. This eliminates hand-written JSON schemas. Our 26 local tools could adopt this pattern independently of ADK (write our own KSP processor or use ADK's annotations). See tracking issue.
+
+**`McpToolset.tool_filter`** — ADK's McpToolset supports filtering tool subsets from MCP servers. This is equivalent to our `OVERLAP_MAPPING` + read-only enforcement in ToolRouter. Validates our approach.
+
+**Processor pipeline** — ADK's `LlmRequestProcessor` / `LlmResponseProcessor` composable chain validates our Phase 5 middleware pipeline design (#120).
+
+### Tracking
+
+- Issue #74 — MCP client replacement (updated with 3 options)
+- Issue #30 — ADK's ML Kit GenAI for on-device Gemini Nano tier
+- Issue #120 — ADK validates Phase 5 middleware pipeline
+
+---
+
 ## Sources
 
 - [Anthropic Tool Search Tool docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)
@@ -305,3 +351,6 @@ User Query (LLM always configured)
 - [MediaPipe Text Classifier](https://ai.google.dev/edge/mediapipe/solutions/customization/text_classifier)
 - [Koog](https://github.com/JetBrains/koog)
 - [Kotlin MCP SDK](https://github.com/modelcontextprotocol/kotlin-sdk)
+- [ADK for Kotlin](https://github.com/google/adk-kotlin)
+- [ADK for Kotlin/Android blog post](https://developers.googleblog.com/adk-kotlin-android-building-ai-agents/)
+- [ADK docs](https://adk.dev)

--- a/docs/reference-projects.md
+++ b/docs/reference-projects.md
@@ -1,0 +1,73 @@
+# Reference Projects
+
+Projects used as reference, inspiration, or integration targets for Ansible Jane. All GitHub URLs verified.
+
+## Architecture References
+
+Projects whose code or patterns directly influenced Ansible Jane's design.
+
+| Project | Language | Stars | What We Used | License | Link |
+|---------|----------|-------|--------------|---------|------|
+| **Kai 9000** | Kotlin (KMP) | 838 | MCP client via OkHttp (~130 LOC), universal Tool interface, multi-provider LLM chain, KMP architecture | Apache 2.0 | [GitHub](https://github.com/SimonSchubert/Kai) |
+| **PennywiseAI** | Kotlin | 462 | Validated dynamic system prompt injection for domain context; on-device inference via LiteRT-LM with streaming Flow | AGPL 3.0 | [GitHub](https://github.com/sarim2000/pennywiseai-tracker) |
+
+## Framework Evaluations
+
+| Project | Language | Stars | Status | License | Link |
+|---------|----------|-------|--------|---------|------|
+| **Koog** (JetBrains) | Kotlin | 4,220 | Evaluated as replacement for custom LLM/MCP/agent code (~1,260 LOC); deferred pending OkHttp upgrade and Kotlin 2.3. See `docs/specs/koog-evaluation.md` | Apache 2.0 | [GitHub](https://github.com/JetBrains/koog) |
+| **ADK for Kotlin** (Google) | Kotlin | 26 | v0.1.0 (experimental). Multi-agent systems with MCP tool support, on-device Gemini Nano via ML Kit, cloud+on-device hybrid orchestration. Uses KSP for tool codegen. Very early but directly relevant to our agent architecture | Apache 2.0 | [GitHub](https://github.com/google/adk-kotlin) |
+
+## MCP Servers (Integration Targets)
+
+| Project | Language | Stars | Role | License | Link |
+|---------|----------|-------|------|---------|------|
+| **aap-mcp-server** | TypeScript | 27 | Official AAP MCP server — primary integration target for Controller, Gateway, and EDA resources | Apache 2.0 | [GitHub](https://github.com/ansible/aap-mcp-server) |
+| **ansible-know-mcp** | Python | 0 | Ansible knowledge layer — module docs, conceptual guides, troubleshooting search | GPL 3.0 | [GitHub](https://github.com/leogallego/ansible-know-mcp) |
+
+## AI Agent Skills (Sources)
+
+Skills bundled in `skills/` for AI-assisted development. See `docs/skills-reference.md` for usage.
+
+| Project | Stars | Contents | License | Link |
+|---------|-------|----------|---------|------|
+| **android/skills** | 5,293 | Edge-to-edge, Navigation 3 | Apache 2.0 | [GitHub](https://github.com/android/skills) |
+| **chrisbanes/skills** | 671 | Compose animations, focus, modifiers, recomposition, side effects, state, testing | Apache 2.0 | [GitHub](https://github.com/chrisbanes/skills) |
+| **javiercamarenatriguero/android-skills** | 3 | Compose patterns, coroutines, Koin DI, unit testing, Gradle config | Apache 2.0 | [GitHub](https://github.com/javiercamarenatriguero/android-skills) |
+| **Meet-Miyani/compose-skill** | 221 | Comprehensive Compose/KMP reference: MVI, Nav 3, Ktor, Room, DataStore, Paging, Coil | MIT | [GitHub](https://github.com/Meet-Miyani/compose-skill) |
+| **anhvt52/jetpack-compose-skills** | 89 | Compose best practices + M3 migration + accessibility + common LLM mistakes. Used: accessibility reference | MIT | [GitHub](https://github.com/anhvt52/jetpack-compose-skills) |
+| **new-silvermoon/awesome-android-agent-skills** | 819 | 16 Android agent skills. Used: Retrofit networking, Gradle build performance | Apache 2.0 | [GitHub](https://github.com/new-silvermoon/awesome-android-agent-skills) |
+
+## Projects to Investigate
+
+Discovered from [privacytoolslist.com/ai](https://privacytoolslist.com/ai/) (2026-05-23). Worth studying for patterns, UX, or future integration.
+
+### Mobile AI Apps
+
+| Project | Language | Stars | What to Look At | License | Link |
+|---------|----------|-------|-----------------|---------|------|
+| **PocketPal AI** | TypeScript (React Native) | 7,027 | Model management UX, on-device inference patterns, model download/caching | MIT | [GitHub](https://github.com/a-ghorbani/pocketpal-ai) |
+| **ChatterUI** | TypeScript (React Native) | 2,425 | Mobile chat frontend UX, multi-backend support | AGPL 3.0 | [GitHub](https://github.com/Vali-98/ChatterUI) |
+| **Off-Grid Mobile AI** | TypeScript | 2,195 | Fully offline mobile AI: text, vision, image gen without internet | MIT | [GitHub](https://github.com/alichherawalla/off-grid-mobile-ai) |
+
+### On-Device Inference
+
+| Project | Language | Stars | What to Look At | License | Link |
+|---------|----------|-------|-----------------|---------|------|
+| **ExecuTorch** | Python/C++ | 4,651 | PyTorch on-device deployment for mobile/embedded — relevant if we run models directly on Android | Other | [GitHub](https://github.com/pytorch/executorch) |
+
+### Agent Frameworks
+
+| Project | Language | Stars | What to Look At | License | Link |
+|---------|----------|-------|-----------------|---------|------|
+| **MobileRun** (fka DroidRun) | Python | 8,395 | LLM-agnostic mobile agent — natural language device automation | MIT | [GitHub](https://github.com/droidrun/mobilerun) |
+
+### Local Inference Servers
+
+| Project | Language | Stars | What to Look At | License | Link |
+|---------|----------|-------|-----------------|---------|------|
+| **RamaLama** | Python | — | Local AI model runner from Red Hat/Fedora ecosystem, container-based | Apache 2.0 | [GitHub](https://github.com/containers/ramalama) |
+
+## See Also
+
+- `docs/mcp-proxy-research.md` — MCP proxy/router solutions relevant to ToolRouter optimization

--- a/skills/android-community/accessibility.md
+++ b/skills/android-community/accessibility.md
@@ -1,0 +1,124 @@
+# Accessibility
+
+Source: [anhvt52/jetpack-compose-skills](https://github.com/anhvt52/jetpack-compose-skills) (MIT)
+
+## Content Descriptions
+
+Every `Image` composable must have a `contentDescription`:
+
+- **Decorative images** (purely visual, no information): `contentDescription = null`.
+- **Meaningful images**: provide a localized string describing the content.
+
+```kotlin
+// Decorative
+Image(painter = painterResource(R.drawable.banner), contentDescription = null)
+
+// Meaningful
+Image(
+    painter = painterResource(R.drawable.avatar),
+    contentDescription = stringResource(R.string.user_avatar_description)
+)
+```
+
+Flag any `Image` with a non-obvious resource name (e.g., `R.drawable.img_003`) that has `contentDescription = null` without a clear comment explaining why it is decorative.
+
+
+## Semantics
+
+Use `Modifier.semantics { }` to add or override accessibility information:
+
+```kotlin
+Box(
+    modifier = Modifier.semantics {
+        contentDescription = "Profile picture of ${user.name}"
+        role = Role.Image
+    }
+)
+```
+
+Common semantic properties:
+- `contentDescription` — overrides the TalkBack announcement
+- `role` — `Role.Button`, `Role.Image`, `Role.Switch`, `Role.Tab`, `Role.RadioButton`
+- `stateDescription` — describes the current state (e.g., "Checked", "Expanded")
+- `heading` — marks a node as a section heading
+
+
+## mergeDescendants
+
+Use `mergeDescendants = true` to group a composable's children into a single TalkBack announcement, preventing the user from navigating through each child element individually.
+
+```kotlin
+Row(modifier = Modifier.semantics(mergeDescendants = true) { }) {
+    Icon(Icons.Default.Star, contentDescription = null) // hidden by merge
+    Text("4.5 stars")
+    Text("(128 reviews)")
+    // TalkBack reads: "4.5 stars, 128 reviews" as one item
+}
+```
+
+
+## clearAndSetSemantics
+
+Use `clearAndSetSemantics { }` to completely replace auto-generated semantics with a custom description, removing all child semantics.
+
+```kotlin
+Row(modifier = Modifier.clearAndSetSemantics {
+    contentDescription = "Rating: 4.5 stars from 128 reviews"
+}) {
+    StarRating(4.5f)
+    Text("(128 reviews)")
+}
+```
+
+
+## Touch Targets
+
+Minimum touch target size is **48x48dp**. Use `Modifier.minimumInteractiveComponentSize()` on custom interactive elements to enforce this automatically.
+
+Material components (`Button`, `IconButton`, etc.) handle this internally — do not add extra padding on top.
+
+
+## Color Contrast
+
+- Ensure text contrast ratio meets WCAG AA: at least 4.5:1 for normal text, 3:1 for large text (18sp+ or 14sp bold+).
+- Never use color as the only way to convey information. Pair with an icon, text, or pattern.
+
+```kotlin
+// Wrong — only color differentiates status
+Box(modifier = Modifier.background(if (isOnline) Color.Green else Color.Red))
+
+// Correct — icon + color
+Row {
+    Icon(if (isOnline) Icons.Default.CheckCircle else Icons.Default.Cancel, ...)
+    Text(if (isOnline) "Online" else "Offline")
+}
+```
+
+
+## Custom Interactive Elements
+
+When using `Modifier.clickable` or `Modifier.pointerInput` on non-Button composables, add semantic role and action:
+
+```kotlin
+Box(
+    modifier = Modifier
+        .clickable(onClickLabel = "Open book details") { onBookClick() }
+        .semantics { role = Role.Button }
+) { ... }
+```
+
+Prefer `Button` / `IconButton` over custom clickable elements when possible — they include correct semantics out of the box.
+
+
+## Custom Accessibility Actions
+
+For complex custom interactions, provide named accessibility actions:
+
+```kotlin
+Modifier.semantics {
+    customActions = listOf(
+        CustomAccessibilityAction("Add to favorites") { onFavorite(); true },
+        CustomAccessibilityAction("Share") { onShare(); true }
+    )
+}
+```

--- a/skills/android-community/gradle-build-performance.md
+++ b/skills/android-community/gradle-build-performance.md
@@ -1,0 +1,250 @@
+# Gradle Build Performance
+
+Source: [new-silvermoon/awesome-android-agent-skills](https://github.com/new-silvermoon/awesome-android-agent-skills) (Apache 2.0)
+
+## When to Use
+
+- Build times are slow (clean or incremental)
+- Investigating build performance regressions
+- Analyzing Gradle Build Scans
+- Identifying configuration vs execution bottlenecks
+- Optimizing CI/CD build times
+- Enabling Gradle Configuration Cache
+- Reducing unnecessary recompilation
+- Debugging kapt/KSP annotation processing
+
+## Workflow
+
+1. **Measure Baseline** — Clean build + incremental build times
+2. **Generate Build Scan** — `./gradlew assembleDebug --scan`
+3. **Identify Phase** — Configuration? Execution? Dependency resolution?
+4. **Apply ONE optimization** — Don't batch changes
+5. **Measure Improvement** — Compare against baseline
+6. **Verify in Build Scan** — Visual confirmation
+
+## Quick Diagnostics
+
+### Generate Build Scan
+
+```bash
+./gradlew assembleDebug --scan
+```
+
+### Profile Build Locally
+
+```bash
+./gradlew assembleDebug --profile
+# Opens report in build/reports/profile/
+```
+
+## Build Phases
+
+| Phase | What Happens | Common Issues |
+|-------|--------------|---------------|
+| **Initialization** | `settings.gradle.kts` evaluated | Too many `include()` statements |
+| **Configuration** | All `build.gradle.kts` files evaluated | Expensive plugins, eager task creation |
+| **Execution** | Tasks run based on inputs/outputs | Cache misses, non-incremental tasks |
+
+## 12 Optimization Patterns
+
+### 1. Enable Configuration Cache
+
+Caches configuration phase across builds (AGP 8.0+):
+
+```properties
+# gradle.properties
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=warn
+```
+
+### 2. Enable Build Cache
+
+Reuses task outputs across builds and machines:
+
+```properties
+# gradle.properties
+org.gradle.caching=true
+```
+
+### 3. Enable Parallel Execution
+
+Build independent modules simultaneously:
+
+```properties
+# gradle.properties
+org.gradle.parallel=true
+```
+
+### 4. Increase JVM Heap
+
+Allocate more memory for large projects:
+
+```properties
+# gradle.properties
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC
+```
+
+### 5. Use Non-Transitive R Classes
+
+Reduces R class size and compilation (AGP 8.0+ default):
+
+```properties
+# gradle.properties
+android.nonTransitiveRClass=true
+```
+
+### 6. Migrate kapt to KSP
+
+KSP is 2x faster than kapt for Kotlin:
+
+```kotlin
+// Before (slow)
+kapt("com.google.dagger:hilt-compiler:2.51.1")
+
+// After (fast)
+ksp("com.google.dagger:hilt-compiler:2.51.1")
+```
+
+### 7. Avoid Dynamic Dependencies
+
+Pin dependency versions:
+
+```kotlin
+// BAD: Forces resolution every build
+implementation("com.example:lib:+")
+
+// GOOD: Fixed version
+implementation("com.example:lib:1.2.3")
+```
+
+### 8. Optimize Repository Order
+
+Put most-used repositories first:
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositories {
+        google()       // First: Android dependencies
+        mavenCentral() // Second: Most libraries
+        // Third-party repos last
+    }
+}
+```
+
+### 9. Use includeBuild for Local Modules
+
+Composite builds are faster than `project()` for large monorepos:
+
+```kotlin
+// settings.gradle.kts
+includeBuild("shared-library") {
+    dependencySubstitution {
+        substitute(module("com.example:shared")).using(project(":"))
+    }
+}
+```
+
+### 10. Enable Incremental Annotation Processing
+
+```properties
+# gradle.properties
+kapt.incremental.apt=true
+kapt.use.worker.api=true
+```
+
+### 11. Avoid Configuration-Time I/O
+
+Don't read files or make network calls during configuration:
+
+```kotlin
+// BAD: Runs during configuration
+val version = file("version.txt").readText()
+
+// GOOD: Defer to execution
+val version = providers.fileContents(file("version.txt")).asText
+```
+
+### 12. Use Lazy Task Configuration
+
+Avoid `create()`, use `register()`:
+
+```kotlin
+// BAD: Eagerly configured
+tasks.create("myTask") { ... }
+
+// GOOD: Lazily configured
+tasks.register("myTask") { ... }
+```
+
+## Common Bottleneck Analysis
+
+### Slow Configuration Phase
+
+| Cause | Fix |
+|-------|-----|
+| Eager task creation | Use `tasks.register()` instead of `tasks.create()` |
+| buildSrc with many dependencies | Migrate to Convention Plugins with `includeBuild` |
+| File I/O in build scripts | Use `providers.fileContents()` |
+| Network calls in plugins | Cache results or use offline mode |
+
+### Slow Compilation
+
+| Cause | Fix |
+|-------|-----|
+| Non-incremental changes | Avoid `build.gradle.kts` changes that invalidate cache |
+| Large modules | Break into smaller feature modules |
+| Excessive kapt usage | Migrate to KSP |
+| Kotlin compiler memory | Increase `kotlin.daemon.jvmargs` |
+
+### Cache Misses
+
+| Cause | Fix |
+|-------|-----|
+| Unstable task inputs | Use `@PathSensitive`, `@NormalizeLineEndings` |
+| Absolute paths in outputs | Use relative paths |
+| Missing `@CacheableTask` | Add annotation to custom tasks |
+| Different JDK versions | Standardize JDK across environments |
+
+## CI/CD Optimizations
+
+### Remote Build Cache
+
+```kotlin
+// settings.gradle.kts
+buildCache {
+    local { isEnabled = true }
+    remote<HttpBuildCache> {
+        url = uri("https://cache.example.com/")
+        isPush = System.getenv("CI") == "true"
+    }
+}
+```
+
+### Skip Unnecessary Tasks in CI
+
+```bash
+# Skip tests for UI-only changes
+./gradlew assembleDebug -x test -x lint
+
+# Only run affected module tests
+./gradlew :feature:login:test
+```
+
+## Verification Checklist
+
+- [ ] Configuration cache enabled and working
+- [ ] Build cache hit rate > 80% (check build scan)
+- [ ] No dynamic dependency versions
+- [ ] KSP used instead of kapt where possible
+- [ ] Parallel execution enabled
+- [ ] JVM memory tuned appropriately
+- [ ] CI remote cache configured
+- [ ] No configuration-time I/O
+
+## References
+
+- [Optimize Build Speed](https://developer.android.com/build/optimize-your-build)
+- [Gradle Configuration Cache](https://docs.gradle.org/current/userguide/configuration_cache.html)
+- [Gradle Build Cache](https://docs.gradle.org/current/userguide/build_cache.html)
+- [Migrate from kapt to KSP](https://developer.android.com/build/migrate-to-ksp)

--- a/skills/android-community/retrofit-networking.md
+++ b/skills/android-community/retrofit-networking.md
@@ -1,0 +1,136 @@
+# Android Networking with Retrofit
+
+Source: [new-silvermoon/awesome-android-agent-skills](https://github.com/new-silvermoon/awesome-android-agent-skills) (Apache 2.0)
+
+## 1. URL Manipulation
+
+Retrofit allows dynamic URL updates through replacement blocks and query parameters.
+
+- **Dynamic Paths**: Use `{name}` in the relative URL and `@Path("name")` in parameters.
+- **Query Parameters**: Use `@Query("key")` for individual parameters.
+- **Complex Queries**: Use `@QueryMap Map<String, String>` for dynamic sets of parameters.
+
+```kotlin
+interface SearchService {
+    @GET("group/{id}/users")
+    suspend fun groupList(
+        @Path("id") groupId: Int,
+        @Query("sort") sort: String?,
+        @QueryMap options: Map<String, String> = emptyMap()
+    ): List<User>
+}
+```
+
+## 2. Request Body & Form Data
+
+- **@Body**: Serializes an object using the configured converter (JSON).
+- **@FormUrlEncoded**: Sends data as `application/x-www-form-urlencoded`. Use `@Field`.
+- **@Multipart**: Sends data as `multipart/form-data`. Use `@Part`.
+
+```kotlin
+interface UserService {
+    @POST("users/new")
+    suspend fun createUser(@Body user: User): User
+
+    @FormUrlEncoded
+    @POST("user/edit")
+    suspend fun updateUser(
+        @Field("first_name") first: String,
+        @Field("last_name") last: String
+    ): User
+
+    @Multipart
+    @PUT("user/photo")
+    suspend fun uploadPhoto(
+        @Part("description") description: RequestBody,
+        @Part photo: MultipartBody.Part
+    ): User
+}
+```
+
+## 3. Header Manipulation
+
+- **Static Headers**: Use `@Headers`.
+- **Dynamic Headers**: Use `@Header`.
+- **Header Maps**: Use `@HeaderMap`.
+- **Global Headers**: Use an OkHttp **Interceptor** (e.g., auth token injection).
+
+```kotlin
+interface WidgetService {
+    @Headers("Cache-Control: max-age=640000")
+    @GET("widget/list")
+    suspend fun widgetList(): List<Widget>
+
+    @GET("user")
+    suspend fun getUser(@Header("Authorization") token: String): User
+}
+```
+
+## 4. Kotlin Support & Response Handling
+
+When using `suspend` functions, two return type choices:
+
+1. **Direct Body (`User`)**: Returns the deserialized body. Throws `HttpException` for non-2xx responses.
+2. **`Response<User>`**: Provides access to the status code, headers, and error body. Does NOT throw on non-2xx results.
+
+```kotlin
+@GET("users")
+suspend fun getUsers(): List<User> // Throws on error
+
+@GET("users")
+suspend fun getUsersResponse(): Response<List<User>> // Manual check
+```
+
+## 5. DI & Serialization Configuration
+
+Provide Retrofit instances as singletons via Koin (this project uses Koin, not Hilt):
+
+```kotlin
+val networkModule = module {
+    single<Json> {
+        Json {
+            ignoreUnknownKeys = true
+            coerceInputValues = true
+        }
+    }
+
+    single<OkHttpClient> {
+        OkHttpClient.Builder()
+            .addInterceptor(HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            })
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .build()
+    }
+
+    single<Retrofit> {
+        Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(get())
+            .addConverterFactory(get<Json>().asConverterFactory("application/json".toMediaType()))
+            .build()
+    }
+}
+```
+
+## 6. Error Handling in Repositories
+
+Handle network exceptions in the Repository layer to keep the UI state clean.
+
+```kotlin
+class AapRepository(private val service: AapApiService) {
+    suspend fun getTemplates(): Result<List<JobTemplate>> = runCatching {
+        service.listJobTemplates()
+    }.onFailure { exception ->
+        // Handle UnknownHostException, SocketTimeoutException, HttpException, etc.
+    }
+}
+```
+
+## 7. Checklist
+
+- [ ] Use `suspend` functions for all network calls.
+- [ ] Prefer `Response<T>` if you need to handle specific status codes (e.g., 401 Unauthorized).
+- [ ] Use `@Path` and `@Query` instead of manual string concatenation for URLs.
+- [ ] Configure `OkHttpClient` with logging (for debug) and sensible timeouts.
+- [ ] Map API DTOs to Domain models to decouple layers.


### PR DESCRIPTION
## Summary

- Add `docs/reference-projects.md` — consolidated reference doc with all architecture references (Kai, PennywiseAI), framework evaluations (Koog, ADK), MCP servers, skills sources (6 repos), and projects to investigate (PocketPal AI, ChatterUI, ExecuTorch, MobileRun, RamaLama, Off-Grid Mobile AI)
- Add 3 new skills to `skills/android-community/` from [anhvt52/jetpack-compose-skills](https://github.com/anhvt52/jetpack-compose-skills) and [new-silvermoon/awesome-android-agent-skills](https://github.com/new-silvermoon/awesome-android-agent-skills):
  - `accessibility.md` — semantics, mergeDescendants, touch targets, color contrast, custom actions
  - `retrofit-networking.md` — Retrofit patterns adapted with Koin DI examples
  - `gradle-build-performance.md` — 12 optimization patterns, build phase diagnostics, CI/CD cache config
- Add Round 3 to `docs/mcp-proxy-research.md` covering:
  - ADK for Kotlin 0.1.0 MCP is JVM-only (stale `mcp:1.1.2` dep, not a design decision)
  - Official Kotlin MCP SDK v0.12.0 already supports Android (upstream issues #188, #272)
  - 3-option comparison table for MCP client replacement (Koog, official SDK, ADK)

## Related Issues

- #133 — @Tool KSP codegen for local tools (new)
- #134 — Track ADK for Kotlin/Android (new)
- #74 — MCP client replacement (comment added with 3 options)

## Test plan

- [ ] Verify all GitHub URLs in reference-projects.md are reachable
- [ ] Verify skills render correctly in skills-reference.md context
- [ ] Confirm mcp-proxy-research.md Round 3 section is consistent with #74 comment

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>