### PR TITLE
Fix AuthScreen theming, contrast, and edge-to-edge handling

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/auth/AuthScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/auth/AuthScreen.kt
@@ -4,8 +4,11 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.Visibility
@@ -21,7 +24,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -68,211 +70,223 @@ fun AuthScreen(
         }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        Box(
+    val topBarTitle = when {
+        isReAuth -> "Re-authenticate"
+        isAddInstance -> "Add Instance"
+        else -> null
+    }
+
+    Scaffold(
+        topBar = {
+            if (onCancel != null && topBarTitle != null) {
+                @OptIn(ExperimentalMaterial3Api::class)
+                TopAppBar(
+                    title = { Text(topBarTitle) },
+                    navigationIcon = {
+                        IconButton(
+                            onClick = onCancel,
+                            modifier = Modifier.testTag("button_back")
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Back"
+                            )
+                        }
+                    }
+                )
+            }
+        }
+    ) { padding ->
+        Column(
             modifier = Modifier
-                .size(96.dp)
-                .clip(RoundedCornerShape(20.dp))
-                .background(Color(0xFFEE0000)),
-            contentAlignment = Alignment.Center
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = if (onCancel == null) Arrangement.Center else Arrangement.Top
         ) {
-            Icon(
-                painter = painterResource(id = R.drawable.ic_launcher_foreground),
-                contentDescription = "Ansible Jane",
-                modifier = Modifier.size(72.dp),
-                tint = Color.White
-            )
-        }
+            Box(
+                modifier = Modifier
+                    .size(96.dp)
+                    .clip(RoundedCornerShape(20.dp))
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_launcher_foreground),
+                    contentDescription = "Ansible Jane",
+                    modifier = Modifier.size(72.dp),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
 
-        Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(12.dp))
 
-        Text(
-            text = if (isReAuth) "Re-authenticate" else "Ansible Jane",
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.primary
-        )
-
-        if (isReAuth) {
-            Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = "Token expired for ${preFilledAlias ?: preFilledUrl ?: "this instance"}. Please enter a new API token.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                text = if (isReAuth) "Re-authenticate" else "Ansible Jane",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.primary
             )
-        }
 
-        Spacer(modifier = Modifier.height(32.dp))
+            if (isReAuth) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Token expired for ${preFilledAlias ?: preFilledUrl ?: "this instance"}. Please enter a new API token.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
 
-        val textFieldColors = OutlinedTextFieldDefaults.colors(
-            focusedTextColor = MaterialTheme.colorScheme.onSurface,
-            unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
-            focusedLabelColor = MaterialTheme.colorScheme.primary,
-            unfocusedLabelColor = MaterialTheme.colorScheme.onSurface,
-            focusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            unfocusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+            Spacer(modifier = Modifier.height(32.dp))
 
-        OutlinedTextField(
-            value = baseUrl,
-            onValueChange = { baseUrl = it },
-            label = { Text("AAP Base URL") },
-            placeholder = { Text("https://aap.example.com") },
-            singleLine = true,
-            enabled = !isReAuth,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-            trailingIcon = {
-                if (baseUrl.isNotEmpty() && !isReAuth) {
-                    IconButton(onClick = { baseUrl = "" }) {
-                        Icon(Icons.Default.Clear, contentDescription = "Clear")
-                    }
-                }
-            },
-            colors = textFieldColors,
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag("field_url")
-                .semantics { contentType = ContentType.Username }
-        )
+            val textFieldColors = OutlinedTextFieldDefaults.colors(
+                focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                focusedLabelColor = MaterialTheme.colorScheme.primary,
+                unfocusedLabelColor = MaterialTheme.colorScheme.onSurface,
+                focusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                unfocusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant
+            )
 
-        Spacer(modifier = Modifier.height(16.dp))
-
-        OutlinedTextField(
-            value = alias,
-            onValueChange = { alias = it },
-            label = { Text("Alias (optional)") },
-            placeholder = { Text("e.g., Production") },
-            singleLine = true,
-            enabled = !isReAuth,
-            trailingIcon = {
-                if (alias.isNotEmpty() && !isReAuth) {
-                    IconButton(onClick = { alias = "" }) {
-                        Icon(Icons.Default.Clear, contentDescription = "Clear")
-                    }
-                }
-            },
-            colors = textFieldColors,
-            modifier = Modifier.fillMaxWidth().testTag("field_alias")
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        OutlinedTextField(
-            value = token,
-            onValueChange = { token = it },
-            label = { Text("AAP Personal API Token") },
-            singleLine = true,
-            visualTransformation = if (passwordVisible) VisualTransformation.None
-                else PasswordVisualTransformation(),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-            trailingIcon = {
-                Row {
-                    if (token.isNotEmpty()) {
-                        IconButton(onClick = { token = "" }) {
+            OutlinedTextField(
+                value = baseUrl,
+                onValueChange = { baseUrl = it },
+                label = { Text("AAP Base URL") },
+                placeholder = { Text("https://aap.example.com") },
+                singleLine = true,
+                enabled = !isReAuth,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                trailingIcon = {
+                    if (baseUrl.isNotEmpty() && !isReAuth) {
+                        IconButton(onClick = { baseUrl = "" }) {
                             Icon(Icons.Default.Clear, contentDescription = "Clear")
                         }
                     }
-                    IconButton(onClick = { passwordVisible = !passwordVisible }) {
-                        Icon(
-                            imageVector = if (passwordVisible) Icons.Default.Visibility
-                                else Icons.Default.VisibilityOff,
-                            contentDescription = if (passwordVisible) "Hide token" else "Show token"
-                        )
-                    }
-                }
-            },
-            colors = textFieldColors,
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag("field_token")
-                .semantics { contentType = ContentType.Password }
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Text(
-                text = "Accept self-signed certificate",
-                style = MaterialTheme.typography.bodyMedium
+                },
+                colors = textFieldColors,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("field_url")
+                    .semantics { contentType = ContentType.Username }
             )
-            Switch(
-                checked = trustSelfSigned,
-                onCheckedChange = { trustSelfSigned = it },
-                modifier = Modifier.testTag("switch_self_signed")
-            )
-        }
 
-        Spacer(modifier = Modifier.height(24.dp))
-
-        val onConnect = {
-            viewModel.connect(
-                baseUrl = baseUrl,
-                token = token,
-                trustSelfSigned = trustSelfSigned,
-                alias = alias.ifBlank { null },
-                existingInstanceId = reAuthInstanceId
-            )
-        }
-
-        when (val state = uiState) {
-            is AuthUiState.Loading -> {
-                CircularProgressIndicator()
-            }
-            is AuthUiState.Error -> {
-                ErrorMessage(
-                    error = state.error,
-                    onRetry = null
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                Button(
-                    onClick = { onConnect() },
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = baseUrl.isNotBlank() && token.isNotBlank()
-                ) {
-                    Text(if (isReAuth) "Re-authenticate" else "Retry")
-                }
-                if (onCancel != null) {
-                    Spacer(modifier = Modifier.height(8.dp))
-                    OutlinedButton(
-                        onClick = onCancel,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text("Cancel")
-                    }
-                }
-            }
-            else -> {
-                Button(
-                    onClick = { onConnect() },
-                    modifier = Modifier.fillMaxWidth().testTag("button_connect"),
-                    enabled = baseUrl.isNotBlank() && token.isNotBlank()
-                ) {
-                    Text(if (isReAuth) "Re-authenticate" else "Connect")
-                }
-                if (onCancel != null) {
-                    Spacer(modifier = Modifier.height(8.dp))
-                    OutlinedButton(
-                        onClick = onCancel,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text("Cancel")
-                    }
-                }
-            }
-        }
-
-        if (!isReAuth && !isAddInstance) {
             Spacer(modifier = Modifier.height(16.dp))
-            ImportFromBackupButton(onNavigateToDashboard = onNavigateToDashboard)
+
+            OutlinedTextField(
+                value = alias,
+                onValueChange = { alias = it },
+                label = { Text("Alias (optional)") },
+                placeholder = { Text("e.g., Production") },
+                singleLine = true,
+                enabled = !isReAuth,
+                trailingIcon = {
+                    if (alias.isNotEmpty() && !isReAuth) {
+                        IconButton(onClick = { alias = "" }) {
+                            Icon(Icons.Default.Clear, contentDescription = "Clear")
+                        }
+                    }
+                },
+                colors = textFieldColors,
+                modifier = Modifier.fillMaxWidth().testTag("field_alias")
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = token,
+                onValueChange = { token = it },
+                label = { Text("AAP Personal API Token") },
+                singleLine = true,
+                visualTransformation = if (passwordVisible) VisualTransformation.None
+                    else PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                trailingIcon = {
+                    Row {
+                        if (token.isNotEmpty()) {
+                            IconButton(onClick = { token = "" }) {
+                                Icon(Icons.Default.Clear, contentDescription = "Clear")
+                            }
+                        }
+                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Icon(
+                                imageVector = if (passwordVisible) Icons.Default.Visibility
+                                    else Icons.Default.VisibilityOff,
+                                contentDescription = if (passwordVisible) "Hide token" else "Show token"
+                            )
+                        }
+                    }
+                },
+                colors = textFieldColors,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("field_token")
+                    .semantics { contentType = ContentType.Password }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Accept self-signed certificate",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Switch(
+                    checked = trustSelfSigned,
+                    onCheckedChange = { trustSelfSigned = it },
+                    modifier = Modifier.testTag("switch_self_signed")
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            val onConnect = {
+                viewModel.connect(
+                    baseUrl = baseUrl,
+                    token = token,
+                    trustSelfSigned = trustSelfSigned,
+                    alias = alias.ifBlank { null },
+                    existingInstanceId = reAuthInstanceId
+                )
+            }
+
+            when (val state = uiState) {
+                is AuthUiState.Loading -> {
+                    CircularProgressIndicator()
+                }
+                is AuthUiState.Error -> {
+                    ErrorMessage(
+                        error = state.error,
+                        onRetry = null
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Button(
+                        onClick = { onConnect() },
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = baseUrl.isNotBlank() && token.isNotBlank()
+                    ) {
+                        Text(if (isReAuth) "Re-authenticate" else "Retry")
+                    }
+                }
+                else -> {
+                    Button(
+                        onClick = { onConnect() },
+                        modifier = Modifier.fillMaxWidth().testTag("button_connect"),
+                        enabled = baseUrl.isNotBlank() && token.isNotBlank()
+                    ) {
+                        Text(if (isReAuth) "Re-authenticate" else "Connect")
+                    }
+                }
+            }
+
+            if (!isReAuth && !isAddInstance) {
+                Spacer(modifier = Modifier.height(16.dp))
+                ImportFromBackupButton(onNavigateToDashboard = onNavigateToDashboard)
+            }
         }
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/auth/AuthScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/auth/AuthScreen.kt
@@ -101,6 +101,8 @@ fun AuthScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
+                .consumeWindowInsets(padding)
+                .imePadding()
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 24.dp, vertical = 24.dp),
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/ui/auth/AuthScreenTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/ui/auth/AuthScreenTest.kt
@@ -135,10 +135,11 @@ class AuthScreenTest {
     }
 
     @Test
-    fun `cancel button visible in add-instance mode`() {
+    fun `back button and title visible in add-instance mode`() {
         setUpScreen(onCancel = {}, isAddInstance = true)
 
-        composeTestRule.onNodeWithText("Cancel").fetchSemanticsNode()
+        composeTestRule.onNodeWithTag("button_back").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Add Instance").assertIsDisplayed()
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Wrap `AuthScreen` in `Scaffold` with optional `TopAppBar` — back arrow for add-instance/re-auth modes, no TopAppBar for first-login (keeps visual weight on centered form)
- Replace hardcoded `Color(0xFFEE0000)` logo background with `MaterialTheme.colorScheme.primaryContainer` and `Color.White` icon tint with `onPrimaryContainer` — adapts to dark theme and dynamic color
- Add `verticalScroll` so the form works on small screens and landscape orientation
- Apply Scaffold padding for proper system bar inset handling with `enableEdgeToEdge()`
- Remove bottom `OutlinedButton("Cancel")` — replaced by standard TopAppBar back arrow matching SettingsScreen pattern

Closes #165

## Test plan

- [ ] Fresh install → auth screen renders with themed background, proper contrast in both light and dark modes
- [ ] Dark theme → logo uses dark-adapted colors, no hardcoded reds/whites
- [ ] Settings → Add Instance → TopAppBar shows "Add Instance" with back arrow, no bottom Cancel button
- [ ] Re-auth flow → TopAppBar shows "Re-authenticate" with back arrow
- [ ] Rotate to landscape → form scrolls, no content clipped under system bars
- [ ] Unit tests pass (`./gradlew testDebugUnitTest`)

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>