### PR TITLE
Chat UI polish + search on Jobs, Inventories, EDA

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
+import io.github.leogallego.ansiblejane.assistant.engine.Role
 import io.github.leogallego.ansiblejane.assistant.data.KnownProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -41,6 +42,11 @@ class AssistantRepository(private val context: Context) : IAssistantRepository {
     }
 
     override fun getHistory(): List<ChatMessage> = messages.toList()
+
+    override fun removeLastAssistantMessage() {
+        val index = messages.indexOfLast { it.role == Role.ASSISTANT }
+        if (index >= 0) messages.removeAt(index)
+    }
 
     override fun clearHistory() {
         messages.clear()

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.Flow
 interface IAssistantRepository {
     fun addMessage(message: ChatMessage)
     fun getHistory(): List<ChatMessage>
+    fun removeLastAssistantMessage()
     fun clearHistory()
     suspend fun saveLlmConfig(config: LlmProviderConfig)
     suspend fun loadLlmConfig(): LlmProviderConfig?

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -273,6 +273,19 @@ class AssistantViewModel(
         }
     }
 
+    fun stopGeneration() {
+        generateJob?.cancel()
+        updateState { copy(isGenerating = false, streamingText = null) }
+    }
+
+    fun regenerateLastMessage() {
+        val history = repository.getHistory()
+        val lastUserMsg = history.lastOrNull { it.role == Role.USER } ?: return
+        repository.removeLastAssistantMessage()
+        updateState { copy(messages = repository.getHistory().toImmutableList()) }
+        sendMessage(lastUserMsg.content)
+    }
+
     fun clearHistory() {
         repository.clearHistory()
         updateState { copy(messages = persistentListOf()) }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
@@ -26,13 +26,18 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -56,6 +61,8 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
@@ -107,6 +114,8 @@ fun AssistantScreen(
             ActiveChatContent(
                 state = state,
                 onSendMessage = { viewModel.sendMessage(it) },
+                onStopGeneration = { viewModel.stopGeneration() },
+                onRegenerateLastMessage = { viewModel.regenerateLastMessage() },
                 modifier = Modifier.fillMaxSize()
             )
         }
@@ -131,6 +140,8 @@ fun AssistantScreen(
 private fun ActiveChatContent(
     state: AssistantUiState.Active,
     onSendMessage: (String) -> Unit,
+    onStopGeneration: () -> Unit,
+    onRegenerateLastMessage: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val listState = rememberLazyListState()
@@ -193,6 +204,11 @@ private fun ActiveChatContent(
             }
         }
 
+        val clipboardManager = LocalClipboardManager.current
+        val lastAssistantId = remember(state.messages) {
+            state.messages.lastOrNull { it.role == Role.ASSISTANT }?.id
+        }
+
         LazyColumn(
             state = listState,
             modifier = Modifier
@@ -228,12 +244,25 @@ private fun ActiveChatContent(
                 key = { it.id },
                 contentType = { it.role }
             ) { message ->
+                val isLastAssistant = message.role == Role.ASSISTANT &&
+                    message.id == lastAssistantId &&
+                    !state.isGenerating
                 when (message.role) {
-                    Role.USER -> UserBubble(message = message)
+                    Role.USER -> UserBubble(
+                        message = message,
+                        onCopy = {
+                            clipboardManager.setText(AnnotatedString(message.content))
+                        },
+                    )
                     Role.ASSISTANT -> AssistantMessage(
                         content = message.content,
                         source = message.source,
-                        toolsUsed = message.toolsUsed
+                        toolsUsed = message.toolsUsed,
+                        onCopy = {
+                            clipboardManager.setText(AnnotatedString(message.content))
+                        },
+                        onRegenerate = if (isLastAssistant) onRegenerateLastMessage
+                            else null,
                     )
                     else -> AssistantMessage(content = message.content)
                 }
@@ -246,50 +275,64 @@ private fun ActiveChatContent(
             }
         }
 
-        Row(
+        OutlinedTextField(
+            value = inputText,
+            onValueChange = { inputText = it },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            OutlinedTextField(
-                value = inputText,
-                onValueChange = { inputText = it },
-                modifier = Modifier
-                    .weight(1f)
-                    .testTag("field_assistant_input")
-                    .focusRequester(focusRequester)
-                    .onPreviewKeyEvent {
-                        if (it.type == KeyEventType.KeyUp &&
-                            it.key == Key.Enter &&
-                            it.isCtrlPressed
-                        ) {
-                            submit()
-                            true
-                        } else false
-                    },
-                placeholder = { Text("Ask a question...") },
-                maxLines = 3,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
-                keyboardActions = KeyboardActions(onSend = { submit() }),
-            )
-
-            IconButton(
-                onClick = { submit() },
-                modifier = Modifier.testTag("button_send"),
-                enabled = inputText.text.isNotBlank() && !state.isGenerating
-            ) {
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .testTag("field_assistant_input")
+                .focusRequester(focusRequester)
+                .onPreviewKeyEvent {
+                    if (it.type == KeyEventType.KeyUp &&
+                        it.key == Key.Enter &&
+                        it.isCtrlPressed
+                    ) {
+                        submit()
+                        true
+                    } else false
+                },
+            placeholder = { Text("Ask a question...") },
+            maxLines = 3,
+            shape = RoundedCornerShape(28.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
+            ),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+            keyboardActions = KeyboardActions(onSend = { submit() }),
+            trailingIcon = {
                 if (state.isGenerating) {
-                    CircularProgressIndicator(modifier = Modifier.padding(4.dp))
+                    FilledIconButton(
+                        onClick = onStopGeneration,
+                        modifier = Modifier
+                            .size(36.dp)
+                            .testTag("button_stop"),
+                        colors = IconButtonDefaults.filledIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.onError,
+                        ),
+                    ) {
+                        Icon(
+                            Icons.Default.Stop,
+                            contentDescription = "Stop generation",
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
                 } else {
-                    Icon(
-                        Icons.AutoMirrored.Filled.Send,
-                        contentDescription = "Send"
-                    )
+                    IconButton(
+                        onClick = { submit() },
+                        modifier = Modifier.testTag("button_send"),
+                        enabled = inputText.text.isNotBlank(),
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.Send,
+                            contentDescription = "Send",
+                        )
+                    }
                 }
-            }
-        }
+            },
+        )
     }
 }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ChatBubble.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ChatBubble.kt
@@ -1,7 +1,10 @@
 package io.github.leogallego.ansiblejane.assistant.ui
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -9,17 +12,27 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -39,64 +52,102 @@ import dev.snipme.highlights.Highlights
 import dev.snipme.highlights.model.SyntaxLanguage
 import dev.snipme.highlights.model.SyntaxThemes
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun UserBubble(
     message: ChatMessage,
+    onCopy: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
-    SelectionContainer {
-        Row(modifier = modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-            Spacer(Modifier.weight(1f))
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    Row(modifier = modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+        Spacer(Modifier.weight(1f))
+        Box {
             Column(
                 modifier = Modifier
+                    .combinedClickable(
+                        onClick = {},
+                        onLongClick = { menuExpanded = true },
+                    )
                     .background(
                         MaterialTheme.colorScheme.onBackground.copy(alpha = 0.15f),
                         RoundedCornerShape(12.dp),
                     )
                     .padding(12.dp)
             ) {
-                Text(
-                    text = message.content,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onBackground,
-                )
+                SelectionContainer {
+                    Text(
+                        text = message.content,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onBackground,
+                    )
+                }
             }
+            MessageContextMenu(
+                expanded = menuExpanded,
+                onDismiss = { menuExpanded = false },
+                onCopy = onCopy,
+            )
         }
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun AssistantMessage(
     content: String,
     source: ResponseSource? = null,
     toolsUsed: List<String> = emptyList(),
+    onCopy: (() -> Unit)? = null,
+    onRegenerate: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     val isError = content.startsWith("Error:")
+    var menuExpanded by remember { mutableStateOf(false) }
 
     if (isError) {
-        Surface(
-            shape = RoundedCornerShape(12.dp),
-            color = MaterialTheme.colorScheme.errorContainer,
-            modifier = modifier
-        ) {
-            Text(
-                text = content,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onErrorContainer,
-                modifier = Modifier.padding(12.dp)
+        Box {
+            Surface(
+                shape = RoundedCornerShape(12.dp),
+                color = MaterialTheme.colorScheme.errorContainer,
+                modifier = modifier.combinedClickable(
+                    onClick = {},
+                    onLongClick = { menuExpanded = true },
+                )
+            ) {
+                Text(
+                    text = content,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    modifier = Modifier.padding(12.dp)
+                )
+            }
+            MessageContextMenu(
+                expanded = menuExpanded,
+                onDismiss = { menuExpanded = false },
+                onCopy = onCopy,
+                onRegenerate = onRegenerate,
             )
         }
     } else {
-        Column(
+        Box(
             modifier = modifier
                 .fillMaxWidth()
-                .padding(vertical = 4.dp)
+                .combinedClickable(
+                    onClick = {},
+                    onLongClick = { menuExpanded = true },
+                )
         ) {
-            if (source != null) {
-                SourceBand(source = source, toolsUsed = toolsUsed)
-            }
-            SelectionContainer {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp)
+            ) {
+                if (source != null) {
+                    SourceBand(source = source, toolsUsed = toolsUsed)
+                }
+                SelectionContainer {
                 val isDarkTheme = isSystemInDarkTheme()
                 val highlightsBuilder = remember(isDarkTheme) {
                     Highlights.Builder().theme(SyntaxThemes.monokai(darkMode = isDarkTheme))
@@ -159,6 +210,13 @@ fun AssistantMessage(
                     )
                 }
             }
+            }
+            MessageContextMenu(
+                expanded = menuExpanded,
+                onDismiss = { menuExpanded = false },
+                onCopy = onCopy,
+                onRegenerate = onRegenerate,
+            )
         }
     }
 }
@@ -211,5 +269,40 @@ private fun SourceBand(
             thickness = 0.5.dp,
             modifier = Modifier.padding(top = 4.dp),
         )
+    }
+}
+
+@Composable
+private fun MessageContextMenu(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+    onCopy: (() -> Unit)? = null,
+    onRegenerate: (() -> Unit)? = null,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismiss,
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        if (onCopy != null) {
+            DropdownMenuItem(
+                text = { Text("Copy") },
+                onClick = { onCopy(); onDismiss() },
+                leadingIcon = {
+                    Icon(Icons.Default.ContentCopy, contentDescription = null)
+                },
+                modifier = Modifier.testTag("menu_copy"),
+            )
+        }
+        if (onRegenerate != null) {
+            DropdownMenuItem(
+                text = { Text("Regenerate") },
+                onClick = { onRegenerate(); onDismiss() },
+                leadingIcon = {
+                    Icon(Icons.Default.Refresh, contentDescription = null)
+                },
+                modifier = Modifier.testTag("menu_regenerate"),
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/EdaAuditRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/EdaAuditRepository.kt
@@ -5,11 +5,12 @@ import io.github.leogallego.ansiblejane.network.AapApiProvider
 
 class EdaAuditRepository(private val apiProvider: AapApiProvider) : IEdaAuditRepository {
 
-    override suspend fun getAuditRules(page: Int, pageSize: Int): Result<EdaAuditResult> {
+    override suspend fun getAuditRules(page: Int, pageSize: Int, search: String?): Result<EdaAuditResult> {
         return try {
             val response = apiProvider.getEdaApiService().getAuditRules(
                 page = page,
-                pageSize = pageSize
+                pageSize = pageSize,
+                search = search
             )
             Result.success(
                 EdaAuditResult(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/IEdaAuditRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/IEdaAuditRepository.kt
@@ -1,5 +1,5 @@
 package io.github.leogallego.ansiblejane.data
 
 interface IEdaAuditRepository {
-    suspend fun getAuditRules(page: Int = 1, pageSize: Int = 20): Result<EdaAuditResult>
+    suspend fun getAuditRules(page: Int = 1, pageSize: Int = 20, search: String? = null): Result<EdaAuditResult>
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/IJobRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/IJobRepository.kt
@@ -11,6 +11,7 @@ interface IJobRepository {
     suspend fun getRecentJobs(
         page: Int = 1,
         pageSize: Int = 20,
-        statusFilters: Set<JobStatus> = emptySet()
+        statusFilters: Set<JobStatus> = emptySet(),
+        search: String? = null
     ): Result<RecentJobsResult>
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/JobRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/JobRepository.kt
@@ -42,7 +42,8 @@ class JobRepository(private val apiProvider: AapApiProvider) : IJobRepository {
     override suspend fun getRecentJobs(
         page: Int,
         pageSize: Int,
-        statusFilters: Set<JobStatus>
+        statusFilters: Set<JobStatus>,
+        search: String?
     ): Result<RecentJobsResult> {
         return try {
             val orStatus = if (statusFilters.size > 1) {
@@ -60,7 +61,8 @@ class JobRepository(private val apiProvider: AapApiProvider) : IJobRepository {
                 pageSize = pageSize,
                 page = page,
                 status = singleStatus,
-                orStatus = orStatus
+                orStatus = orStatus,
+                search = search
             )
             Result.success(
                 RecentJobsResult(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/AapApiService.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/AapApiService.kt
@@ -43,7 +43,8 @@ interface AapApiService {
         @Query("page_size") pageSize: Int = 20,
         @Query("page") page: Int = 1,
         @Query("status") status: String? = null,
-        @Query("or__status") orStatus: List<String>? = null
+        @Query("or__status") orStatus: List<String>? = null,
+        @Query("search") search: String? = null
     ): PaginatedResponse<Job>
 
     @GET("schedules/")

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/EdaApiService.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/EdaApiService.kt
@@ -12,7 +12,8 @@ interface EdaApiService {
     @GET("audit-rules/")
     suspend fun getAuditRules(
         @Query("page") page: Int = 1,
-        @Query("page_size") pageSize: Int = 20
+        @Query("page_size") pageSize: Int = 20,
+        @Query("search") search: String? = null
     ): PaginatedResponse<EdaRuleAudit>
 
     @GET("audit-rules/{id}/")

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/eda/EdaAuditViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/eda/EdaAuditViewModel.kt
@@ -7,6 +7,7 @@ import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AppError
 import io.github.leogallego.ansiblejane.model.EdaRuleAudit
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -22,9 +23,14 @@ class EdaAuditViewModel(
     private val _uiState = MutableStateFlow<EdaAuditUiState>(EdaAuditUiState.Loading)
     val uiState: StateFlow<EdaAuditUiState> = _uiState.asStateFlow()
 
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
     private var currentPage = 1
     private val allAuditRules = mutableListOf<EdaRuleAudit>()
     private var fetchJob: Job? = null
+    private var searchJob: Job? = null
+    private var currentSearch: String? = null
 
     init {
         viewModelScope.launch {
@@ -56,6 +62,19 @@ class EdaAuditViewModel(
         }
     }
 
+    fun search(query: String) {
+        _searchQuery.value = query
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            delay(300)
+            currentSearch = query.ifBlank { null }
+            currentPage = 1
+            allAuditRules.clear()
+            _uiState.value = EdaAuditUiState.Loading
+            fetchAuditRules()
+        }
+    }
+
     fun loadMore() {
         val current = _uiState.value
         if (current is EdaAuditUiState.Success && current.hasMore && !current.isLoadingMore) {
@@ -68,7 +87,7 @@ class EdaAuditViewModel(
     }
 
     private suspend fun fetchAuditRules(append: Boolean = false) {
-        val result = edaAuditRepository.getAuditRules(page = currentPage)
+        val result = edaAuditRepository.getAuditRules(page = currentPage, search = currentSearch)
         result.fold(
             onSuccess = { auditResult ->
                 if (append) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/inventory/InventoriesViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/inventory/InventoriesViewModel.kt
@@ -7,6 +7,7 @@ import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AppError
 import io.github.leogallego.ansiblejane.model.Inventory
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,9 +22,14 @@ class InventoriesViewModel(
     private val _uiState = MutableStateFlow<InventoriesUiState>(InventoriesUiState.Loading)
     val uiState: StateFlow<InventoriesUiState> = _uiState.asStateFlow()
 
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
     private var currentPage = 1
     private val allInventories = mutableListOf<Inventory>()
     private var fetchJob: Job? = null
+    private var searchJob: Job? = null
+    private var currentSearch: String? = null
 
     init {
         viewModelScope.launch {
@@ -55,6 +61,19 @@ class InventoriesViewModel(
         }
     }
 
+    fun search(query: String) {
+        _searchQuery.value = query
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            delay(300)
+            currentSearch = query.ifBlank { null }
+            currentPage = 1
+            allInventories.clear()
+            _uiState.value = InventoriesUiState.Loading
+            fetchInventories()
+        }
+    }
+
     fun loadMore() {
         val current = _uiState.value
         if (current is InventoriesUiState.Success && current.hasMore && !current.isLoadingMore) {
@@ -67,7 +86,7 @@ class InventoriesViewModel(
     }
 
     private suspend fun fetchInventories(append: Boolean = false) {
-        val result = inventoryRepository.getInventories(page = currentPage)
+        val result = inventoryRepository.getInventories(page = currentPage, search = currentSearch)
         result.fold(
             onSuccess = { inventoryResult ->
                 if (append) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/jobs/RecentJobsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/jobs/RecentJobsViewModel.kt
@@ -7,6 +7,7 @@ import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AppError
 import io.github.leogallego.ansiblejane.model.Job
 import io.github.leogallego.ansiblejane.model.JobStatus
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,10 +22,15 @@ class RecentJobsViewModel(
     private val _uiState = MutableStateFlow<RecentJobsUiState>(RecentJobsUiState.Loading)
     val uiState: StateFlow<RecentJobsUiState> = _uiState.asStateFlow()
 
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
     private var currentPage = 1
     private val allJobs = mutableListOf<Job>()
     private var activeFilters = mutableSetOf<JobStatus>()
     private var fetchJob: kotlinx.coroutines.Job? = null
+    private var searchJob: kotlinx.coroutines.Job? = null
+    private var currentSearch: String? = null
 
     init {
         viewModelScope.launch {
@@ -80,6 +86,19 @@ class RecentJobsViewModel(
         }
     }
 
+    fun search(query: String) {
+        _searchQuery.value = query
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            delay(300)
+            currentSearch = query.ifBlank { null }
+            currentPage = 1
+            allJobs.clear()
+            _uiState.value = RecentJobsUiState.Loading
+            fetchJobs()
+        }
+    }
+
     fun getActiveFilters(): Set<JobStatus> = activeFilters.toSet()
 
     fun loadMore() {
@@ -96,7 +115,8 @@ class RecentJobsViewModel(
     private suspend fun fetchJobs(append: Boolean = false) {
         val result = jobRepository.getRecentJobs(
             page = currentPage,
-            statusFilters = activeFilters.toSet()
+            statusFilters = activeFilters.toSet(),
+            search = currentSearch
         )
         result.fold(
             onSuccess = { jobsResult ->

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/eda/EdaAuditScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/eda/EdaAuditScreen.kt
@@ -41,6 +41,7 @@ import io.github.leogallego.ansiblejane.presentation.eda.EdaAuditViewModel
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import io.github.leogallego.ansiblejane.ui.components.ErrorMessage
 import io.github.leogallego.ansiblejane.ui.components.JobStatusBadge
+import io.github.leogallego.ansiblejane.ui.components.SearchBar
 import io.github.leogallego.ansiblejane.ui.components.SkeletonCard
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -95,6 +96,8 @@ fun EdaAuditScreen(
                 }
             }
             is EdaAuditUiState.Success -> {
+                val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
+
                 PullToRefreshBox(
                     isRefreshing = isRefreshing,
                     onRefresh = {
@@ -117,27 +120,35 @@ fun EdaAuditScreen(
                             .collect { if (it) viewModel.loadMore() }
                     }
 
-                    LazyColumn(
-                        state = listState,
-                        modifier = Modifier.fillMaxSize().testTag("list_eda_audit")
-                    ) {
-                        items(
-                            items = state.auditRules,
-                            key = { it.id }
-                        ) { auditRule ->
-                            EdaAuditItem(
-                                auditRule = auditRule,
-                                onClick = { selectedAuditRule = auditRule }
-                            )
-                        }
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        SearchBar(
+                            onSearch = { viewModel.search(it) },
+                            placeholder = "Search audit rules...",
+                            initialQuery = searchQuery,
+                        )
 
-                        if (state.isLoadingMore) {
-                            item {
-                                LinearProgressIndicator(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(16.dp)
+                        LazyColumn(
+                            state = listState,
+                            modifier = Modifier.fillMaxSize().weight(1f).testTag("list_eda_audit")
+                        ) {
+                            items(
+                                items = state.auditRules,
+                                key = { it.id }
+                            ) { auditRule ->
+                                EdaAuditItem(
+                                    auditRule = auditRule,
+                                    onClick = { selectedAuditRule = auditRule }
                                 )
+                            }
+
+                            if (state.isLoadingMore) {
+                                item {
+                                    LinearProgressIndicator(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(16.dp)
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/inventory/InventoriesScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/inventory/InventoriesScreen.kt
@@ -39,6 +39,7 @@ import io.github.leogallego.ansiblejane.model.Inventory
 import io.github.leogallego.ansiblejane.presentation.inventory.InventoriesUiState
 import io.github.leogallego.ansiblejane.presentation.inventory.InventoriesViewModel
 import io.github.leogallego.ansiblejane.ui.components.ErrorMessage
+import io.github.leogallego.ansiblejane.ui.components.SearchBar
 import io.github.leogallego.ansiblejane.ui.components.SkeletonCard
 import io.github.leogallego.ansiblejane.ui.components.pressScale
 import org.koin.compose.viewmodel.koinViewModel
@@ -94,6 +95,8 @@ fun InventoriesScreen(
                 }
             }
             is InventoriesUiState.Success -> {
+                val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
+
                 PullToRefreshBox(
                     isRefreshing = isRefreshing,
                     onRefresh = {
@@ -116,9 +119,16 @@ fun InventoriesScreen(
                             .collect { if (it) viewModel.loadMore() }
                     }
 
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        SearchBar(
+                            onSearch = { viewModel.search(it) },
+                            placeholder = "Search inventories...",
+                            initialQuery = searchQuery,
+                        )
+
                     LazyColumn(
                         state = listState,
-                        modifier = Modifier.fillMaxSize().testTag("list_inventories")
+                        modifier = Modifier.fillMaxSize().weight(1f).testTag("list_inventories")
                     ) {
                         items(
                             items = state.inventories,
@@ -139,6 +149,7 @@ fun InventoriesScreen(
                                 )
                             }
                         }
+                    }
                     }
                 }
             }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/jobs/RecentJobsScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/jobs/RecentJobsScreen.kt
@@ -41,6 +41,7 @@ import io.github.leogallego.ansiblejane.presentation.jobs.RecentJobsViewModel
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import io.github.leogallego.ansiblejane.ui.components.ErrorMessage
 import io.github.leogallego.ansiblejane.ui.components.JobStatusBadge
+import io.github.leogallego.ansiblejane.ui.components.SearchBar
 import io.github.leogallego.ansiblejane.ui.components.SkeletonCard
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -84,7 +85,15 @@ fun RecentJobsScreen(
                     },
                     modifier = Modifier.fillMaxSize()
                 ) {
+                    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
+
                     Column(modifier = Modifier.fillMaxSize()) {
+                        SearchBar(
+                            onSearch = { viewModel.search(it) },
+                            placeholder = "Search jobs...",
+                            initialQuery = searchQuery,
+                        )
+
                         StatusFilterChips(
                             activeFilters = state.activeFilters,
                             onToggleFilter = { viewModel.toggleFilter(it) }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
@@ -4,6 +4,7 @@ import io.github.leogallego.ansiblejane.assistant.data.IAssistantRepository
 import io.github.leogallego.ansiblejane.assistant.data.KnownProvider
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
+import io.github.leogallego.ansiblejane.assistant.engine.Role
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -27,6 +28,11 @@ class FakeAssistantRepository : IAssistantRepository {
     }
 
     override fun getHistory(): List<ChatMessage> = messages.toList()
+
+    override fun removeLastAssistantMessage() {
+        val index = messages.indexOfLast { it.role == Role.ASSISTANT }
+        if (index >= 0) messages.removeAt(index)
+    }
 
     override fun clearHistory() {
         messages.clear()

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeEdaAuditRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeEdaAuditRepository.kt
@@ -10,7 +10,7 @@ class FakeEdaAuditRepository : IEdaAuditRepository {
     var failureException: Exception = RuntimeException("Test error")
     var hasMore = false
 
-    override suspend fun getAuditRules(page: Int, pageSize: Int): Result<EdaAuditResult> {
+    override suspend fun getAuditRules(page: Int, pageSize: Int, search: String?): Result<EdaAuditResult> {
         if (shouldFail) return Result.failure(failureException)
         return Result.success(EdaAuditResult(auditRules, hasMore = hasMore, totalCount = auditRules.size))
     }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeJobRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeJobRepository.kt
@@ -34,7 +34,7 @@ class FakeJobRepository : IJobRepository {
         return Result.success(jobStdout)
     }
 
-    override suspend fun getRecentJobs(page: Int, pageSize: Int, statusFilters: Set<JobStatus>): Result<RecentJobsResult> {
+    override suspend fun getRecentJobs(page: Int, pageSize: Int, statusFilters: Set<JobStatus>, search: String?): Result<RecentJobsResult> {
         lastRequestedPage = page
         if (shouldFail) return Result.failure(failureException)
         return Result.success(RecentJobsResult(jobs, hasMore = hasMore, totalCount = jobs.size))


### PR DESCRIPTION
## Summary

- **#107** — Pill-shaped chat input field with inline stop/send trailing icons, replacing the separate OutlinedTextField + IconButton layout
- **#108** — Long-press context menu on chat messages: Copy (all messages), Regenerate (last assistant message only). Adds `stopGeneration()` and `regenerateLastMessage()` to AssistantViewModel
- **#23** — Search bar on Inventories screen (API already had `search` param, wired ViewModel + UI)
- **#24** — Search bar on Jobs screen (added `search` query param to API, repository, ViewModel, UI)
- **#25** — Search bar on EDA Audit screen (added `search` query param to EDA API, repository, ViewModel, UI)

All three search implementations reuse the existing `SearchBar` component with 300ms debounce and follow the server-side search pattern from Templates and Hosts screens.

Closes #107, closes #108, closes #23, closes #24, closes #25

## Test plan

- [ ] Chat: verify pill-shaped input renders with rounded corners
- [ ] Chat: type message, send via button and IME action
- [ ] Chat: during generation, stop button appears (red filled circle), tapping cancels
- [ ] Chat: long-press user message — Copy menu appears
- [ ] Chat: long-press last assistant message — Copy + Regenerate appear
- [ ] Chat: long-press non-last assistant message — only Copy appears
- [ ] Jobs: search bar filters jobs by name via server-side search
- [ ] Inventories: search bar filters inventories by name/description
- [ ] EDA Audit: search bar filters audit rules by rule name
- [ ] All search: clearing search restores full list with pagination

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>