### PR TITLE
Add read-only local tools for Controller and EDA (#137, #138)

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/LocalToolsModule.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/LocalToolsModule.kt
@@ -1,36 +1,12 @@
 package io.github.leogallego.ansiblejane.assistant
 
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.GetHostFactsLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.GetJobLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.GetJobStdoutLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.GetWorkflowJobLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.LaunchJobLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.LaunchWorkflowLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.GetCredentialLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.GetEdaActivationLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.GetInstanceLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.GetMeshTopologyLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.GetProjectLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListCredentialsLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListEdaActivationsLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListEdaAuditRulesLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListExecutionEnvironmentsLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListHostsLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListInstanceGroupsLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListInstancesLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListInventoriesLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListJobTemplatesLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListJobsLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListProjectsLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListSchedulesLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListWorkflowTemplatesLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.PingLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ToggleScheduleLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.local.*
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val localToolsModule = module {
+    // Jobs & Templates
     single { ListJobTemplatesLocalTool(get()) } bind LocalTool::class
     single { LaunchJobLocalTool(get()) } bind LocalTool::class
     single { GetJobLocalTool(get()) } bind LocalTool::class
@@ -39,22 +15,58 @@ val localToolsModule = module {
     single { ListWorkflowTemplatesLocalTool(get()) } bind LocalTool::class
     single { LaunchWorkflowLocalTool(get()) } bind LocalTool::class
     single { GetWorkflowJobLocalTool(get()) } bind LocalTool::class
+    single { ListSchedulesLocalTool(get()) } bind LocalTool::class
+    single { ToggleScheduleLocalTool(get()) } bind LocalTool::class
+    single { ListWorkflowNodesLocalTool(get()) } bind LocalTool::class
+    single { GetSurveySpecLocalTool(get()) } bind LocalTool::class
+
+    // Inventory
     single { ListInventoriesLocalTool(get()) } bind LocalTool::class
     single { ListHostsLocalTool(get()) } bind LocalTool::class
     single { GetHostFactsLocalTool(get()) } bind LocalTool::class
-    single { ListSchedulesLocalTool(get()) } bind LocalTool::class
-    single { ToggleScheduleLocalTool(get()) } bind LocalTool::class
-    single { ListEdaAuditRulesLocalTool(get()) } bind LocalTool::class
+    single { GetHostJobSummariesLocalTool(get()) } bind LocalTool::class
+    single { ListGroupsLocalTool(get()) } bind LocalTool::class
+    single { ListInventorySourcesLocalTool(get()) } bind LocalTool::class
+    single { ListLabelsLocalTool(get()) } bind LocalTool::class
+
+    // Infrastructure & Monitoring
     single { ListInstancesLocalTool(get()) } bind LocalTool::class
     single { GetInstanceLocalTool(get()) } bind LocalTool::class
     single { ListInstanceGroupsLocalTool(get()) } bind LocalTool::class
     single { PingLocalTool(get()) } bind LocalTool::class
     single { GetMeshTopologyLocalTool(get()) } bind LocalTool::class
+
+    // Security & Credentials
     single { ListCredentialsLocalTool(get()) } bind LocalTool::class
     single { GetCredentialLocalTool(get()) } bind LocalTool::class
+    single { ListCredentialTypesLocalTool(get()) } bind LocalTool::class
+
+    // Configuration
     single { ListProjectsLocalTool(get()) } bind LocalTool::class
     single { GetProjectLocalTool(get()) } bind LocalTool::class
     single { ListExecutionEnvironmentsLocalTool(get()) } bind LocalTool::class
+    single { ListNotificationTemplatesLocalTool(get()) } bind LocalTool::class
+    single { GetSettingsLocalTool(get()) } bind LocalTool::class
+    single { GetConfigLocalTool(get()) } bind LocalTool::class
+
+    // RBAC / Admin
+    single { ListOrganizationsLocalTool(get()) } bind LocalTool::class
+    single { ListUsersLocalTool(get()) } bind LocalTool::class
+    single { ListTeamsLocalTool(get()) } bind LocalTool::class
+    single { ListRolesLocalTool(get()) } bind LocalTool::class
+    single { ListRoleDefinitionsLocalTool(get()) } bind LocalTool::class
+    single { ListApplicationsLocalTool(get()) } bind LocalTool::class
+    single { ListTokensLocalTool(get()) } bind LocalTool::class
+
+    // EDA
+    single { ListEdaAuditRulesLocalTool(get()) } bind LocalTool::class
     single { ListEdaActivationsLocalTool(get()) } bind LocalTool::class
     single { GetEdaActivationLocalTool(get()) } bind LocalTool::class
+    single { ListEdaRulebooksLocalTool(get()) } bind LocalTool::class
+    single { ListEdaDecisionEnvironmentsLocalTool(get()) } bind LocalTool::class
+    single { ListEdaProjectsLocalTool(get()) } bind LocalTool::class
+    single { ListEdaCredentialsLocalTool(get()) } bind LocalTool::class
+    single { ListEdaCredentialTypesLocalTool(get()) } bind LocalTool::class
+    single { ListEdaEventStreamsLocalTool(get()) } bind LocalTool::class
+    single { ListEdaUsersLocalTool(get()) } bind LocalTool::class
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -21,10 +21,14 @@ class ToolRouter {
             keywords = setOf(
                 "host", "hosts", "group", "groups", "inventory", "inventories",
                 "infrastructure", "facts", "gather", "info", "server", "servers",
-                "machine", "machines", "asset", "assets"
+                "machine", "machines", "asset", "assets", "source", "sources",
+                "label", "labels", "tag", "tags", "summary", "summaries"
             ),
-            resourcePrefixes = setOf("hosts", "groups", "inventories", "constructed_inventories", "inventory_sources"),
-            localToolNames = setOf("list_inventories", "list_hosts", "get_host_facts")
+            resourcePrefixes = setOf("hosts", "groups", "inventories", "constructed_inventories", "inventory_sources", "labels"),
+            localToolNames = setOf(
+                "list_inventories", "list_hosts", "get_host_facts", "get_host_job_summaries",
+                "list_groups", "list_inventory_sources", "list_labels"
+            )
         ),
         JOBS(
             keywords = setOf(
@@ -32,13 +36,15 @@ class ToolRouter {
                 "schedule", "schedules", "workflow", "playbook", "jt", "wfjt",
                 "output", "stdout", "running", "failed", "started", "task",
                 "tasks", "command", "error", "errors", "failure", "status",
-                "playbooks", "workflows", "execution", "executions"
+                "playbooks", "workflows", "execution", "executions",
+                "survey", "node", "nodes", "prompt", "variable", "variables"
             ),
-            resourcePrefixes = setOf("jobs", "job_templates", "workflow_jobs", "workflow_job_templates", "workflow_job_nodes", "schedules", "ad_hoc_commands"),
+            resourcePrefixes = setOf("jobs", "job_templates", "workflow_jobs", "workflow_job_templates", "workflow_job_nodes", "workflow_job_template_nodes", "schedules", "ad_hoc_commands"),
             localToolNames = setOf(
                 "list_job_templates", "launch_job", "get_job", "get_job_stdout", "list_jobs",
                 "list_workflow_templates", "launch_workflow", "get_workflow_job",
-                "list_schedules", "toggle_schedule"
+                "list_schedules", "toggle_schedule",
+                "list_workflow_nodes", "get_survey_spec"
             )
         ),
         MONITORING(
@@ -57,19 +63,25 @@ class ToolRouter {
                 "user", "users", "team", "teams", "organization", "organizations",
                 "org", "role", "roles", "permission", "permissions", "member",
                 "members", "people", "admin", "admins", "token", "tokens",
-                "application", "applications", "app", "apps", "access", "rbac"
+                "application", "applications", "app", "apps", "access", "rbac",
+                "definition", "definitions", "oauth"
             ),
-            resourcePrefixes = setOf("users", "teams", "organizations", "roles", "tokens", "applications"),
-            localToolNames = emptySet()
+            resourcePrefixes = setOf("users", "teams", "organizations", "roles", "role_definitions", "tokens", "applications"),
+            localToolNames = setOf(
+                "list_organizations", "list_users", "list_teams",
+                "list_roles", "list_role_definitions",
+                "list_applications", "list_tokens"
+            )
         ),
         SECURITY(
             keywords = setOf(
                 "credential", "credentials", "secret", "secrets", "security",
                 "compliance", "policy", "certificate", "creds", "vault",
-                "password", "passwords", "key", "keys", "cert", "certs"
+                "password", "passwords", "key", "keys", "cert", "certs",
+                "type", "types"
             ),
             resourcePrefixes = setOf("credentials", "credential_types", "credential_input_sources"),
-            localToolNames = setOf("list_credentials", "get_credential")
+            localToolNames = setOf("list_credentials", "get_credential", "list_credential_types")
         ),
         CONFIGURATION(
             keywords = setOf(
@@ -77,10 +89,13 @@ class ToolRouter {
                 "notifications", "label", "labels", "project", "projects",
                 "execution", "environment", "environments", "config", "ee",
                 "ees", "scm", "repo", "repos", "repository", "alert", "alerts",
-                "tag", "tags"
+                "tag", "tags", "license", "subscription", "version"
             ),
-            resourcePrefixes = setOf("settings", "notification_templates", "notifications", "labels", "execution_environments", "projects"),
-            localToolNames = setOf("list_projects", "get_project", "list_execution_environments")
+            resourcePrefixes = setOf("settings", "notification_templates", "notifications", "labels", "execution_environments", "projects", "config"),
+            localToolNames = setOf(
+                "list_projects", "get_project", "list_execution_environments",
+                "list_notification_templates", "get_settings", "get_config"
+            )
         ),
         EDA(
             keywords = setOf(
@@ -89,8 +104,13 @@ class ToolRouter {
                 "stream", "streams", "decision", "driven", "rulebooks",
                 "activations", "events", "environment"
             ),
-            resourcePrefixes = setOf("audit_rules", "activations", "decision_environments", "rulebooks", "event_streams"),
-            localToolNames = setOf("list_eda_audit_rules", "list_eda_activations", "get_eda_activation")
+            resourcePrefixes = setOf("audit_rules", "activations", "decision_environments", "rulebooks", "event_streams", "eda_credentials", "eda_credential_types", "eda_projects", "eda_users"),
+            localToolNames = setOf(
+                "list_eda_audit_rules", "list_eda_activations", "get_eda_activation",
+                "list_eda_rulebooks", "list_eda_decision_environments",
+                "list_eda_projects", "list_eda_credentials", "list_eda_credential_types",
+                "list_eda_event_streams", "list_eda_users"
+            )
         );
 
         val stemmedKeywords: Set<String> by lazy {
@@ -128,6 +148,30 @@ class ToolRouter {
             "list_execution_environments" to setOf("controller.execution_environments_list"),
             "list_eda_activations" to setOf("eda.activations_list"),
             "get_eda_activation" to setOf("eda.activations_read"),
+            "list_organizations" to setOf("controller.organizations_list"),
+            "list_users" to setOf("controller.users_list"),
+            "list_teams" to setOf("controller.teams_list"),
+            "list_roles" to setOf("controller.roles_list"),
+            "list_role_definitions" to setOf("controller.role_definitions_list"),
+            "list_groups" to setOf("controller.groups_list"),
+            "list_inventory_sources" to setOf("controller.inventory_sources_list"),
+            "list_labels" to setOf("controller.labels_list"),
+            "get_host_job_summaries" to setOf("controller.hosts_job_host_summaries_list"),
+            "list_credential_types" to setOf("controller.credential_types_list"),
+            "list_notification_templates" to setOf("controller.notification_templates_list"),
+            "list_applications" to setOf("controller.applications_list"),
+            "list_tokens" to setOf("controller.tokens_list"),
+            "get_settings" to setOf("controller.settings_list"),
+            "get_config" to setOf("controller.config_read"),
+            "list_workflow_nodes" to setOf("controller.workflow_job_template_nodes_list"),
+            "get_survey_spec" to setOf("controller.job_templates_survey_spec_read"),
+            "list_eda_rulebooks" to setOf("eda.rulebooks_list"),
+            "list_eda_decision_environments" to setOf("eda.decision_environments_list"),
+            "list_eda_projects" to setOf("eda.projects_list"),
+            "list_eda_credentials" to setOf("eda.credentials_list"),
+            "list_eda_credential_types" to setOf("eda.credential_types_list"),
+            "list_eda_event_streams" to setOf("eda.event_streams_list"),
+            "list_eda_users" to setOf("eda.users_list"),
         )
 
         private val MCP_TOOLS_WITH_LOCAL_OVERLAP: Set<String> =

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetConfigLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetConfigLocalTool.kt
@@ -1,0 +1,22 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import kotlinx.serialization.json.JsonObject
+
+class GetConfigLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "get_config",
+        description = "Get AAP configuration including license info, version, and platform details",
+        parametersSchema = buildToolSchema()
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val config = repository.getConfig().getOrThrow()
+        ToolResult(success = true, data = config.toString())
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetHostJobSummariesLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetHostJobSummariesLocalTool.kt
@@ -1,0 +1,43 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.HostRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class GetHostJobSummariesLocalTool(
+    private val repository: HostRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "get_host_job_summaries",
+        description = "Get job execution summaries for a specific host (pass/fail history)",
+        parametersSchema = buildToolSchema(
+            Triple("id", "integer", "Host ID"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 10, max 20)"),
+            required = listOf("id")
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val id = args.intArg("id") ?: return@executeSafely ToolResult(
+            success = false, data = "Error: 'id' parameter is required"
+        )
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 10
+        val result = repository.getHostJobSummaries(
+            hostId = id,
+            page = args.pageArg(),
+            pageSize = pageSize
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "job_host_summaries" to networkJson.encodeToString(result.summaries)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetSettingsLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetSettingsLocalTool.kt
@@ -1,0 +1,22 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import kotlinx.serialization.json.JsonObject
+
+class GetSettingsLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "get_settings",
+        description = "Get AAP system settings categories and their endpoints",
+        parametersSchema = buildToolSchema()
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val settings = repository.getSettings().getOrThrow()
+        ToolResult(success = true, data = settings.toString())
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetSurveySpecLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetSurveySpecLocalTool.kt
@@ -1,0 +1,33 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class GetSurveySpecLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "get_survey_spec",
+        description = "Get the survey specification for a job template (required variables and prompts)",
+        parametersSchema = buildToolSchema(
+            Triple("id", "integer", "Job template ID"),
+            required = listOf("id")
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val id = args.intArg("id") ?: return@executeSafely ToolResult(
+            success = false, data = "Error: 'id' parameter is required"
+        )
+        val survey = repository.getSurveySpec(id).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(survey)
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListApplicationsLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListApplicationsLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListApplicationsLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_applications",
+        description = "List OAuth2 applications registered in AAP",
+        parametersSchema = buildToolSchema(
+            Triple("search", "string", "Search term to filter by name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
+        val result = repository.getApplications(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            search = args.stringArg("search")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "applications" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListCredentialTypesLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListCredentialTypesLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListCredentialTypesLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_credential_types",
+        description = "List credential types (SSH, Vault, Cloud, etc.) available in AAP",
+        parametersSchema = buildToolSchema(
+            Triple("search", "string", "Search term to filter by name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
+        val result = repository.getCredentialTypes(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            search = args.stringArg("search")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "credential_types" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialTypesLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialTypesLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListEdaCredentialTypesLocalTool(
+    private val repository: EdaReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_eda_credential_types",
+        description = "List EDA credential types available for rulebook activations",
+        parametersSchema = buildToolSchema(
+            Triple("name", "string", "Filter by name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 20, max 20)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 20
+        val result = repository.getCredentialTypes(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            name = args.stringArg("name")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "credential_types" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialsLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialsLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListEdaCredentialsLocalTool(
+    private val repository: EdaReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_eda_credentials",
+        description = "List EDA credentials (metadata only, no secrets)",
+        parametersSchema = buildToolSchema(
+            Triple("name", "string", "Filter by credential name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 20, max 20)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 20
+        val result = repository.getCredentials(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            name = args.stringArg("name")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "credentials" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaDecisionEnvironmentsLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaDecisionEnvironmentsLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListEdaDecisionEnvironmentsLocalTool(
+    private val repository: EdaReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_eda_decision_environments",
+        description = "List EDA decision environments (container images for rulebook activations)",
+        parametersSchema = buildToolSchema(
+            Triple("name", "string", "Filter by name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 20, max 20)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 20
+        val result = repository.getDecisionEnvironments(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            name = args.stringArg("name")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "decision_environments" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaEventStreamsLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaEventStreamsLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListEdaEventStreamsLocalTool(
+    private val repository: EdaReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_eda_event_streams",
+        description = "List EDA event streams (webhook endpoints for external events)",
+        parametersSchema = buildToolSchema(
+            Triple("name", "string", "Filter by name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 20, max 20)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 20
+        val result = repository.getEventStreams(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            name = args.stringArg("name")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "event_streams" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaProjectsLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaProjectsLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListEdaProjectsLocalTool(
+    private val repository: EdaReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_eda_projects",
+        description = "List EDA projects (Git repositories containing rulebooks)",
+        parametersSchema = buildToolSchema(
+            Triple("name", "string", "Filter by project name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 20, max 20)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 20
+        val result = repository.getProjects(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            name = args.stringArg("name")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "projects" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaRulebooksLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaRulebooksLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListEdaRulebooksLocalTool(
+    private val repository: EdaReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_eda_rulebooks",
+        description = "List EDA rulebooks (requires EDA to be installed on the AAP instance)",
+        parametersSchema = buildToolSchema(
+            Triple("name", "string", "Filter by rulebook name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 20, max 20)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 20
+        val result = repository.getRulebooks(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            name = args.stringArg("name")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "rulebooks" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaUsersLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaUsersLocalTool.kt
@@ -1,0 +1,37 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListEdaUsersLocalTool(
+    private val repository: EdaReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_eda_users",
+        description = "List EDA users (requires EDA to be installed on the AAP instance)",
+        parametersSchema = buildToolSchema(
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 20, max 20)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 20) ?: 20
+        val result = repository.getUsers(
+            page = args.pageArg(),
+            pageSize = pageSize
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "users" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListGroupsLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListGroupsLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListGroupsLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_groups",
+        description = "List inventory groups with optional search",
+        parametersSchema = buildToolSchema(
+            Triple("search", "string", "Search term to filter by group name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
+        val result = repository.getGroups(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            search = args.stringArg("search")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "groups" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInventorySourcesLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInventorySourcesLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListInventorySourcesLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_inventory_sources",
+        description = "List inventory sources (dynamic inventory configurations)",
+        parametersSchema = buildToolSchema(
+            Triple("search", "string", "Search term to filter by name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
+        val result = repository.getInventorySources(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            search = args.stringArg("search")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "inventory_sources" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListLabelsLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListLabelsLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListLabelsLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_labels",
+        description = "List labels used for tagging templates and other resources",
+        parametersSchema = buildToolSchema(
+            Triple("search", "string", "Search term to filter by label name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
+        val result = repository.getLabels(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            search = args.stringArg("search")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "labels" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListNotificationTemplatesLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListNotificationTemplatesLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListNotificationTemplatesLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_notification_templates",
+        description = "List notification templates (Slack, email, webhook, etc.)",
+        parametersSchema = buildToolSchema(
+            Triple("search", "string", "Search term to filter by name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
+        val result = repository.getNotificationTemplates(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            search = args.stringArg("search")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "notification_templates" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListOrganizationsLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListOrganizationsLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListOrganizationsLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_organizations",
+        description = "List organizations in AAP with optional search",
+        parametersSchema = buildToolSchema(
+            Triple("search", "string", "Search term to filter by name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
+        val result = repository.getOrganizations(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            search = args.stringArg("search")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "organizations" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRoleDefinitionsLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRoleDefinitionsLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListRoleDefinitionsLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_role_definitions",
+        description = "List RBAC role definitions with their permissions",
+        parametersSchema = buildToolSchema(
+            Triple("search", "string", "Search term to filter role definitions"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
+        val result = repository.getRoleDefinitions(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            search = args.stringArg("search")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "role_definitions" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRolesLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRolesLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListRolesLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_roles",
+        description = "List RBAC roles defined in AAP",
+        parametersSchema = buildToolSchema(
+            Triple("search", "string", "Search term to filter roles"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
+        val result = repository.getRoles(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            search = args.stringArg("search")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "roles" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTeamsLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTeamsLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListTeamsLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_teams",
+        description = "List teams in AAP with optional search",
+        parametersSchema = buildToolSchema(
+            Triple("search", "string", "Search term to filter by team name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
+        val result = repository.getTeams(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            search = args.stringArg("search")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "teams" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTokensLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTokensLocalTool.kt
@@ -1,0 +1,37 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListTokensLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_tokens",
+        description = "List personal access tokens (metadata only, no secrets)",
+        parametersSchema = buildToolSchema(
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
+        val result = repository.getTokens(
+            page = args.pageArg(),
+            pageSize = pageSize
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "tokens" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListUsersLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListUsersLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListUsersLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_users",
+        description = "List users in AAP with optional search by username",
+        parametersSchema = buildToolSchema(
+            Triple("search", "string", "Search term to filter by username or name"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
+        val result = repository.getUsers(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            search = args.stringArg("search")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "users" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListWorkflowNodesLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListWorkflowNodesLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+class ListWorkflowNodesLocalTool(
+    private val repository: ControllerReadOnlyRepository
+) : LocalTool(
+    spec = ToolSpec(
+        name = "list_workflow_nodes",
+        description = "List workflow job template nodes, optionally filtered by workflow template ID",
+        parametersSchema = buildToolSchema(
+            Triple("workflow_job_template", "integer", "Filter by workflow job template ID"),
+            Triple("page", "integer", "Page number (default 1)"),
+            Triple("page_size", "integer", "Results per page (default 25, max 25)"),
+        )
+    )
+) {
+    override suspend fun execute(args: JsonObject): ToolResult = executeSafely {
+        val pageSize = args.intArg("page_size")?.coerceIn(1, 25) ?: 25
+        val result = repository.getWorkflowJobTemplateNodes(
+            page = args.pageArg(),
+            pageSize = pageSize,
+            workflowJobTemplate = args.intArg("workflow_job_template")
+        ).getOrThrow()
+        ToolResult(
+            success = true,
+            data = networkJson.encodeToString(mapOf(
+                "count" to result.totalCount.toString(),
+                "workflow_nodes" to networkJson.encodeToString(result.items)
+            ))
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/ControllerReadOnlyRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/ControllerReadOnlyRepository.kt
@@ -1,0 +1,150 @@
+package io.github.leogallego.ansiblejane.data
+
+import io.github.leogallego.ansiblejane.model.*
+import io.github.leogallego.ansiblejane.network.AapApiProvider
+import kotlinx.serialization.json.JsonElement
+
+class ControllerReadOnlyRepository(private val apiProvider: AapApiProvider) {
+
+    suspend fun getOrganizations(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<ListResult<Organization>> = runPaginated {
+        apiProvider.getApiService().getOrganizations(page, pageSize, search)
+    }
+
+    suspend fun getUsers(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<ListResult<User>> = runPaginated {
+        apiProvider.getApiService().getUsers(page, pageSize, search)
+    }
+
+    suspend fun getTeams(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<ListResult<Team>> = runPaginated {
+        apiProvider.getApiService().getTeams(page, pageSize, search)
+    }
+
+    suspend fun getRoles(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<ListResult<Role>> = runPaginated {
+        apiProvider.getApiService().getRoles(page, pageSize, search)
+    }
+
+    suspend fun getRoleDefinitions(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<ListResult<RoleDefinition>> = runPaginated {
+        apiProvider.getApiService().getRoleDefinitions(page, pageSize, search)
+    }
+
+    suspend fun getGroups(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<ListResult<Group>> = runPaginated {
+        apiProvider.getApiService().getGroups(page, pageSize, search)
+    }
+
+    suspend fun getInventorySources(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<ListResult<InventorySource>> = runPaginated {
+        apiProvider.getApiService().getInventorySources(page, pageSize, search)
+    }
+
+    suspend fun getLabels(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<ListResult<Label>> = runPaginated {
+        apiProvider.getApiService().getLabels(page, pageSize, search)
+    }
+
+    suspend fun getCredentialTypes(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<ListResult<CredentialType>> = runPaginated {
+        apiProvider.getApiService().getCredentialTypes(page, pageSize, search)
+    }
+
+    suspend fun getNotificationTemplates(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<ListResult<NotificationTemplate>> = runPaginated {
+        apiProvider.getApiService().getNotificationTemplates(page, pageSize, search)
+    }
+
+    suspend fun getApplications(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null
+    ): Result<ListResult<Application>> = runPaginated {
+        apiProvider.getApiService().getApplications(page, pageSize, search)
+    }
+
+    suspend fun getTokens(
+        page: Int = 1,
+        pageSize: Int = 25
+    ): Result<ListResult<AapToken>> = runPaginated {
+        apiProvider.getApiService().getTokens(page, pageSize)
+    }
+
+    suspend fun getSettings(): Result<JsonElement> = try {
+        Result.success(apiProvider.getApiService().getSettings())
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    suspend fun getConfig(): Result<JsonElement> = try {
+        Result.success(apiProvider.getApiService().getConfig())
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    suspend fun getWorkflowJobTemplateNodes(
+        page: Int = 1,
+        pageSize: Int = 25,
+        workflowJobTemplate: Int? = null
+    ): Result<ListResult<WorkflowJobTemplateNode>> = runPaginated {
+        apiProvider.getApiService().getWorkflowJobTemplateNodes(page, pageSize, workflowJobTemplate)
+    }
+
+    suspend fun getSurveySpec(id: Int): Result<SurveySpec> = try {
+        Result.success(apiProvider.getApiService().getSurveySpec(id))
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    private inline fun <T> runPaginated(
+        block: () -> PaginatedResponse<T>
+    ): Result<ListResult<T>> = try {
+        val response = block()
+        Result.success(
+            ListResult(
+                items = response.results,
+                hasMore = response.next != null,
+                totalCount = response.count
+            )
+        )
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+}
+
+data class ListResult<T>(
+    val items: List<T>,
+    val hasMore: Boolean,
+    val totalCount: Int
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/DataModule.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/DataModule.kt
@@ -23,4 +23,6 @@ val dataModule = module {
     single { CredentialRepository(get<AapApiProvider>()) } bind ICredentialRepository::class
     single { ProjectRepository(get<AapApiProvider>()) } bind IProjectRepository::class
     single { EdaActivationRepository(get<AapApiProvider>()) } bind IEdaActivationRepository::class
+    single { ControllerReadOnlyRepository(get<AapApiProvider>()) }
+    single { EdaReadOnlyRepository(get<AapApiProvider>()) }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/EdaReadOnlyRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/EdaReadOnlyRepository.kt
@@ -1,0 +1,77 @@
+package io.github.leogallego.ansiblejane.data
+
+import io.github.leogallego.ansiblejane.model.*
+import io.github.leogallego.ansiblejane.network.AapApiProvider
+
+class EdaReadOnlyRepository(private val apiProvider: AapApiProvider) {
+
+    suspend fun getRulebooks(
+        page: Int = 1,
+        pageSize: Int = 20,
+        name: String? = null
+    ): Result<ListResult<EdaRulebook>> = runEdaPaginated {
+        apiProvider.getEdaApiService().getRulebooks(page, pageSize, name)
+    }
+
+    suspend fun getDecisionEnvironments(
+        page: Int = 1,
+        pageSize: Int = 20,
+        name: String? = null
+    ): Result<ListResult<EdaDecisionEnvironment>> = runEdaPaginated {
+        apiProvider.getEdaApiService().getDecisionEnvironments(page, pageSize, name)
+    }
+
+    suspend fun getProjects(
+        page: Int = 1,
+        pageSize: Int = 20,
+        name: String? = null
+    ): Result<ListResult<EdaProject>> = runEdaPaginated {
+        apiProvider.getEdaApiService().getProjects(page, pageSize, name)
+    }
+
+    suspend fun getCredentials(
+        page: Int = 1,
+        pageSize: Int = 20,
+        name: String? = null
+    ): Result<ListResult<EdaCredential>> = runEdaPaginated {
+        apiProvider.getEdaApiService().getCredentials(page, pageSize, name)
+    }
+
+    suspend fun getCredentialTypes(
+        page: Int = 1,
+        pageSize: Int = 20,
+        name: String? = null
+    ): Result<ListResult<EdaCredentialType>> = runEdaPaginated {
+        apiProvider.getEdaApiService().getCredentialTypes(page, pageSize, name)
+    }
+
+    suspend fun getEventStreams(
+        page: Int = 1,
+        pageSize: Int = 20,
+        name: String? = null
+    ): Result<ListResult<EdaEventStream>> = runEdaPaginated {
+        apiProvider.getEdaApiService().getEventStreams(page, pageSize, name)
+    }
+
+    suspend fun getUsers(
+        page: Int = 1,
+        pageSize: Int = 20
+    ): Result<ListResult<EdaUser>> = runEdaPaginated {
+        apiProvider.getEdaApiService().getUsers(page, pageSize)
+    }
+
+    private inline fun <T> runEdaPaginated(
+        block: () -> PaginatedResponse<T>
+    ): Result<ListResult<T>> = try {
+        val response = block()
+        Result.success(
+            ListResult(
+                items = response.results,
+                hasMore = response.next != null,
+                totalCount = response.count
+            )
+        )
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/AapToken.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/AapToken.kt
@@ -1,0 +1,11 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AapToken(
+    val id: Int,
+    val description: String = "",
+    val scope: String = "",
+    val user: Int? = null
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/Application.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/Application.kt
@@ -1,0 +1,14 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Application(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    @SerialName("client_type") val clientType: String = "",
+    @SerialName("authorization_grant_type") val authorizationGrantType: String = "",
+    val organization: Int? = null
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/CredentialType.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/CredentialType.kt
@@ -1,0 +1,14 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+@Serializable
+data class CredentialType(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    val kind: String = "",
+    val managed: Boolean = false,
+    val inputs: JsonObject? = null
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaCredential.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaCredential.kt
@@ -1,0 +1,13 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EdaCredential(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    @SerialName("credential_type_id") val credentialTypeId: Int? = null,
+    @SerialName("organization_id") val organizationId: Int? = null
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaCredentialType.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaCredentialType.kt
@@ -1,0 +1,10 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EdaCredentialType(
+    val id: Int,
+    val name: String = "",
+    val description: String = ""
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaDecisionEnvironment.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaDecisionEnvironment.kt
@@ -1,0 +1,13 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EdaDecisionEnvironment(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    @SerialName("image_url") val imageUrl: String = "",
+    @SerialName("organization_id") val organizationId: Int? = null
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaEventStream.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaEventStream.kt
@@ -1,0 +1,13 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EdaEventStream(
+    val id: Int,
+    val name: String = "",
+    val uuid: String = "",
+    @SerialName("forward_events") val forwardEvents: Boolean = false,
+    @SerialName("organization_id") val organizationId: Int? = null
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaProject.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaProject.kt
@@ -1,0 +1,14 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EdaProject(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    val url: String = "",
+    @SerialName("scm_branch") val scmBranch: String = "",
+    @SerialName("organization_id") val organizationId: Int? = null
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaRulebook.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaRulebook.kt
@@ -1,0 +1,13 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EdaRulebook(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    @SerialName("project_id") val projectId: Int? = null,
+    @SerialName("organization_id") val organizationId: Int? = null
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaUser.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/EdaUser.kt
@@ -1,0 +1,14 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EdaUser(
+    val id: Int,
+    val username: String = "",
+    val email: String = "",
+    @SerialName("first_name") val firstName: String = "",
+    @SerialName("last_name") val lastName: String = "",
+    @SerialName("is_superuser") val isSuperuser: Boolean = false
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/Group.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/Group.kt
@@ -1,0 +1,11 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Group(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    val inventory: Int? = null
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/InventorySource.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/InventorySource.kt
@@ -1,0 +1,15 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class InventorySource(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    val source: String = "",
+    val inventory: Int? = null,
+    @SerialName("update_on_launch") val updateOnLaunch: Boolean = false,
+    val status: String = ""
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/NotificationTemplate.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/NotificationTemplate.kt
@@ -1,0 +1,13 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NotificationTemplate(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    @SerialName("notification_type") val notificationType: String = "",
+    val organization: Int? = null
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/Organization.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/Organization.kt
@@ -1,0 +1,12 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Organization(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    @SerialName("max_hosts") val maxHosts: Int = 0
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/Role.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/Role.kt
@@ -1,0 +1,10 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Role(
+    val id: Int,
+    val name: String = "",
+    val description: String = ""
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/RoleDefinition.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/RoleDefinition.kt
@@ -1,0 +1,13 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RoleDefinition(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    @SerialName("content_type") val contentType: String = "",
+    val permissions: List<String> = emptyList()
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/SurveySpec.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/SurveySpec.kt
@@ -1,0 +1,25 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+@Serializable
+data class SurveySpec(
+    val name: String = "",
+    val description: String = "",
+    val spec: List<SurveyQuestion> = emptyList()
+)
+
+@Serializable
+data class SurveyQuestion(
+    @SerialName("question_name") val questionName: String = "",
+    @SerialName("question_description") val questionDescription: String = "",
+    val required: Boolean = false,
+    val type: String = "",
+    val variable: String = "",
+    val default: JsonElement? = null,
+    val choices: JsonElement? = null,
+    val min: Int? = null,
+    val max: Int? = null
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/Team.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/Team.kt
@@ -1,0 +1,11 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Team(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    val organization: Int? = null
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/WorkflowJobTemplateNode.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/WorkflowJobTemplateNode.kt
@@ -1,0 +1,12 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WorkflowJobTemplateNode(
+    val id: Int,
+    val identifier: String = "",
+    @SerialName("unified_job_template") val unifiedJobTemplate: Int? = null,
+    @SerialName("workflow_job_template") val workflowJobTemplate: Int? = null
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/AapApiService.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/AapApiService.kt
@@ -171,4 +171,113 @@ interface AapApiService {
         @Query("page") page: Int = 1,
         @Query("page_size") pageSize: Int = 25
     ): PaginatedResponse<ExecutionEnvironment>
+
+    @GET("organizations/")
+    suspend fun getOrganizations(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "name"
+    ): PaginatedResponse<Organization>
+
+    @GET("users/")
+    suspend fun getUsers(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "username"
+    ): PaginatedResponse<User>
+
+    @GET("teams/")
+    suspend fun getTeams(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "name"
+    ): PaginatedResponse<Team>
+
+    @GET("roles/")
+    suspend fun getRoles(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null
+    ): PaginatedResponse<Role>
+
+    @GET("role_definitions/")
+    suspend fun getRoleDefinitions(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null
+    ): PaginatedResponse<RoleDefinition>
+
+    @GET("groups/")
+    suspend fun getGroups(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "name"
+    ): PaginatedResponse<Group>
+
+    @GET("inventory_sources/")
+    suspend fun getInventorySources(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "name"
+    ): PaginatedResponse<InventorySource>
+
+    @GET("labels/")
+    suspend fun getLabels(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "name"
+    ): PaginatedResponse<Label>
+
+    @GET("credential_types/")
+    suspend fun getCredentialTypes(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "name"
+    ): PaginatedResponse<CredentialType>
+
+    @GET("notification_templates/")
+    suspend fun getNotificationTemplates(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "name"
+    ): PaginatedResponse<NotificationTemplate>
+
+    @GET("applications/")
+    suspend fun getApplications(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("search") search: String? = null,
+        @Query("order_by") orderBy: String = "name"
+    ): PaginatedResponse<Application>
+
+    @GET("tokens/")
+    suspend fun getTokens(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("order_by") orderBy: String = "-created"
+    ): PaginatedResponse<AapToken>
+
+    @GET("settings/")
+    suspend fun getSettings(): kotlinx.serialization.json.JsonElement
+
+    @GET("config/")
+    suspend fun getConfig(): kotlinx.serialization.json.JsonElement
+
+    @GET("workflow_job_template_nodes/")
+    suspend fun getWorkflowJobTemplateNodes(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("workflow_job_template") workflowJobTemplate: Int? = null
+    ): PaginatedResponse<WorkflowJobTemplateNode>
+
+    @GET("job_templates/{id}/survey_spec/")
+    suspend fun getSurveySpec(@Path("id") id: Int): SurveySpec
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/EdaApiService.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/EdaApiService.kt
@@ -1,8 +1,6 @@
 package io.github.leogallego.ansiblejane.network
 
-import io.github.leogallego.ansiblejane.model.EdaActivation
-import io.github.leogallego.ansiblejane.model.EdaRuleAudit
-import io.github.leogallego.ansiblejane.model.PaginatedResponse
+import io.github.leogallego.ansiblejane.model.*
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -26,4 +24,52 @@ interface EdaApiService {
 
     @GET("activations/{id}/")
     suspend fun getActivation(@Path("id") id: Int): EdaActivation
+
+    @GET("rulebooks/")
+    suspend fun getRulebooks(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 20,
+        @Query("name") name: String? = null
+    ): PaginatedResponse<EdaRulebook>
+
+    @GET("decision-environments/")
+    suspend fun getDecisionEnvironments(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 20,
+        @Query("name") name: String? = null
+    ): PaginatedResponse<EdaDecisionEnvironment>
+
+    @GET("projects/")
+    suspend fun getProjects(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 20,
+        @Query("name") name: String? = null
+    ): PaginatedResponse<EdaProject>
+
+    @GET("credentials/")
+    suspend fun getCredentials(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 20,
+        @Query("name") name: String? = null
+    ): PaginatedResponse<EdaCredential>
+
+    @GET("credential-types/")
+    suspend fun getCredentialTypes(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 20,
+        @Query("name") name: String? = null
+    ): PaginatedResponse<EdaCredentialType>
+
+    @GET("event-streams/")
+    suspend fun getEventStreams(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 20,
+        @Query("name") name: String? = null
+    ): PaginatedResponse<EdaEventStream>
+
+    @GET("users/")
+    suspend fun getUsers(
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 20
+    ): PaginatedResponse<EdaUser>
 }


### PR DESCRIPTION
## Summary

- Expands Jane's local tool coverage from **26 to 50 tools** by adding read-only endpoints for all remaining Controller and EDA API resources
- Adds **17 new Controller tools**: organizations, users, teams, roles, role definitions, groups, inventory sources, labels, credential types, notification templates, applications, tokens, settings, config, workflow template nodes, survey spec, and host job summaries
- Adds **7 new EDA tools**: rulebooks, decision environments, projects, credentials, credential types, event streams, and users
- Introduces `ControllerReadOnlyRepository` and `EdaReadOnlyRepository` with a generic `ListResult<T>` wrapper to avoid per-resource repository boilerplate for Jane-only tools
- Updates `ToolRouter` categories, keywords, and `OVERLAP_MAPPING` for all new tools

## Architecture

New tools follow the existing 4-layer pattern (model → Retrofit → repository → LocalTool) but use shared repositories instead of one per resource:

| Layer | Controller | EDA |
|-------|-----------|-----|
| Models | 12 new data classes | 7 new data classes |
| Retrofit | 16 new `@GET` in `AapApiService` | 7 new `@GET` in `EdaApiService` |
| Repository | `ControllerReadOnlyRepository` | `EdaReadOnlyRepository` |
| Tools | 17 new LocalTool classes | 7 new LocalTool classes |

## Test plan

- [x] `compileDebugKotlin` passes
- [x] `ToolRouterTest` passes
- [x] All assistant-related unit tests pass
- [x] Pre-existing test failures (Robolectric `FileSystemException`) confirmed on main — not introduced by this PR
- [ ] Manual: Settings → Agent → Jane should show ~50 tools in `list_tools`
- [ ] Manual: Ask Jane "list organizations" / "show EDA rulebooks" / "what credential types are available"

Closes #137
Closes #138

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>