### PR TITLE
Fix workflow node cards review findings

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowTemplateDetailViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowTemplateDetailViewModel.kt
@@ -46,7 +46,10 @@ class WorkflowTemplateDetailViewModel(
     }
 
     private fun loadNodes() {
-        if (templateId <= 0) return
+        if (templateId <= 0) {
+            _uiState.value = WorkflowTemplateDetailUiState.Error(AppError.Unknown("Invalid workflow template"))
+            return
+        }
         _uiState.value = WorkflowTemplateDetailUiState.Loading
         viewModelScope.launch {
             workflowRepository.getWorkflowTemplateNodes(templateId)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/workflows/WorkflowJobStatusScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/workflows/WorkflowJobStatusScreen.kt
@@ -189,15 +189,10 @@ private fun WorkflowJobDetailContent(
                 items = orderedNodes,
                 key = { _, item -> item.node.id }
             ) { index, orderedNode ->
-                val node = orderedNode.node
-                val jobId = node.summaryFields.job?.id
-                val hasOutgoing = node.successNodes.isNotEmpty() ||
-                    node.failureNodes.isNotEmpty() ||
-                    node.alwaysNodes.isNotEmpty()
+                val jobId = orderedNode.node.summaryFields.job?.id
 
                 WorkflowNodeCard(
                     orderedNode = orderedNode,
-                    hasOutgoingEdge = hasOutgoing,
                     isExpanded = jobId != null && jobId == expandedNodeId,
                     stdoutState = jobId?.let { nodeStdout[it] },
                     onToggleExpand = jobId?.let { id -> { onToggleNode(id) } }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/workflows/WorkflowNodeCard.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/workflows/WorkflowNodeCard.kt
@@ -34,7 +34,6 @@ import io.github.leogallego.ansiblejane.ui.components.JobStatusBadge
 @Composable
 fun WorkflowNodeCard(
     orderedNode: OrderedNode,
-    hasOutgoingEdge: Boolean,
     isExpanded: Boolean,
     stdoutState: NodeStdoutState?,
     onToggleExpand: (() -> Unit)?,

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/workflows/WorkflowNodeOrder.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/workflows/WorkflowNodeOrder.kt
@@ -113,17 +113,33 @@ private data class GraphNode(
     val alwaysNodes: List<Int>
 )
 
+private val EDGE_PRIORITY = mapOf(
+    ConnectorType.SUCCESS to 0,
+    ConnectorType.ALWAYS to 1,
+    ConnectorType.FAILURE to 2
+)
+
 private fun buildEdges(items: List<GraphNode>): Pair<Set<Int>, Map<Int, ConnectorType>> {
     val childIds = mutableSetOf<Int>()
     val incomingEdge = mutableMapOf<Int, ConnectorType>()
+
+    fun setEdge(childId: Int, type: ConnectorType) {
+        childIds += childId
+        val existing = incomingEdge[childId]
+        if (existing == null || EDGE_PRIORITY.getValue(type) > EDGE_PRIORITY.getValue(existing)) {
+            incomingEdge[childId] = type
+        }
+    }
+
     for (item in items) {
-        for (childId in item.successNodes) { childIds += childId; incomingEdge[childId] = ConnectorType.SUCCESS }
-        for (childId in item.failureNodes) { childIds += childId; incomingEdge[childId] = ConnectorType.FAILURE }
-        for (childId in item.alwaysNodes) { childIds += childId; incomingEdge[childId] = ConnectorType.ALWAYS }
+        for (childId in item.successNodes) setEdge(childId, ConnectorType.SUCCESS)
+        for (childId in item.alwaysNodes) setEdge(childId, ConnectorType.ALWAYS)
+        for (childId in item.failureNodes) setEdge(childId, ConnectorType.FAILURE)
     }
     return childIds to incomingEdge
 }
 
+// AAP prevents cyclic workflows; cycles here produce undefined ordering but no crash.
 private fun topoSort(items: List<GraphNode>): List<Int> {
     val byId = items.associateBy { it.id }
     val (childIds, _) = buildEdges(items)


### PR DESCRIPTION
## Summary

Follow-up fixes from code review of #149.

- Fix multiple incoming edges: when a node has parents with different edge types, show the most critical one (FAILURE > ALWAYS > SUCCESS) instead of whichever was processed last
- Show error state instead of infinite loading spinner when navigating to workflow detail with an invalid template ID
- Remove unused `hasOutgoingEdge` parameter from `WorkflowNodeCard`
- Document that cycles in workflow graphs produce undefined ordering (AAP prevents creating them)

## Test plan

- [ ] Verify workflow nodes with multiple parents show the highest-priority edge color
- [ ] Navigate to workflow detail with invalid ID → should show error, not spinner

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>