### PR TITLE
Add workflow approval notifications — approve/deny from your phone

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,6 +117,7 @@ dependencies {
     implementation(libs.koin.compose.viewmodel)
 
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.work.runtime)
     implementation(libs.tink.android)
     implementation(libs.kotlinx.collections.immutable)
     implementation(libs.kotlinx.coroutines.android)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".AnsibleJaneApp"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,11 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="ansiblejane" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.AnsibleJane">
             <intent-filter>

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
@@ -3,9 +3,14 @@ package io.github.leogallego.ansiblejane
 import android.app.Application
 import io.github.leogallego.ansiblejane.assistant.assistantModule
 import io.github.leogallego.ansiblejane.assistant.localToolsModule
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
 import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
 import io.github.leogallego.ansiblejane.data.dataModule
 import io.github.leogallego.ansiblejane.network.networkModule
+import io.github.leogallego.ansiblejane.notification.ApprovalNotificationManager
+import io.github.leogallego.ansiblejane.notification.ApprovalPollingWorker
 import io.github.leogallego.ansiblejane.presentation.presentationModule
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import kotlinx.coroutines.CoroutineScope
@@ -18,6 +23,7 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 import java.time.ZoneId
+import java.util.concurrent.TimeUnit
 
 class AnsibleJaneApp : Application() {
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -29,6 +35,14 @@ class AnsibleJaneApp : Application() {
             androidContext(this@AnsibleJaneApp)
             modules(networkModule, dataModule, presentationModule, localToolsModule, assistantModule)
         }
+
+        ApprovalNotificationManager.createChannel(this)
+
+        WorkManager.getInstance(this).enqueueUniquePeriodicWork(
+            ApprovalPollingWorker.WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            PeriodicWorkRequestBuilder<ApprovalPollingWorker>(15, TimeUnit.MINUTES).build()
+        )
 
         val userPreferences: IUserPreferencesRepository by inject()
         appScope.launch {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/MainActivity.kt
@@ -1,5 +1,6 @@
 package io.github.leogallego.ansiblejane
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -10,6 +11,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
 import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
 import io.github.leogallego.ansiblejane.navigation.AppNavigation
 import io.github.leogallego.ansiblejane.ui.components.ThemeMode
@@ -18,11 +21,14 @@ import org.koin.android.ext.android.inject
 
 class MainActivity : ComponentActivity() {
     private val userPreferences: IUserPreferencesRepository by inject()
+    private var navController: NavHostController? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
+            val nc = rememberNavController()
+            navController = nc
             val themeMode by userPreferences.themeMode.collectAsStateWithLifecycle(ThemeMode.SYSTEM)
             val darkTheme = when (themeMode) {
                 ThemeMode.SYSTEM -> isSystemInDarkTheme()
@@ -30,8 +36,16 @@ class MainActivity : ComponentActivity() {
                 ThemeMode.DARK -> true
             }
             AnsibleJaneTheme(darkTheme = darkTheme) {
-                AppNavigation(modifier = Modifier.semantics { testTagsAsResourceId = true })
+                AppNavigation(
+                    navController = nc,
+                    modifier = Modifier.semantics { testTagsAsResourceId = true }
+                )
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        navController?.handleDeepLink(intent)
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/LocalToolsModule.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/LocalToolsModule.kt
@@ -19,6 +19,9 @@ val localToolsModule = module {
     single { ToggleScheduleLocalTool(get()) } bind LocalTool::class
     single { ListWorkflowNodesLocalTool(get()) } bind LocalTool::class
     single { GetSurveySpecLocalTool(get()) } bind LocalTool::class
+    single { ListPendingApprovalsLocalTool(get()) } bind LocalTool::class
+    single { ApproveWorkflowLocalTool(get()) } bind LocalTool::class
+    single { DenyWorkflowLocalTool(get()) } bind LocalTool::class
 
     // Inventory
     single { ListInventoriesLocalTool(get()) } bind LocalTool::class

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
@@ -12,6 +12,7 @@ import io.github.leogallego.ansiblejane.assistant.llm.LlmRateLimitException
 import io.github.leogallego.ansiblejane.assistant.llm.LlmServerException
 import io.github.leogallego.ansiblejane.assistant.llm.LlmTimeoutException
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
 import io.github.leogallego.ansiblejane.assistant.tools.toToolDescriptor
 import kotlinx.coroutines.CancellationException
@@ -31,6 +32,11 @@ sealed interface ChatEvent {
     data class TextDelta(val text: String) : ChatEvent
     data class ToolExecuting(val toolName: String, val args: JsonObject) : ChatEvent
     data class ToolResult(val toolName: String, val result: io.github.leogallego.ansiblejane.assistant.tools.ToolResult) : ChatEvent
+    data class ConfirmationRequired(
+        val toolName: String,
+        val args: JsonObject,
+        val description: String
+    ) : ChatEvent
     data class AssistantMessage(val fullText: String, val toolCallCount: Int) : ChatEvent
     data class Error(val message: String, val cause: Throwable? = null) : ChatEvent
 }
@@ -47,7 +53,8 @@ class ChatEngine(
         history: List<ChatMessage>,
         tools: List<ToolSpec>,
         maxTokens: Int? = null,
-        contextChars: Int = DEFAULT_CONTEXT_CHARS
+        contextChars: Int = DEFAULT_CONTEXT_CHARS,
+        onConfirmationRequired: (suspend (toolName: String, description: String, args: JsonObject) -> Boolean)? = null
     ): Flow<ChatEvent> = flow {
         try {
             val messages = mutableListOf<ChatMessage>()
@@ -169,7 +176,26 @@ class ChatEngine(
                         }
                         emit(ChatEvent.ToolExecuting(toolCall.tool, argsJson))
 
-                        val toolResult = toolExecutor.execute(toolCall)
+                        val tool = toolExecutor.findTool(toolCall.tool)
+                        val toolResult = if (tool is LocalTool && tool.destructive) {
+                            val description = descriptionForConfirmation(toolCall.tool, argsJson)
+                            emit(ChatEvent.ConfirmationRequired(toolCall.tool, argsJson, description))
+                            if (onConfirmationRequired != null) {
+                                val approved = onConfirmationRequired(toolCall.tool, description, argsJson)
+                                if (approved) {
+                                    toolExecutor.execute(toolCall)
+                                } else {
+                                    io.github.leogallego.ansiblejane.assistant.tools.ToolResult(
+                                        success = false,
+                                        data = "User declined the action"
+                                    )
+                                }
+                            } else {
+                                toolExecutor.execute(toolCall)
+                            }
+                        } else {
+                            toolExecutor.execute(toolCall)
+                        }
                         totalToolCalls++
 
                         emit(ChatEvent.ToolResult(toolCall.tool, toolResult))
@@ -387,6 +413,17 @@ class ChatEngine(
 
         if (keepFrom > systemMessages.size) {
             messages.subList(systemMessages.size, keepFrom).clear()
+        }
+    }
+
+    private fun descriptionForConfirmation(toolName: String, args: JsonObject): String {
+        return when (toolName) {
+            "approve_workflow" -> "Approve workflow approval step #${args["approval_id"]?.jsonPrimitive?.content ?: "?"}"
+            "deny_workflow" -> "Deny workflow approval step #${args["approval_id"]?.jsonPrimitive?.content ?: "?"}"
+            "launch_job" -> "Launch job template #${args["template_id"]?.jsonPrimitive?.content ?: "?"}"
+            "launch_workflow" -> "Launch workflow template #${args["template_id"]?.jsonPrimitive?.content ?: "?"}"
+            "toggle_schedule" -> "Toggle schedule #${args["schedule_id"]?.jsonPrimitive?.content ?: "?"}"
+            else -> "Execute $toolName"
         }
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
@@ -177,21 +177,17 @@ class ChatEngine(
                         emit(ChatEvent.ToolExecuting(toolCall.tool, argsJson))
 
                         val tool = toolExecutor.findTool(toolCall.tool)
-                        val toolResult = if (tool is LocalTool && tool.destructive) {
+                        val toolResult = if (tool is LocalTool && tool.destructive && onConfirmationRequired != null) {
                             val description = descriptionForConfirmation(toolCall.tool, argsJson)
                             emit(ChatEvent.ConfirmationRequired(toolCall.tool, argsJson, description))
-                            if (onConfirmationRequired != null) {
-                                val approved = onConfirmationRequired(toolCall.tool, description, argsJson)
-                                if (approved) {
-                                    toolExecutor.execute(toolCall)
-                                } else {
-                                    io.github.leogallego.ansiblejane.assistant.tools.ToolResult(
-                                        success = false,
-                                        data = "User declined the action"
-                                    )
-                                }
-                            } else {
+                            val approved = onConfirmationRequired(toolCall.tool, description, argsJson)
+                            if (approved) {
                                 toolExecutor.execute(toolCall)
+                            } else {
+                                io.github.leogallego.ansiblejane.assistant.tools.ToolResult(
+                                    success = false,
+                                    data = "User declined the action"
+                                )
                             }
                         } else {
                             toolExecutor.execute(toolCall)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
@@ -3,6 +3,7 @@ package io.github.leogallego.ansiblejane.assistant.engine
 import ai.koog.prompt.message.MessagePart
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 import io.github.leogallego.ansiblejane.assistant.tools.ErrorType
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
 import kotlinx.coroutines.TimeoutCancellationException
@@ -35,11 +36,14 @@ class ToolExecutor(
                 )
             }
 
+        val isDestructive = tool is LocalTool && tool.destructive
         val cacheKey = "${toolCall.tool}:${toolCall.args.hashCode()}"
-        val cached = resultCache[cacheKey]
-        if (cached != null && System.currentTimeMillis() - cached.first < CACHE_TTL_MS) {
-            Log.d(TAG, "EXEC: cache hit for ${toolCall.tool}")
-            return cached.second
+        if (!isDestructive) {
+            val cached = resultCache[cacheKey]
+            if (cached != null && System.currentTimeMillis() - cached.first < CACHE_TTL_MS) {
+                Log.d(TAG, "EXEC: cache hit for ${toolCall.tool}")
+                return cached.second
+            }
         }
 
         val argsJson = try {
@@ -81,7 +85,7 @@ class ToolExecutor(
             "in ${elapsedMs}ms, result=${rawLen}→${if (cappedLen != rawLen) "${cappedLen}→" else ""}${finalLen} chars")
         Log.d(TAG, "EXEC DATA: ${finalResult.data?.take(500)}")
 
-        if (finalResult.success) {
+        if (finalResult.success && !isDestructive) {
             resultCache[cacheKey] = System.currentTimeMillis() to finalResult
         }
         return finalResult

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
@@ -22,6 +22,8 @@ class ToolExecutor(
 ) {
     private val resultCache = mutableMapOf<String, Pair<Long, ToolResult>>()
 
+    fun findTool(name: String): Tool? = tools.find { it.spec.name == name }
+
     suspend fun execute(toolCall: MessagePart.Tool.Call): ToolResult {
         val tool = tools.find { it.spec.name == toolCall.tool }
             ?: run {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -37,14 +37,16 @@ class ToolRouter {
                 "output", "stdout", "running", "failed", "started", "task",
                 "tasks", "command", "error", "errors", "failure", "status",
                 "playbooks", "workflows", "execution", "executions",
-                "survey", "node", "nodes", "prompt", "variable", "variables"
+                "survey", "node", "nodes", "prompt", "variable", "variables",
+                "approval", "approvals", "approve", "deny", "pending"
             ),
-            resourcePrefixes = setOf("jobs", "job_templates", "workflow_jobs", "workflow_job_templates", "workflow_job_nodes", "workflow_job_template_nodes", "schedules", "ad_hoc_commands"),
+            resourcePrefixes = setOf("jobs", "job_templates", "workflow_jobs", "workflow_job_templates", "workflow_job_nodes", "workflow_job_template_nodes", "schedules", "ad_hoc_commands", "workflow_approvals"),
             localToolNames = setOf(
                 "list_job_templates", "launch_job", "get_job", "get_job_stdout", "list_jobs",
                 "list_workflow_templates", "launch_workflow", "get_workflow_job",
                 "list_schedules", "toggle_schedule",
-                "list_workflow_nodes", "get_survey_spec"
+                "list_workflow_nodes", "get_survey_spec",
+                "list_pending_approvals", "approve_workflow", "deny_workflow"
             )
         ),
         MONITORING(
@@ -178,6 +180,9 @@ class ToolRouter {
             "get_config" to setOf("controller.config_read"),
             "list_workflow_nodes" to setOf("controller.workflow_job_template_nodes_list"),
             "get_survey_spec" to setOf("controller.job_templates_survey_spec_read"),
+            "list_pending_approvals" to setOf("controller.workflow_approvals_list"),
+            "approve_workflow" to setOf("controller.workflow_approvals_approve_create"),
+            "deny_workflow" to setOf("controller.workflow_approvals_deny_create"),
             "list_eda_rulebooks" to setOf("eda.rulebooks_list"),
             "list_eda_decision_environments" to setOf("eda.decision_environments_list"),
             "list_eda_projects" to setOf("eda.projects_list"),

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantUiState.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantUiState.kt
@@ -6,6 +6,13 @@ import io.github.leogallego.ansiblejane.model.AppError
 import io.github.leogallego.ansiblejane.network.mcp.McpConnectionState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.CompletableDeferred
+
+data class PendingConfirmation(
+    val toolName: String,
+    val description: String,
+    val continuation: CompletableDeferred<Boolean>
+)
 
 sealed interface AssistantUiState {
     data object Idle : AssistantUiState
@@ -15,7 +22,8 @@ sealed interface AssistantUiState {
         val messages: ImmutableList<ChatMessage> = persistentListOf(),
         val isGenerating: Boolean = false,
         val streamingText: String? = null,
-        val connections: Map<String, McpConnectionState> = emptyMap()
+        val connections: Map<String, McpConnectionState> = emptyMap(),
+        val pendingConfirmation: PendingConfirmation? = null
     ) : AssistantUiState
     data class Error(val error: AppError) : AssistantUiState
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -23,6 +23,7 @@ import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -221,8 +222,21 @@ class AssistantViewModel(
 
             updateState { copy(streamingText = "Thinking...") }
 
-            engine.processMessage(text, repository.getHistory(), toolSpecs, maxTokens, contextChars)
-                .collect { event ->
+            engine.processMessage(
+                text, repository.getHistory(), toolSpecs, maxTokens, contextChars,
+                onConfirmationRequired = { toolName, description, _ ->
+                    val deferred = CompletableDeferred<Boolean>()
+                    val pending = PendingConfirmation(
+                        toolName = toolName,
+                        description = description,
+                        continuation = deferred
+                    )
+                    updateState { copy(pendingConfirmation = pending) }
+                    val result = deferred.await()
+                    updateState { copy(pendingConfirmation = null) }
+                    result
+                }
+            ).collect { event ->
                     when (event) {
                         is ChatEvent.TextDelta -> {
                             textBuilder.append(event.text)
@@ -237,6 +251,9 @@ class AssistantViewModel(
                         is ChatEvent.ToolResult -> {
                             updateState { copy(streamingText = "Processing results...") }
                             textBuilder.clear()
+                        }
+                        is ChatEvent.ConfirmationRequired -> {
+                            updateState { copy(streamingText = "Waiting for confirmation...") }
                         }
                         is ChatEvent.AssistantMessage -> {
                             val responseSource = when {
@@ -276,6 +293,13 @@ class AssistantViewModel(
                         }
                     }
                 }
+        }
+    }
+
+    fun confirmAction(approved: Boolean) {
+        val current = _uiState.value
+        if (current is AssistantUiState.Active) {
+            current.pendingConfirmation?.continuation?.complete(approved)
         }
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -305,7 +305,7 @@ class AssistantViewModel(
 
     fun stopGeneration() {
         generateJob?.cancel()
-        updateState { copy(isGenerating = false, streamingText = null) }
+        updateState { copy(isGenerating = false, streamingText = null, pendingConfirmation = null) }
     }
 
     fun regenerateLastMessage() {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ApproveWorkflowLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ApproveWorkflowLocalTool.kt
@@ -1,0 +1,29 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.serialization.typeToken
+import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.data.IWorkflowRepository
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+class ApproveWorkflowLocalTool(
+    private val repository: IWorkflowRepository
+) : AapLocalTool<ApproveWorkflowLocalTool.Args>(
+    typeToken<Args>(), Args.serializer(),
+    name = "approve_workflow",
+    description = "Approve a pending workflow approval step",
+    destructive = true
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("ID of the workflow approval to approve")
+        @SerialName("approval_id")
+        val approvalId: Int
+    )
+
+    override suspend fun execute(args: Args): String {
+        repository.approveWorkflow(args.approvalId).getOrThrow()
+        return """{"approval_id": ${args.approvalId}, "status": "approved"}"""
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/DenyWorkflowLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/DenyWorkflowLocalTool.kt
@@ -1,0 +1,29 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.serialization.typeToken
+import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.data.IWorkflowRepository
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+class DenyWorkflowLocalTool(
+    private val repository: IWorkflowRepository
+) : AapLocalTool<DenyWorkflowLocalTool.Args>(
+    typeToken<Args>(), Args.serializer(),
+    name = "deny_workflow",
+    description = "Deny a pending workflow approval step",
+    destructive = true
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("ID of the workflow approval to deny")
+        @SerialName("approval_id")
+        val approvalId: Int
+    )
+
+    override suspend fun execute(args: Args): String {
+        repository.denyWorkflow(args.approvalId).getOrThrow()
+        return """{"approval_id": ${args.approvalId}, "status": "denied"}"""
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPendingApprovalsLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPendingApprovalsLocalTool.kt
@@ -1,0 +1,39 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.serialization.typeToken
+import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.data.IWorkflowRepository
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+
+class ListPendingApprovalsLocalTool(
+    private val repository: IWorkflowRepository
+) : AapLocalTool<ListPendingApprovalsLocalTool.Args>(
+    typeToken<Args>(), Args.serializer(),
+    name = "list_pending_approvals",
+    description = "List pending workflow approval requests"
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("Page number (default 1)")
+        val page: Int = 1,
+        @property:LLMDescription("Results per page (default 25)")
+        @SerialName("page_size")
+        val pageSize: Int = 25
+    )
+
+    override suspend fun execute(args: Args): String {
+        val result = repository.getPendingApprovals(
+            page = args.page.coerceAtLeast(1),
+            pageSize = args.pageSize.coerceIn(1, 100)
+        ).getOrThrow()
+        return networkJson.encodeToString(mapOf(
+            "count" to result.totalCount.toString(),
+            "has_more" to result.hasMore.toString(),
+            "results" to networkJson.encodeToString(result.approvals)
+        ))
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPendingApprovalsLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPendingApprovalsLocalTool.kt
@@ -8,6 +8,9 @@ import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 
 class ListPendingApprovalsLocalTool(
     private val repository: IWorkflowRepository
@@ -30,10 +33,14 @@ class ListPendingApprovalsLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 100)
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "has_more" to result.hasMore.toString(),
-            "results" to networkJson.encodeToString(result.approvals)
-        ))
+        val resultsArray = networkJson.encodeToJsonElement(
+            kotlinx.serialization.builtins.ListSerializer(io.github.leogallego.ansiblejane.model.WorkflowApproval.serializer()),
+            result.approvals
+        )
+        return JsonObject(mapOf(
+            "count" to JsonPrimitive(result.totalCount),
+            "has_more" to JsonPrimitive(result.hasMore),
+            "results" to resultsArray
+        )).toString()
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
@@ -169,7 +169,7 @@ private fun ActiveChatContent(
         (if (state.isGenerating) 1 else 0) +
         (if (messageCount == 0 && !state.isGenerating) 1 else 0)
 
-    LaunchedEffect(messageCount, state.isGenerating) {
+    LaunchedEffect(messageCount, state.isGenerating, state.pendingConfirmation) {
         if (totalItems > 0) {
             listState.animateScrollToItem(totalItems - 1)
         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
@@ -116,6 +116,8 @@ fun AssistantScreen(
                 onSendMessage = { viewModel.sendMessage(it) },
                 onStopGeneration = { viewModel.stopGeneration() },
                 onRegenerateLastMessage = { viewModel.regenerateLastMessage() },
+                onConfirmApprove = { viewModel.confirmAction(true) },
+                onConfirmDeny = { viewModel.confirmAction(false) },
                 modifier = Modifier.fillMaxSize()
             )
         }
@@ -142,6 +144,8 @@ private fun ActiveChatContent(
     onSendMessage: (String) -> Unit,
     onStopGeneration: () -> Unit,
     onRegenerateLastMessage: () -> Unit,
+    onConfirmApprove: () -> Unit,
+    onConfirmDeny: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val listState = rememberLazyListState()
@@ -161,6 +165,7 @@ private fun ActiveChatContent(
     val imeVisible = WindowInsets.isImeVisible
     val messageCount = state.messages.size
     val totalItems = messageCount +
+        (if (state.pendingConfirmation != null) 1 else 0) +
         (if (state.isGenerating) 1 else 0) +
         (if (messageCount == 0 && !state.isGenerating) 1 else 0)
 
@@ -265,6 +270,18 @@ private fun ActiveChatContent(
                             else null,
                     )
                     else -> AssistantMessage(content = message.content)
+                }
+            }
+
+            if (state.pendingConfirmation != null) {
+                item(key = "confirmation", contentType = "confirmation") {
+                    ConfirmationCard(
+                        toolName = state.pendingConfirmation.toolName,
+                        description = state.pendingConfirmation.description,
+                        onApprove = onConfirmApprove,
+                        onDeny = onConfirmDeny,
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    )
                 }
             }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ConfirmationCard.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ConfirmationCard.kt
@@ -1,0 +1,85 @@
+package io.github.leogallego.ansiblejane.assistant.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ConfirmationCard(
+    toolName: String,
+    description: String,
+    onApprove: () -> Unit,
+    onDeny: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Warning,
+                    contentDescription = "Confirmation required",
+                    tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = toolName,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer
+                )
+            }
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                modifier = Modifier.padding(top = 8.dp, bottom = 12.dp)
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                OutlinedButton(
+                    onClick = onDeny,
+                    modifier = Modifier.testTag("button_confirm_deny")
+                ) {
+                    Text("Deny")
+                }
+                Spacer(Modifier.width(8.dp))
+                Button(
+                    onClick = onApprove,
+                    modifier = Modifier.testTag("button_confirm_approve")
+                ) {
+                    Text("Approve")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/DataModule.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/DataModule.kt
@@ -2,6 +2,8 @@ package io.github.leogallego.ansiblejane.data
 
 import io.github.leogallego.ansiblejane.data.backup.BackupManager
 import io.github.leogallego.ansiblejane.network.AapApiProvider
+import io.github.leogallego.ansiblejane.notification.ApprovalNotificationManager
+import io.github.leogallego.ansiblejane.notification.ApprovalTracker
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -10,6 +12,8 @@ val dataModule = module {
     single { TokenManager(androidContext()) } bind ITokenManager::class
     single { UserPreferencesRepository(androidContext()) } bind IUserPreferencesRepository::class
     single { BackupManager() }
+    single { ApprovalTracker(androidContext()) }
+    single { ApprovalNotificationManager() }
     single { ConnectivityObserver(androidContext()) }
     single { AuthRepository(get(), get(), get()) } bind IAuthRepository::class
     single { TemplateRepository(get<AapApiProvider>()) } bind ITemplateRepository::class

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/IWorkflowRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/IWorkflowRepository.kt
@@ -1,5 +1,6 @@
 package io.github.leogallego.ansiblejane.data
 
+import io.github.leogallego.ansiblejane.model.WorkflowApproval
 import io.github.leogallego.ansiblejane.model.WorkflowJob
 import io.github.leogallego.ansiblejane.model.WorkflowJobTemplateNode
 import io.github.leogallego.ansiblejane.model.WorkflowNode
@@ -17,4 +18,8 @@ interface IWorkflowRepository {
     fun pollWorkflowJobStatus(workflowJobId: Int): Flow<WorkflowJob>
     suspend fun getWorkflowNodes(workflowJobId: Int): Result<List<WorkflowNode>>
     suspend fun getWorkflowTemplateNodes(templateId: Int): Result<List<WorkflowJobTemplateNode>>
+    suspend fun getWorkflowApproval(approvalId: Int): Result<WorkflowApproval>
+    suspend fun getPendingApprovals(page: Int = 1, pageSize: Int = 25): Result<PendingApprovalResult>
+    suspend fun approveWorkflow(approvalId: Int): Result<Unit>
+    suspend fun denyWorkflow(approvalId: Int): Result<Unit>
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/WorkflowRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/WorkflowRepository.kt
@@ -1,6 +1,7 @@
 package io.github.leogallego.ansiblejane.data
 
 import io.github.leogallego.ansiblejane.model.LaunchRequest
+import io.github.leogallego.ansiblejane.model.WorkflowApproval
 import io.github.leogallego.ansiblejane.model.WorkflowJob
 import io.github.leogallego.ansiblejane.model.WorkflowJobTemplate
 import io.github.leogallego.ansiblejane.model.WorkflowJobTemplateNode
@@ -86,10 +87,61 @@ class WorkflowRepository(private val apiProvider: AapApiProvider) : IWorkflowRep
             Result.failure(e)
         }
     }
+
+    override suspend fun getWorkflowApproval(approvalId: Int): Result<WorkflowApproval> {
+        return try {
+            Result.success(apiProvider.getApiService().getWorkflowApproval(approvalId))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getPendingApprovals(page: Int, pageSize: Int): Result<PendingApprovalResult> {
+        return try {
+            val response = apiProvider.getApiService().getWorkflowApprovals(
+                status = "pending",
+                page = page,
+                pageSize = pageSize
+            )
+            Result.success(
+                PendingApprovalResult(
+                    approvals = response.results,
+                    hasMore = response.next != null,
+                    totalCount = response.count
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun approveWorkflow(approvalId: Int): Result<Unit> {
+        return try {
+            apiProvider.getApiService().approveWorkflow(approvalId)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun denyWorkflow(approvalId: Int): Result<Unit> {
+        return try {
+            apiProvider.getApiService().denyWorkflow(approvalId)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 }
 
 data class WorkflowTemplateListResult(
     val templates: List<WorkflowJobTemplate>,
+    val hasMore: Boolean,
+    val totalCount: Int
+)
+
+data class PendingApprovalResult(
+    val approvals: List<WorkflowApproval>,
     val hasMore: Boolean,
     val totalCount: Int
 )

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/WorkflowApproval.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/WorkflowApproval.kt
@@ -1,0 +1,41 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WorkflowApproval(
+    val id: Int,
+    val name: String = "",
+    val status: String = "",
+    @SerialName("workflow_job") val workflowJob: Int? = null,
+    @SerialName("summary_fields") val summaryFields: WorkflowApprovalSummary = WorkflowApprovalSummary(),
+    val created: String = "",
+    @SerialName("timed_out") val timedOut: Boolean = false,
+)
+
+@Serializable
+data class WorkflowApprovalSummary(
+    @SerialName("workflow_job") val workflowJob: WorkflowApprovalJobRef? = null,
+    @SerialName("workflow_job_template") val workflowJobTemplate: WorkflowApprovalTemplateRef? = null,
+    @SerialName("approved_or_denied_by") val approvedOrDeniedBy: WorkflowApprovalUserRef? = null,
+)
+
+@Serializable
+data class WorkflowApprovalJobRef(
+    val id: Int,
+    val name: String = "",
+    val status: String = "",
+)
+
+@Serializable
+data class WorkflowApprovalTemplateRef(
+    val id: Int,
+    val name: String = "",
+)
+
+@Serializable
+data class WorkflowApprovalUserRef(
+    val id: Int,
+    val username: String = "",
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/navigation/AppNavigation.kt
@@ -26,6 +26,7 @@ import io.github.leogallego.ansiblejane.ui.auth.AuthScreen
 import io.github.leogallego.ansiblejane.ui.jobs.JobStatusScreen
 import io.github.leogallego.ansiblejane.ui.main.MainScreen
 import io.github.leogallego.ansiblejane.ui.settings.SettingsScreen
+import io.github.leogallego.ansiblejane.ui.approval.ApprovalDetailScreen
 import io.github.leogallego.ansiblejane.ui.workflows.WorkflowJobStatusScreen
 import io.github.leogallego.ansiblejane.ui.workflows.WorkflowTemplateDetailScreen
 import org.koin.compose.viewmodel.koinViewModel
@@ -42,8 +43,10 @@ object Routes {
     const val JOB_STATUS = "job_status/{jobId}"
     const val WORKFLOW_JOB_STATUS = "workflow_job_status/{workflowJobId}"
     const val WORKFLOW_TEMPLATE_DETAIL = "workflow_template_detail/{templateId}/{templateName}"
+    const val APPROVAL_DETAIL = "approval/{approvalId}"
     const val SETTINGS = "settings"
 
+    fun approvalDetail(approvalId: Int) = "approval/$approvalId"
     fun jobStatus(jobId: Int) = "job_status/$jobId"
     fun workflowJobStatus(workflowJobId: Int) = "workflow_job_status/$workflowJobId"
     fun workflowTemplateDetail(templateId: Int, templateName: String): String {
@@ -252,6 +255,19 @@ fun AppNavigation(
                 onNavigateToWorkflowJobStatus = { workflowJobId ->
                     navController.navigate(Routes.workflowJobStatus(workflowJobId))
                 }
+            )
+        }
+
+        composable(
+            route = Routes.APPROVAL_DETAIL,
+            arguments = listOf(navArgument("approvalId") { type = NavType.IntType }),
+            enterTransition = { slideInHorizontally { it } },
+            exitTransition = { slideOutHorizontally { -it } },
+            popEnterTransition = { slideInHorizontally { -it } },
+            popExitTransition = { slideOutHorizontally { it } }
+        ) {
+            ApprovalDetailScreen(
+                onNavigateBack = { navController.popBackStack() }
             )
         }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/navigation/AppNavigation.kt
@@ -18,6 +18,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import androidx.navigation.navDeepLink
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.leogallego.ansiblejane.data.TokenManager
 import io.github.leogallego.ansiblejane.network.AuthInterceptor
@@ -261,6 +262,7 @@ fun AppNavigation(
         composable(
             route = Routes.APPROVAL_DETAIL,
             arguments = listOf(navArgument("approvalId") { type = NavType.IntType }),
+            deepLinks = listOf(navDeepLink { uriPattern = "ansiblejane://approval/{approvalId}" }),
             enterTransition = { slideInHorizontally { it } },
             exitTransition = { slideOutHorizontally { -it } },
             popEnterTransition = { slideInHorizontally { -it } },

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/AapApiService.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/AapApiService.kt
@@ -282,4 +282,21 @@ interface AapApiService {
 
     @GET("job_templates/{id}/survey_spec/")
     suspend fun getSurveySpec(@Path("id") id: Int): SurveySpec
+
+    @GET("workflow_approvals/{id}/")
+    suspend fun getWorkflowApproval(@Path("id") id: Int): WorkflowApproval
+
+    @GET("workflow_approvals/")
+    suspend fun getWorkflowApprovals(
+        @Query("status") status: String? = null,
+        @Query("page") page: Int = 1,
+        @Query("page_size") pageSize: Int = 25,
+        @Query("order_by") orderBy: String = "-created"
+    ): PaginatedResponse<WorkflowApproval>
+
+    @POST("workflow_approvals/{id}/approve/")
+    suspend fun approveWorkflow(@Path("id") id: Int): okhttp3.ResponseBody
+
+    @POST("workflow_approvals/{id}/deny/")
+    suspend fun denyWorkflow(@Path("id") id: Int): okhttp3.ResponseBody
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/AapApiService.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/AapApiService.kt
@@ -295,8 +295,8 @@ interface AapApiService {
     ): PaginatedResponse<WorkflowApproval>
 
     @POST("workflow_approvals/{id}/approve/")
-    suspend fun approveWorkflow(@Path("id") id: Int): okhttp3.ResponseBody
+    suspend fun approveWorkflow(@Path("id") id: Int)
 
     @POST("workflow_approvals/{id}/deny/")
-    suspend fun denyWorkflow(@Path("id") id: Int): okhttp3.ResponseBody
+    suspend fun denyWorkflow(@Path("id") id: Int)
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
@@ -1,0 +1,88 @@
+package io.github.leogallego.ansiblejane.notification
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import io.github.leogallego.ansiblejane.MainActivity
+import io.github.leogallego.ansiblejane.R
+import io.github.leogallego.ansiblejane.model.WorkflowApproval
+
+class ApprovalNotificationManager {
+
+    companion object {
+        const val CHANNEL_ID = "workflow_approvals"
+        const val CHANNEL_NAME = "Workflow Approvals"
+        const val EXTRA_APPROVAL_ID = "approval_id"
+
+        /**
+         * Creates the notification channel. Safe to call multiple times.
+         * Should be called from Application.onCreate().
+         */
+        fun createChannel(context: Context) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = "Notifications for pending workflow approvals"
+            }
+            val notificationManager = context.getSystemService(NotificationManager::class.java)
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    /**
+     * Shows a notification for a pending workflow approval.
+     * Each approval gets a unique notification ID based on its API id.
+     */
+    fun showNotification(context: Context, approval: WorkflowApproval) {
+        // Check POST_NOTIFICATIONS permission on Android 13+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) != PackageManager.PERMISSION_GRANTED
+            ) {
+                return
+            }
+        }
+
+        val intent = Intent(context, MainActivity::class.java).apply {
+            putExtra(EXTRA_APPROVAL_ID, approval.id)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            approval.id,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val templateName = approval.summaryFields.workflowJobTemplate?.name
+        val bodyText = if (templateName != null) {
+            "Pending workflow approval for $templateName"
+        } else {
+            "Pending workflow approval"
+        }
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(approval.name)
+            .setContentText(bodyText)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(approval.id, notification)
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
@@ -7,6 +7,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -20,12 +21,7 @@ class ApprovalNotificationManager {
     companion object {
         const val CHANNEL_ID = "workflow_approvals"
         const val CHANNEL_NAME = "Workflow Approvals"
-        const val EXTRA_APPROVAL_ID = "approval_id"
 
-        /**
-         * Creates the notification channel. Safe to call multiple times.
-         * Should be called from Application.onCreate().
-         */
         fun createChannel(context: Context) {
             val channel = NotificationChannel(
                 CHANNEL_ID,
@@ -39,12 +35,7 @@ class ApprovalNotificationManager {
         }
     }
 
-    /**
-     * Shows a notification for a pending workflow approval.
-     * Each approval gets a unique notification ID based on its API id.
-     */
     fun showNotification(context: Context, approval: WorkflowApproval) {
-        // Check POST_NOTIFICATIONS permission on Android 13+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (ContextCompat.checkSelfPermission(
                     context,
@@ -55,8 +46,8 @@ class ApprovalNotificationManager {
             }
         }
 
-        val intent = Intent(context, MainActivity::class.java).apply {
-            putExtra(EXTRA_APPROVAL_ID, approval.id)
+        val deepLinkUri = Uri.parse("ansiblejane://approval/${approval.id}")
+        val intent = Intent(Intent.ACTION_VIEW, deepLinkUri, context, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.network.AapApiProvider
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
@@ -20,6 +21,10 @@ class ApprovalPollingWorker(
 
     override suspend fun doWork(): Result {
         return try {
+            val tokenManager: ITokenManager = get()
+            if (tokenManager.activeInstance.value == null) {
+                return Result.success()
+            }
             val apiProvider: AapApiProvider = get()
             val approvalTracker: ApprovalTracker = get()
             val notificationManager: ApprovalNotificationManager = get()

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
@@ -1,0 +1,53 @@
+package io.github.leogallego.ansiblejane.notification
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import io.github.leogallego.ansiblejane.network.AapApiProvider
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+
+class ApprovalPollingWorker(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : CoroutineWorker(appContext, workerParams), KoinComponent {
+
+    companion object {
+        private const val TAG = "ApprovalPollingWorker"
+        const val WORK_NAME = "approval_polling"
+    }
+
+    override suspend fun doWork(): Result {
+        return try {
+            val apiProvider: AapApiProvider = get()
+            val approvalTracker: ApprovalTracker = get()
+            val notificationManager: ApprovalNotificationManager = get()
+
+            val response = apiProvider.getApiService().getWorkflowApprovals(status = "pending")
+            val pendingApprovals = response.results
+            val pendingIds = pendingApprovals.map { it.id }.toSet()
+
+            val seenIds = approvalTracker.getSeenIds()
+            val newIds = pendingIds - seenIds
+
+            for (approval in pendingApprovals) {
+                if (approval.id in newIds) {
+                    notificationManager.showNotification(applicationContext, approval)
+                }
+            }
+
+            if (newIds.isNotEmpty()) {
+                approvalTracker.markSeen(newIds)
+            }
+
+            // Prune IDs that are no longer pending
+            approvalTracker.pruneIds(pendingIds)
+
+            Result.success()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to poll for workflow approvals", e)
+            Result.retry()
+        }
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
@@ -7,6 +7,8 @@ import androidx.work.WorkerParameters
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.network.AapApiProvider
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 
@@ -23,7 +25,10 @@ class ApprovalPollingWorker(
     override suspend fun doWork(): Result {
         return try {
             val tokenManager: ITokenManager = get()
-            if (tokenManager.activeInstance.value == null) {
+            val instance = withTimeoutOrNull(5_000L) {
+                tokenManager.activeInstance.firstOrNull { it != null }
+            }
+            if (instance == null) {
                 return Result.success()
             }
             val apiProvider: AapApiProvider = get()

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
@@ -6,6 +6,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.network.AapApiProvider
+import kotlinx.coroutines.CancellationException
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 
@@ -50,6 +51,8 @@ class ApprovalPollingWorker(
             approvalTracker.pruneIds(pendingIds)
 
             Result.success()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Failed to poll for workflow approvals", e)
             Result.retry()

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalTracker.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalTracker.kt
@@ -1,0 +1,51 @@
+package io.github.leogallego.ansiblejane.notification
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+
+private val Context.approvalTrackerDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "approval_tracker"
+)
+
+class ApprovalTracker(private val context: Context) {
+
+    companion object {
+        private val KEY_SEEN_IDS = stringSetPreferencesKey("seen_approval_ids")
+    }
+
+    /**
+     * Returns the set of approval IDs that have already been seen.
+     */
+    suspend fun getSeenIds(): Set<Int> {
+        val prefs = context.approvalTrackerDataStore.data.first()
+        val strings = prefs[KEY_SEEN_IDS] ?: emptySet()
+        return strings.mapNotNull { it.toIntOrNull() }.toSet()
+    }
+
+    /**
+     * Marks the given approval IDs as seen.
+     */
+    suspend fun markSeen(ids: Set<Int>) {
+        context.approvalTrackerDataStore.edit { prefs ->
+            val existing = prefs[KEY_SEEN_IDS] ?: emptySet()
+            prefs[KEY_SEEN_IDS] = existing + ids.map { it.toString() }.toSet()
+        }
+    }
+
+    /**
+     * Prunes IDs that are no longer in the active pending set.
+     * This prevents the seen set from growing indefinitely.
+     */
+    suspend fun pruneIds(activeIds: Set<Int>) {
+        context.approvalTrackerDataStore.edit { prefs ->
+            val existing = prefs[KEY_SEEN_IDS] ?: emptySet()
+            val activeStrings = activeIds.map { it.toString() }.toSet()
+            prefs[KEY_SEEN_IDS] = existing.intersect(activeStrings)
+        }
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/PresentationModule.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/PresentationModule.kt
@@ -1,5 +1,6 @@
 package io.github.leogallego.ansiblejane.presentation
 
+import io.github.leogallego.ansiblejane.presentation.approval.ApprovalDetailViewModel
 import io.github.leogallego.ansiblejane.presentation.auth.AuthViewModel
 import io.github.leogallego.ansiblejane.presentation.dashboard.DashboardViewModel
 import io.github.leogallego.ansiblejane.presentation.settings.BackupViewModel
@@ -18,6 +19,7 @@ import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val presentationModule = module {
+    viewModelOf(::ApprovalDetailViewModel)
     viewModelOf(::AuthViewModel)
     viewModelOf(::DashboardViewModel)
     viewModelOf(::TemplatesViewModel)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/approval/ApprovalDetailViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/approval/ApprovalDetailViewModel.kt
@@ -1,0 +1,96 @@
+package io.github.leogallego.ansiblejane.presentation.approval
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.github.leogallego.ansiblejane.data.IWorkflowRepository
+import io.github.leogallego.ansiblejane.model.AppError
+import io.github.leogallego.ansiblejane.model.WorkflowApproval
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+sealed interface ApprovalDetailUiState {
+    data object Loading : ApprovalDetailUiState
+    data class Ready(val approval: WorkflowApproval) : ApprovalDetailUiState
+    data class ActionInProgress(val approval: WorkflowApproval, val action: String) : ApprovalDetailUiState
+    data class Completed(val approval: WorkflowApproval, val action: String) : ApprovalDetailUiState
+    data class Error(val error: AppError) : ApprovalDetailUiState
+}
+
+class ApprovalDetailViewModel(
+    savedStateHandle: SavedStateHandle,
+    private val workflowRepository: IWorkflowRepository
+) : ViewModel() {
+
+    private val approvalId: Int = savedStateHandle.get<Int>("approvalId") ?: -1
+
+    private val _uiState = MutableStateFlow<ApprovalDetailUiState>(ApprovalDetailUiState.Loading)
+    val uiState: StateFlow<ApprovalDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        loadApproval()
+    }
+
+    fun loadApproval() {
+        if (approvalId <= 0) {
+            _uiState.value = ApprovalDetailUiState.Error(
+                AppError.Unknown("Invalid approval ID")
+            )
+            return
+        }
+
+        _uiState.value = ApprovalDetailUiState.Loading
+        viewModelScope.launch {
+            workflowRepository.getWorkflowApproval(approvalId).fold(
+                onSuccess = { approval ->
+                    _uiState.value = ApprovalDetailUiState.Ready(approval)
+                },
+                onFailure = { e ->
+                    _uiState.value = ApprovalDetailUiState.Error(AppError.from(e))
+                }
+            )
+        }
+    }
+
+    fun approve() {
+        val currentState = _uiState.value
+        val approval = when (currentState) {
+            is ApprovalDetailUiState.Ready -> currentState.approval
+            else -> return
+        }
+
+        _uiState.value = ApprovalDetailUiState.ActionInProgress(approval, "approve")
+        viewModelScope.launch {
+            workflowRepository.approveWorkflow(approvalId).fold(
+                onSuccess = {
+                    _uiState.value = ApprovalDetailUiState.Completed(approval, "approved")
+                },
+                onFailure = { e ->
+                    _uiState.value = ApprovalDetailUiState.Error(AppError.from(e))
+                }
+            )
+        }
+    }
+
+    fun deny() {
+        val currentState = _uiState.value
+        val approval = when (currentState) {
+            is ApprovalDetailUiState.Ready -> currentState.approval
+            else -> return
+        }
+
+        _uiState.value = ApprovalDetailUiState.ActionInProgress(approval, "deny")
+        viewModelScope.launch {
+            workflowRepository.denyWorkflow(approvalId).fold(
+                onSuccess = {
+                    _uiState.value = ApprovalDetailUiState.Completed(approval, "denied")
+                },
+                onFailure = { e ->
+                    _uiState.value = ApprovalDetailUiState.Error(AppError.from(e))
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
@@ -87,9 +87,11 @@ fun ApprovalDetailScreen(
                 }
 
                 is ApprovalDetailUiState.Ready -> {
+                    val isPending = state.approval.status == "pending"
                     ApprovalDetailContent(
                         approval = state.approval,
                         isActionInProgress = false,
+                        showActions = isPending,
                         onApprove = { showConfirmDialog = "approve" },
                         onDeny = { showConfirmDialog = "deny" }
                     )
@@ -99,6 +101,7 @@ fun ApprovalDetailScreen(
                     ApprovalDetailContent(
                         approval = state.approval,
                         isActionInProgress = true,
+                        showActions = true,
                         onApprove = {},
                         onDeny = {}
                     )
@@ -161,6 +164,7 @@ fun ApprovalDetailScreen(
 private fun ApprovalDetailContent(
     approval: WorkflowApproval,
     isActionInProgress: Boolean,
+    showActions: Boolean,
     onApprove: () -> Unit,
     onDeny: () -> Unit
 ) {
@@ -203,8 +207,13 @@ private fun ApprovalDetailContent(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        // Action buttons
-        if (isActionInProgress) {
+        if (!showActions) {
+            Text(
+                text = "This approval has already been ${approval.status}.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        } else if (isActionInProgress) {
             Box(
                 modifier = Modifier.fillMaxWidth(),
                 contentAlignment = Alignment.Center

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
@@ -1,0 +1,304 @@
+package io.github.leogallego.ansiblejane.ui.approval
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.leogallego.ansiblejane.model.WorkflowApproval
+import io.github.leogallego.ansiblejane.presentation.approval.ApprovalDetailUiState
+import io.github.leogallego.ansiblejane.presentation.approval.ApprovalDetailViewModel
+import io.github.leogallego.ansiblejane.ui.components.DateFormatter
+import io.github.leogallego.ansiblejane.ui.components.DetailRowHorizontal
+import io.github.leogallego.ansiblejane.ui.components.ErrorMessage
+import org.koin.compose.viewmodel.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ApprovalDetailScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: ApprovalDetailViewModel = koinViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    var showConfirmDialog by remember { mutableStateOf<String?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Workflow Approval") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            when (val state = uiState) {
+                is ApprovalDetailUiState.Loading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+
+                is ApprovalDetailUiState.Error -> {
+                    ErrorMessage(
+                        error = state.error,
+                        onRetry = { viewModel.loadApproval() },
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+
+                is ApprovalDetailUiState.Ready -> {
+                    ApprovalDetailContent(
+                        approval = state.approval,
+                        isActionInProgress = false,
+                        onApprove = { showConfirmDialog = "approve" },
+                        onDeny = { showConfirmDialog = "deny" }
+                    )
+                }
+
+                is ApprovalDetailUiState.ActionInProgress -> {
+                    ApprovalDetailContent(
+                        approval = state.approval,
+                        isActionInProgress = true,
+                        onApprove = {},
+                        onDeny = {}
+                    )
+                }
+
+                is ApprovalDetailUiState.Completed -> {
+                    ApprovalCompletedContent(
+                        approval = state.approval,
+                        action = state.action,
+                        onNavigateBack = onNavigateBack
+                    )
+                }
+            }
+        }
+    }
+
+    // Confirmation dialog
+    showConfirmDialog?.let { action ->
+        val approvalName = when (val state = uiState) {
+            is ApprovalDetailUiState.Ready -> state.approval.name
+            else -> "this approval"
+        }
+
+        AlertDialog(
+            onDismissRequest = { showConfirmDialog = null },
+            title = {
+                Text(
+                    text = if (action == "approve") "Approve Workflow?" else "Deny Workflow?"
+                )
+            },
+            text = {
+                Text(
+                    text = if (action == "approve") {
+                        "Are you sure you want to approve \"$approvalName\"?"
+                    } else {
+                        "Are you sure you want to deny \"$approvalName\"? This action cannot be undone."
+                    }
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showConfirmDialog = null
+                        if (action == "approve") viewModel.approve() else viewModel.deny()
+                    }
+                ) {
+                    Text(if (action == "approve") "Approve" else "Deny")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showConfirmDialog = null }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun ApprovalDetailContent(
+    approval: WorkflowApproval,
+    isActionInProgress: Boolean,
+    onApprove: () -> Unit,
+    onDeny: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        // Approval info card
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = approval.name,
+                    style = MaterialTheme.typography.headlineSmall
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                DetailRowHorizontal("Status", approval.status)
+
+                if (approval.created.isNotBlank()) {
+                    DetailRowHorizontal("Created", DateFormatter.formatDateTime(approval.created))
+                }
+
+                approval.summaryFields.workflowJobTemplate?.let { template ->
+                    DetailRowHorizontal("Workflow Template", template.name)
+                }
+
+                approval.summaryFields.workflowJob?.let { job ->
+                    DetailRowHorizontal("Workflow Job", job.name)
+                    DetailRowHorizontal("Job Status", job.status)
+                }
+
+                if (approval.timedOut) {
+                    DetailRowHorizontal("Timed Out", "Yes")
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Action buttons
+        if (isActionInProgress) {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Button(
+                    onClick = onApprove,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("button_approve_action"),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    Icon(
+                        Icons.Default.CheckCircle,
+                        contentDescription = null,
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                    Text("Approve")
+                }
+
+                OutlinedButton(
+                    onClick = onDeny,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("button_deny_action"),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Icon(
+                        Icons.Default.Cancel,
+                        contentDescription = null,
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                    Text("Deny")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ApprovalCompletedContent(
+    approval: WorkflowApproval,
+    action: String,
+    onNavigateBack: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        val icon = if (action == "approved") Icons.Default.CheckCircle else Icons.Default.Cancel
+        val color = if (action == "approved") {
+            MaterialTheme.colorScheme.primary
+        } else {
+            MaterialTheme.colorScheme.error
+        }
+
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = color,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        Text(
+            text = "Workflow ${action.replaceFirstChar { it.uppercase() }}",
+            style = MaterialTheme.typography.headlineSmall,
+            color = color
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = approval.name,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(onClick = onNavigateBack) {
+            Text("Go Back")
+        }
+    }
+}

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeWorkflowRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeWorkflowRepository.kt
@@ -1,7 +1,9 @@
 package io.github.leogallego.ansiblejane.fakes
 
 import io.github.leogallego.ansiblejane.data.IWorkflowRepository
+import io.github.leogallego.ansiblejane.data.PendingApprovalResult
 import io.github.leogallego.ansiblejane.data.WorkflowTemplateListResult
+import io.github.leogallego.ansiblejane.model.WorkflowApproval
 import io.github.leogallego.ansiblejane.model.WorkflowJob
 import io.github.leogallego.ansiblejane.model.WorkflowJobTemplate
 import io.github.leogallego.ansiblejane.model.WorkflowJobTemplateNode
@@ -54,5 +56,29 @@ class FakeWorkflowRepository : IWorkflowRepository {
     override suspend fun getWorkflowTemplateNodes(templateId: Int): Result<List<WorkflowJobTemplateNode>> {
         if (shouldFail) return Result.failure(failureException)
         return Result.success(templateNodes)
+    }
+
+    var approvals = listOf<WorkflowApproval>()
+
+    override suspend fun getWorkflowApproval(approvalId: Int): Result<WorkflowApproval> {
+        if (shouldFail) return Result.failure(failureException)
+        return approvals.find { it.id == approvalId }
+            ?.let { Result.success(it) }
+            ?: Result.failure(RuntimeException("Not found"))
+    }
+
+    override suspend fun getPendingApprovals(page: Int, pageSize: Int): Result<PendingApprovalResult> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(PendingApprovalResult(approvals, hasMore = false, totalCount = approvals.size))
+    }
+
+    override suspend fun approveWorkflow(approvalId: Int): Result<Unit> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(Unit)
+    }
+
+    override suspend fun denyWorkflow(approvalId: Int): Result<Unit> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(Unit)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ okhttp = "5.3.2"
 kotlinx-serialization-json = "1.11.0"
 koin = "4.2.1"
 datastore-preferences = "1.2.1"
+work-runtime = "2.10.1"
 tink-android = "1.21.0"
 collections-immutable = "0.3.8"
 coroutines = "1.11.0"
@@ -47,6 +48,7 @@ koin-compose = { group = "io.insert-koin", name = "koin-compose", version.ref = 
 koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
 koin-compose-viewmodel = { group = "io.insert-koin", name = "koin-compose-viewmodel", version.ref = "koin" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore-preferences" }
+androidx-work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work-runtime" }
 tink-android = { group = "com.google.crypto.tink", name = "tink-android", version.ref = "tink-android" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "collections-immutable" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }


### PR DESCRIPTION
## Summary

- **Track 1 — Foundation**: `WorkflowApproval` model, 4 API endpoints (`getWorkflowApproval`, `getWorkflowApprovals`, `approveWorkflow`, `denyWorkflow`), repository methods with `PendingApprovalResult`
- **Track 2 — Chat path**: 3 local tools (`list_pending_approvals`, `approve_workflow`, `deny_workflow`), ChatEngine confirmation gate for **all** destructive tools (not just approvals), `ConfirmationCard` UI with approve/deny buttons, ViewModel wiring via `CompletableDeferred`
- **Track 3 — Notification path**: WorkManager 15-min polling for pending approvals, Android notification channel + builder, DataStore-backed approval tracking (`ApprovalTracker`), standalone `ApprovalDetailScreen` with approve/deny + confirmation dialog, navigation route

Closes #166, closes #167, closes #7

## Test plan

- [ ] Build with network access (first time downloads `work-runtime-ktx:2.10.1`)
- [ ] Connect to AAP 2.6 (aaplm.ansible.ar), create workflow with approval node, launch it
- [ ] Ask Jane "list pending approvals" — verify read tool returns results
- [ ] Ask Jane "approve the pending workflow" — verify confirmation card appears
- [ ] Tap Approve — verify POST succeeds, workflow continues
- [ ] Test Deny path via chat
- [ ] Test existing destructive tools (`launch_job`) — verify they now also show confirmation card
- [ ] Wait for WorkManager poll (or force via `adb shell am broadcast`) — verify notification appears
- [ ] Tap notification — verify Approval Detail screen opens with correct data
- [ ] Approve/Deny from detail screen — verify action succeeds
- [ ] Edge: no pending approvals → graceful empty state
- [ ] Edge: stop generation while confirmation pending → no deadlock

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>