### PR TITLE
Bump version to 1.5.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "io.github.leogallego.ansiblejane"
         minSdk = 31
         targetSdk = 36
-        versionCode = 26052302
-        versionName = "1.4.0"
+        versionCode = 26052400
+        versionName = "1.5.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Summary
- Bumps versionName from 1.4.0 to 1.5.0
- Bumps versionCode from 26052302 to 26052400

### Notable changes since 1.4.0
- Dashboard home screen with job stats, EDA, resources, activity chart, schedules, instance info (#147)
- Chat UI polish: pill-shaped input, long-press context menu, stop/regenerate (#144)
- Search on Jobs, Inventories, EDA Audit screens (#144)
- Workflow node card visualization (#9)
- Koog 0.8.0 → 1.0.0 upgrade (#146)

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>