### PR TITLE
Upgrade Koog 0.8.0 → 1.0.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,6 +108,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.koog.openai.client)
     implementation(libs.koog.google.client)
+    implementation(libs.koog.http.ktor)
     implementation(libs.ktor.client.cio)
     implementation(libs.ktor.client.okhttp)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,7 +109,6 @@ dependencies {
     implementation(libs.koog.openai.client)
     implementation(libs.koog.google.client)
     implementation(libs.koog.http.ktor)
-    implementation(libs.ktor.client.cio)
     implementation(libs.ktor.client.okhttp)
 
     implementation(libs.koin.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Koog 1.0.0 declares minSdk 35 but uses no Android 35+ APIs (pure Kotlin/HTTP) -->
+    <uses-sdk tools:overrideLibrary="ai.koog.prompt.executor.openai.client,ai.koog.prompt.executor.openai.client.base,ai.koog.prompt.executor.google.client,ai.koog.prompt.executor.clients,ai.koog.prompt.model,ai.koog.prompt.llm,ai.koog.prompt.structure,ai.koog.prompt.markdown,ai.koog.agents.tools,ai.koog.agents.utils,ai.koog.http.client.core,ai.koog.http.client.ktor,ai.koog.serialization.core,ai.koog.utils" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
@@ -1,7 +1,8 @@
 package io.github.leogallego.ansiblejane.assistant.engine
 
-import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.Prompt
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.MessagePart
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
@@ -107,11 +108,10 @@ class ChatEngine(
                 val completedCalls = pendingToolCalls.values
                     .filter { it.name != null }
                     .map { tc ->
-                        Message.Tool.Call(
+                        MessagePart.Tool.Call(
                             id = tc.id,
                             tool = tc.name!!,
-                            content = tc.args.toString().ifEmpty { "{}" },
-                            metaInfo = ResponseMetaInfo.Empty
+                            args = tc.args.toString().ifEmpty { "{}" }
                         )
                     }
 
@@ -121,7 +121,7 @@ class ChatEngine(
                     Log.d(TAG, "ITER $iterations: ${completedCalls.size} tool calls: " +
                         "${completedCalls.map { it.tool }}")
                     val currentSignature = completedCalls.map {
-                        "${it.tool}:${it.content.hashCode()}"
+                        "${it.tool}:${it.args.hashCode()}"
                     }
                     toolCallHistory.add(currentSignature)
 
@@ -138,9 +138,9 @@ class ChatEngine(
                         JsonArray.serializer(),
                         JsonArray(completedCalls.map { tc ->
                             JsonObject(mapOf(
-                                "id" to kotlinx.serialization.json.JsonPrimitive(tc.id),
-                                "name" to kotlinx.serialization.json.JsonPrimitive(tc.tool),
-                                "arguments" to kotlinx.serialization.json.JsonPrimitive(tc.content)
+                                "id" to JsonPrimitive(tc.id),
+                                "name" to JsonPrimitive(tc.tool),
+                                "arguments" to JsonPrimitive(tc.args)
                             ))
                         })
                     )
@@ -153,7 +153,7 @@ class ChatEngine(
                     val toolSummaries = mutableListOf<String>()
                     for (toolCall in completedCalls) {
                         val argsJson = try {
-                            json.parseToJsonElement(toolCall.content).jsonObject
+                            json.parseToJsonElement(toolCall.args).jsonObject
                         } catch (_: Exception) {
                             JsonObject(emptyMap())
                         }
@@ -227,7 +227,16 @@ class ChatEngine(
                 ))
                 Role.ASSISTANT -> {
                     if (msg.toolCallsJson != null) {
-                        parseToolCalls(msg.toolCallsJson)
+                        val toolCalls = parseToolCalls(msg.toolCallsJson)
+                        val parts = mutableListOf<MessagePart.ResponsePart>()
+                        if (msg.content.isNotEmpty()) {
+                            parts.add(MessagePart.Text(msg.content))
+                        }
+                        parts.addAll(toolCalls)
+                        listOf(Message.Assistant(
+                            parts = parts,
+                            metaInfo = ResponseMetaInfo.Empty
+                        ))
                     } else {
                         listOf(Message.Assistant(
                             content = msg.content,
@@ -235,10 +244,12 @@ class ChatEngine(
                         ))
                     }
                 }
-                Role.TOOL -> listOf(Message.Tool.Result(
-                    id = msg.toolCallId,
-                    tool = msg.toolName ?: msg.toolCallId ?: "",
-                    content = msg.content,
+                Role.TOOL -> listOf(Message.User(
+                    part = MessagePart.Tool.Result(
+                        id = msg.toolCallId,
+                        tool = msg.toolName ?: msg.toolCallId ?: "",
+                        output = msg.content
+                    ),
                     metaInfo = RequestMetaInfo.Empty
                 ))
             }
@@ -246,17 +257,16 @@ class ChatEngine(
         return Prompt(messages = koogMessages, id = "chat")
     }
 
-    private fun parseToolCalls(toolCallsJson: String): List<Message.Tool.Call> {
+    private fun parseToolCalls(toolCallsJson: String): List<MessagePart.Tool.Call> {
         return try {
             val element = json.parseToJsonElement(toolCallsJson)
             if (element is JsonArray) {
                 element.map { el ->
                     val obj = el.jsonObject
-                    Message.Tool.Call(
+                    MessagePart.Tool.Call(
                         id = obj["id"]?.jsonPrimitive?.content,
                         tool = obj["name"]?.jsonPrimitive?.content ?: "",
-                        content = obj["arguments"]?.jsonPrimitive?.content ?: "{}",
-                        metaInfo = ResponseMetaInfo.Empty
+                        args = obj["arguments"]?.jsonPrimitive?.content ?: "{}"
                     )
                 }
             } else emptyList()

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
@@ -1,6 +1,6 @@
 package io.github.leogallego.ansiblejane.assistant.engine
 
-import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.MessagePart
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 import io.github.leogallego.ansiblejane.assistant.tools.ErrorType
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
@@ -22,7 +22,7 @@ class ToolExecutor(
 ) {
     private val resultCache = mutableMapOf<String, Pair<Long, ToolResult>>()
 
-    suspend fun execute(toolCall: Message.Tool.Call): ToolResult {
+    suspend fun execute(toolCall: MessagePart.Tool.Call): ToolResult {
         val tool = tools.find { it.spec.name == toolCall.tool }
             ?: run {
                 Log.w(TAG, "EXEC: tool '${toolCall.tool}' not found in ${tools.size} registered tools")
@@ -33,7 +33,7 @@ class ToolExecutor(
                 )
             }
 
-        val cacheKey = "${toolCall.tool}:${toolCall.content.hashCode()}"
+        val cacheKey = "${toolCall.tool}:${toolCall.args.hashCode()}"
         val cached = resultCache[cacheKey]
         if (cached != null && System.currentTimeMillis() - cached.first < CACHE_TTL_MS) {
             Log.d(TAG, "EXEC: cache hit for ${toolCall.tool}")
@@ -41,13 +41,13 @@ class ToolExecutor(
         }
 
         val argsJson = try {
-            val parsed = json.parseToJsonElement(toolCall.content)
+            val parsed = json.parseToJsonElement(toolCall.args)
             if (parsed is JsonObject) parsed else JsonObject(emptyMap())
         } catch (_: Exception) {
             JsonObject(emptyMap())
         }
 
-        Log.d(TAG, "EXEC: ${toolCall.tool}(${toolCall.content.take(200)})")
+        Log.d(TAG, "EXEC: ${toolCall.tool}(${toolCall.args.take(200)})")
         val startMs = System.currentTimeMillis()
         val result = try {
             withTimeout(30_000L) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/llm/GeminiLlmProvider.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/llm/GeminiLlmProvider.kt
@@ -2,13 +2,14 @@ package io.github.leogallego.ansiblejane.assistant.llm
 
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.Prompt
+import ai.koog.http.client.KoogHttpClientException
+import ai.koog.http.client.ktor.KtorKoogHttpClient
+import ai.koog.prompt.executor.clients.LLMClientException
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.llm.LLMProvider as KoogLLMProvider
 import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.http.client.KoogHttpClientException
-import ai.koog.prompt.executor.clients.LLMClientException
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.flow.Flow
@@ -21,7 +22,10 @@ class GeminiLlmProvider(
     modelId: String
 ) : LlmProvider {
 
-    private val client = GoogleLLMClient(apiKey = apiKey)
+    private val client = GoogleLLMClient(
+        apiKey = apiKey,
+        httpClientFactory = KtorKoogHttpClient.Factory()
+    )
 
     private val model = LLModel(
         provider = KoogLLMProvider.Google,

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/llm/GeminiLlmProvider.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/llm/GeminiLlmProvider.kt
@@ -1,7 +1,7 @@
 package io.github.leogallego.ansiblejane.assistant.llm
 
 import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.Prompt
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLModel

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/llm/KoogLlmProvider.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/llm/KoogLlmProvider.kt
@@ -1,20 +1,19 @@
 package io.github.leogallego.ansiblejane.assistant.llm
 
 import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.Prompt
+import ai.koog.http.client.KoogHttpClientException
+import ai.koog.http.client.ktor.KtorKoogHttpClient
+import ai.koog.prompt.executor.clients.LLMClientException
 import ai.koog.prompt.executor.clients.openai.OpenAIClientSettings
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.llm.LLMProvider as KoogLLMProvider
-
 import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.http.client.KoogHttpClientException
-import ai.koog.prompt.executor.clients.LLMClientException
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.network.CertTrustManager
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.ServerResponseException
@@ -40,23 +39,23 @@ class KoogLlmProvider(
             baseUrl = baseUrl,
             chatCompletionsPath = chatPath
         )
-        val httpClient = if (trustSelfSigned) {
+        val factory = if (trustSelfSigned) {
             val tm = CertTrustManager.createTrustAllManager()
-            HttpClient(OkHttp) {
+            KtorKoogHttpClient.Factory(baseClient = HttpClient(OkHttp) {
                 engine {
                     config {
                         sslSocketFactory(CertTrustManager.createSslSocketFactory(tm), tm)
                         hostnameVerifier { _, _ -> true }
                     }
                 }
-            }
+            })
         } else {
-            HttpClient(CIO)
+            KtorKoogHttpClient.Factory()
         }
         OpenAILLMClient(
             apiKey = config.apiKey ?: "",
             settings = settings,
-            baseClient = httpClient
+            httpClientFactory = factory
         )
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/llm/LlmProvider.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/llm/LlmProvider.kt
@@ -1,7 +1,7 @@
 package io.github.leogallego.ansiblejane.assistant.llm
 
 import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.Prompt
 import ai.koog.prompt.streaming.StreamFrame
 import kotlinx.coroutines.flow.Flow
 

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineTest.kt
@@ -1,7 +1,7 @@
 package io.github.leogallego.ansiblejane.assistant.engine
 
 import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.Prompt
 import ai.koog.prompt.streaming.StreamFrame
 import app.cash.turbine.test
 import io.github.leogallego.ansiblejane.assistant.llm.LlmProvider

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutorTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutorTest.kt
@@ -1,7 +1,6 @@
 package io.github.leogallego.ansiblejane.assistant.engine
 
-import ai.koog.prompt.message.Message
-import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.message.MessagePart
 import io.github.leogallego.ansiblejane.assistant.tools.ErrorType
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
@@ -20,8 +19,8 @@ import org.junit.Test
 
 class ToolExecutorTest {
 
-    private fun toolCall(name: String, args: String = "{}"): Message.Tool.Call =
-        Message.Tool.Call(id = "1", tool = name, content = args, metaInfo = ResponseMetaInfo.Empty)
+    private fun toolCall(name: String, args: String = "{}"): MessagePart.Tool.Call =
+        MessagePart.Tool.Call(id = "1", tool = name, args = args)
 
     @Test
     fun `execute dispatches to correct tool by name`() = runTest {

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/llm/KoogLlmProviderTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/llm/KoogLlmProviderTest.kt
@@ -115,7 +115,7 @@ class KoogLlmProviderTest {
         server.enqueue(
             MockResponse()
                 .setResponseCode(401)
-                .setBody("""{"error":{"message":"Unauthorized"}}""")
+                .setChunkedBody("""{"error":{"message":"Unauthorized"}}""", 1024)
         )
 
         try {
@@ -131,7 +131,7 @@ class KoogLlmProviderTest {
         server.enqueue(
             MockResponse()
                 .setResponseCode(429)
-                .setBody("""{"error":{"message":"Rate limit exceeded"}}""")
+                .setChunkedBody("""{"error":{"message":"Rate limit exceeded"}}""", 1024)
         )
 
         try {
@@ -147,7 +147,7 @@ class KoogLlmProviderTest {
         server.enqueue(
             MockResponse()
                 .setResponseCode(500)
-                .setBody("""{"error":{"message":"Internal Server Error"}}""")
+                .setChunkedBody("""{"error":{"message":"Internal Server Error"}}""", 1024)
         )
 
         try {

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/llm/KoogLlmProviderTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/llm/KoogLlmProviderTest.kt
@@ -1,6 +1,6 @@
 package io.github.leogallego.ansiblejane.assistant.llm
 
-import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.Prompt
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.streaming.StreamFrame

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,7 +65,6 @@ screenshot-validation-api = { group = "com.android.tools.screenshot", name = "sc
 koog-openai-client = { group = "ai.koog", name = "prompt-executor-openai-client", version.ref = "koog" }
 koog-google-client = { group = "ai.koog", name = "prompt-executor-google-client", version.ref = "koog-google" }
 koog-http-ktor = { group = "ai.koog", name = "http-client-ktor", version.ref = "koog" }
-ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
 ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
 markdown-renderer = { group = "com.mikepenz", name = "multiplatform-markdown-renderer", version.ref = "markdownRenderer" }
 markdown-renderer-m3 = { group = "com.mikepenz", name = "multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,8 @@ coroutines = "1.11.0"
 core-ktx = "1.18.0"
 markdownRenderer = "0.41.0"
 ktor = "3.2.2"
-koog = "0.8.0"
+koog = "1.0.0"
+koog-google = "1.0.0-beta"
 robolectric = "4.14.1"
 androidx-test-runner = "1.6.2"
 androidx-test-rules = "1.6.1"
@@ -62,7 +63,8 @@ androidx-test-runner = { group = "androidx.test", name = "runner", version.ref =
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidx-test-rules" }
 screenshot-validation-api = { group = "com.android.tools.screenshot", name = "screenshot-validation-api", version.ref = "screenshot" }
 koog-openai-client = { group = "ai.koog", name = "prompt-executor-openai-client", version.ref = "koog" }
-koog-google-client = { group = "ai.koog", name = "prompt-executor-google-client", version.ref = "koog" }
+koog-google-client = { group = "ai.koog", name = "prompt-executor-google-client", version.ref = "koog-google" }
+koog-http-ktor = { group = "ai.koog", name = "http-client-ktor", version.ref = "koog" }
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
 ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
 markdown-renderer = { group = "com.mikepenz", name = "multiplatform-markdown-renderer", version.ref = "markdownRenderer" }


### PR DESCRIPTION
## Summary
- Upgrade Koog LLM framework from 0.8.0 to 1.0.0 (first stable release)
- Migrate all 16 Koog imports across 11 files to new API surface
- `Prompt` class moved from `ai.koog.prompt.dsl` to `ai.koog.prompt`
- `Message.Tool.Call/Result` replaced by `MessagePart.Tool.Call/Result` with renamed fields
- `OpenAILLMClient` constructor updated: `baseClient` → `httpClientFactory` via `KtorKoogHttpClient.Factory`
- Google client pinned to `1.0.0-beta` (separate version track from OpenAI client)
- Added explicit `http-client-ktor` dependency (no longer transitive in 1.0.0)
- Override `minSdk` for Koog libraries (they declare 35 but use no Android 35+ APIs)

Closes #142

## Test plan
- [x] `compileDebugKotlin` — builds clean
- [x] `testDebugUnitTest` — all 339 tests pass
- [ ] Deploy to device — verify LLM providers work (OpenAI-compat, Gemini)
- [ ] Test self-signed TLS path (KtorKoogHttpClient.Factory with custom OkHttp engine)

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>