### PR TITLE
Use AAP MCP server toolset-specific endpoints

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -199,6 +199,8 @@ class ToolRouter {
             "security_compliance" to setOf(Category.SECURITY),
             "platform_configuration" to setOf(Category.CONFIGURATION),
             "event_management" to setOf(Category.EDA),
+            "integration" to setOf(Category.CONFIGURATION, Category.SECURITY, Category.USERS),
+            "developer_integration" to setOf(Category.JOBS, Category.MONITORING),
         )
 
         fun stem(word: String): String {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -195,6 +195,9 @@ class ToolRouter {
             "job_management" to setOf(Category.JOBS),
             "inventory_management" to setOf(Category.INVENTORY),
             "system_monitoring" to setOf(Category.MONITORING),
+            "user_management" to setOf(Category.USERS),
+            "security_compliance" to setOf(Category.SECURITY),
+            "platform_configuration" to setOf(Category.CONFIGURATION),
         )
 
         fun stem(word: String): String {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.assistant.engine
 
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.McpTool
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.model.McpServerConfig
@@ -190,6 +191,12 @@ class ToolRouter {
             "any", "been"
         )
 
+        private val TOOLSET_CATEGORY_MAP = mapOf(
+            "job_management" to setOf(Category.JOBS),
+            "inventory_management" to setOf(Category.INVENTORY),
+            "system_monitoring" to setOf(Category.MONITORING),
+        )
+
         fun stem(word: String): String {
             val result = word
                 .removeSuffix("ies").let { if (it != word) "${it}y" else it }
@@ -258,11 +265,18 @@ class ToolRouter {
         }
 
         val filteredMcp = mcpTools.filter { tool ->
-            val resource = tool.spec.name
-                .substringAfter(".")
-                .substringBeforeLast("_")
-            val matchesCategory = resource in matchedPrefixes
             val isEnabled = isToolEnabled(tool.spec.name, ToolSource.MCP)
+
+            val toolToolset = (tool as? McpTool)?.toolset
+            val toolsetCategories = toolToolset?.let { TOOLSET_CATEGORY_MAP[it] }
+            val matchesCategory = if (toolsetCategories != null) {
+                matchedCategories.any { it in toolsetCategories }
+            } else {
+                val resource = tool.spec.name
+                    .substringAfter(".")
+                    .substringBeforeLast("_")
+                resource in matchedPrefixes
+            }
 
             val passesReadOnly = if (readOnlyLabels.isNotEmpty()) {
                 val serverLabel = tool.spec.description

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -198,6 +198,7 @@ class ToolRouter {
             "user_management" to setOf(Category.USERS),
             "security_compliance" to setOf(Category.SECURITY),
             "platform_configuration" to setOf(Category.CONFIGURATION),
+            "event_management" to setOf(Category.EDA),
         )
 
         fun stem(word: String): String {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
@@ -13,7 +13,8 @@ import java.net.SocketTimeoutException
 class McpTool(
     private val client: McpClient,
     private val mcpToolDef: McpToolDefinition,
-    private val serverLabel: String
+    private val serverLabel: String,
+    val toolset: String? = null
 ) : Tool {
 
     companion object {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
@@ -19,7 +19,7 @@ class McpTool(
 
     companion object {
         const val MAX_PAGE_SIZE = 10
-        private const val MAX_DESCRIPTION_CHARS = 120
+        private const val MAX_DESCRIPTION_CHARS = 300
     }
 
     override val spec: ToolSpec = ToolSpec(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/AapInstance.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/model/AapInstance.kt
@@ -10,7 +10,8 @@ data class McpServerConfig(
     val enabled: Boolean = true,
     val isAutoDetected: Boolean = false,
     val useInstanceAuth: Boolean = true,
-    val readOnly: Boolean = false
+    val readOnly: Boolean = false,
+    val toolset: String? = null
 )
 
 data class AapInstance(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManager.kt
@@ -56,7 +56,7 @@ class McpServerManager(
             clients[config.label] = client
 
             val tools = client.tools.value.map { toolDef ->
-                McpTool(client, toolDef, config.label)
+                McpTool(client, toolDef, config.label, config.toolset)
             }
             synchronized(mcpTools) { mcpTools.addAll(tools) }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -227,6 +227,18 @@ class SettingsViewModel(
                         url = "$base/system_monitoring/mcp", label = "Monitoring",
                         isAutoDetected = true, readOnly = true, toolset = "system_monitoring"
                     ),
+                    McpServerConfig(
+                        url = "$base/user_management/mcp", label = "Users",
+                        isAutoDetected = true, readOnly = true, toolset = "user_management"
+                    ),
+                    McpServerConfig(
+                        url = "$base/security_compliance/mcp", label = "Security",
+                        isAutoDetected = true, readOnly = true, toolset = "security_compliance"
+                    ),
+                    McpServerConfig(
+                        url = "$base/platform_configuration/mcp", label = "Configuration",
+                        isAutoDetected = true, readOnly = true, toolset = "platform_configuration"
+                    ),
                 )
             } else {
                 instance.mcpServerUrls

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -243,6 +243,14 @@ class SettingsViewModel(
                         url = "$base/event_management/mcp", label = "EDA",
                         isAutoDetected = true, readOnly = true, toolset = "event_management"
                     ),
+                    McpServerConfig(
+                        url = "$base/integration/mcp", label = "Integration",
+                        isAutoDetected = true, readOnly = true, toolset = "integration"
+                    ),
+                    McpServerConfig(
+                        url = "$base/developer_integration/mcp", label = "Developer",
+                        isAutoDetected = true, readOnly = true, toolset = "developer_integration"
+                    ),
                 )
             } else {
                 instance.mcpServerUrls

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -243,14 +243,6 @@ class SettingsViewModel(
                         url = "$base/event_management/mcp", label = "EDA",
                         isAutoDetected = true, readOnly = true, toolset = "event_management"
                     ),
-                    McpServerConfig(
-                        url = "$base/integration/mcp", label = "Integration",
-                        isAutoDetected = true, readOnly = true, toolset = "integration"
-                    ),
-                    McpServerConfig(
-                        url = "$base/developer_integration/mcp", label = "Developer",
-                        isAutoDetected = true, readOnly = true, toolset = "developer_integration"
-                    ),
                 )
             } else {
                 instance.mcpServerUrls

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -239,10 +239,6 @@ class SettingsViewModel(
                         url = "$base/platform_configuration/mcp", label = "Configuration",
                         isAutoDetected = true, readOnly = true, toolset = "platform_configuration"
                     ),
-                    McpServerConfig(
-                        url = "$base/event_management/mcp", label = "EDA",
-                        isAutoDetected = true, readOnly = true, toolset = "event_management"
-                    ),
                 )
             } else {
                 instance.mcpServerUrls

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -239,6 +239,10 @@ class SettingsViewModel(
                         url = "$base/platform_configuration/mcp", label = "Configuration",
                         isAutoDetected = true, readOnly = true, toolset = "platform_configuration"
                     ),
+                    McpServerConfig(
+                        url = "$base/event_management/mcp", label = "EDA",
+                        isAutoDetected = true, readOnly = true, toolset = "event_management"
+                    ),
                 )
             } else {
                 instance.mcpServerUrls

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -212,38 +212,41 @@ class SettingsViewModel(
     fun toggleMcpEnabled(enabled: Boolean) {
         val instance = tokenManager.activeInstance.value ?: return
         viewModelScope.launch {
-            val servers = if (enabled && instance.mcpServerUrls.isNullOrEmpty()) {
-                val base = "${instance.baseUrl.trimEnd('/')}:8448"
-                listOf(
-                    McpServerConfig(
-                        url = "$base/job_management/mcp", label = "Jobs",
-                        isAutoDetected = true, readOnly = true, toolset = "job_management"
-                    ),
-                    McpServerConfig(
-                        url = "$base/inventory_management/mcp", label = "Inventory",
-                        isAutoDetected = true, readOnly = true, toolset = "inventory_management"
-                    ),
-                    McpServerConfig(
-                        url = "$base/system_monitoring/mcp", label = "Monitoring",
-                        isAutoDetected = true, readOnly = true, toolset = "system_monitoring"
-                    ),
-                    McpServerConfig(
-                        url = "$base/user_management/mcp", label = "Users",
-                        isAutoDetected = true, readOnly = true, toolset = "user_management"
-                    ),
-                    McpServerConfig(
-                        url = "$base/security_compliance/mcp", label = "Security",
-                        isAutoDetected = true, readOnly = true, toolset = "security_compliance"
-                    ),
-                    McpServerConfig(
-                        url = "$base/platform_configuration/mcp", label = "Configuration",
-                        isAutoDetected = true, readOnly = true, toolset = "platform_configuration"
-                    ),
-                )
-            } else {
-                instance.mcpServerUrls
+            if (!enabled) {
+                tokenManager.updateMcpConfig(instance.id, false, null)
+                return@launch
             }
-            tokenManager.updateMcpConfig(instance.id, enabled, if (enabled) servers else null)
+            val base = "${instance.baseUrl.trimEnd('/')}:8448"
+            val manualServers = instance.mcpServerUrls
+                ?.filter { !it.isAutoDetected }
+                ?: emptyList()
+            val autoDetected = listOf(
+                McpServerConfig(
+                    url = "$base/job_management/mcp", label = "Jobs",
+                    isAutoDetected = true, readOnly = true, toolset = "job_management"
+                ),
+                McpServerConfig(
+                    url = "$base/inventory_management/mcp", label = "Inventory",
+                    isAutoDetected = true, readOnly = true, toolset = "inventory_management"
+                ),
+                McpServerConfig(
+                    url = "$base/system_monitoring/mcp", label = "Monitoring",
+                    isAutoDetected = true, readOnly = true, toolset = "system_monitoring"
+                ),
+                McpServerConfig(
+                    url = "$base/user_management/mcp", label = "Users",
+                    isAutoDetected = true, readOnly = true, toolset = "user_management"
+                ),
+                McpServerConfig(
+                    url = "$base/security_compliance/mcp", label = "Security",
+                    isAutoDetected = true, readOnly = true, toolset = "security_compliance"
+                ),
+                McpServerConfig(
+                    url = "$base/platform_configuration/mcp", label = "Configuration",
+                    isAutoDetected = true, readOnly = true, toolset = "platform_configuration"
+                ),
+            )
+            tokenManager.updateMcpConfig(instance.id, true, manualServers + autoDetected)
         }
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -215,7 +215,18 @@ class SettingsViewModel(
             val servers = if (enabled && instance.mcpServerUrls.isNullOrEmpty()) {
                 val base = "${instance.baseUrl.trimEnd('/')}:8448"
                 listOf(
-                    McpServerConfig(url = "$base/mcp", label = "aap", isAutoDetected = true, readOnly = true)
+                    McpServerConfig(
+                        url = "$base/job_management/mcp", label = "Jobs",
+                        isAutoDetected = true, readOnly = true, toolset = "job_management"
+                    ),
+                    McpServerConfig(
+                        url = "$base/inventory_management/mcp", label = "Inventory",
+                        isAutoDetected = true, readOnly = true, toolset = "inventory_management"
+                    ),
+                    McpServerConfig(
+                        url = "$base/system_monitoring/mcp", label = "Monitoring",
+                        isAutoDetected = true, readOnly = true, toolset = "system_monitoring"
+                    ),
                 )
             } else {
                 instance.mcpServerUrls
@@ -224,11 +235,11 @@ class SettingsViewModel(
         }
     }
 
-    fun addMcpServer(url: String, label: String) {
+    fun addMcpServer(url: String, label: String, toolset: String? = null) {
         val instance = tokenManager.activeInstance.value ?: return
         viewModelScope.launch {
             val current = instance.mcpServerUrls?.toMutableList() ?: mutableListOf()
-            current.add(McpServerConfig(url = url.trimEnd('/'), label = label))
+            current.add(McpServerConfig(url = url.trimEnd('/'), label = label, toolset = toolset))
             tokenManager.updateMcpConfig(instance.id, true, current)
         }
     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
@@ -80,7 +80,7 @@ fun SettingsScreen(
                     onFetchModels = { url, key -> viewModel.fetchAvailableModels(url, key) },
                     onClearFetchedModels = { viewModel.clearFetchedModels() },
                     onToggleMcp = { viewModel.toggleMcpEnabled(it) },
-                    onAddMcpServer = { url, label -> viewModel.addMcpServer(url, label) },
+                    onAddMcpServer = { url, label, toolset -> viewModel.addMcpServer(url, label, toolset) },
                     onRemoveMcpServer = { viewModel.removeMcpServer(it) },
                     onToggleReadOnly = { url, readOnly -> viewModel.toggleServerReadOnly(url, readOnly) },
                     modifier = Modifier
@@ -111,7 +111,7 @@ private fun SettingsContent(
     onFetchModels: (String, String?) -> Unit,
     onClearFetchedModels: () -> Unit,
     onToggleMcp: (Boolean) -> Unit,
-    onAddMcpServer: (String, String) -> Unit,
+    onAddMcpServer: (String, String, String?) -> Unit,
     onRemoveMcpServer: (String) -> Unit,
     onToggleReadOnly: (String, Boolean) -> Unit,
     modifier: Modifier = Modifier

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolsTab.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolsTab.kt
@@ -179,7 +179,12 @@ fun ToolsTab(
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     OutlinedButton(
-                        onClick = { showAddServer = false },
+                        onClick = {
+                            newServerUrl = ""
+                            newServerLabel = ""
+                            newServerToolset = ""
+                            showAddServer = false
+                        },
                         modifier = Modifier.weight(1f)
                     ) { Text("Cancel") }
                     Button(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolsTab.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolsTab.kt
@@ -45,7 +45,7 @@ fun ToolsTab(
     mcpServers: List<McpServerConfig>,
     connections: Map<String, McpConnectionState>,
     onToggleMcp: (Boolean) -> Unit,
-    onAddMcpServer: (url: String, label: String) -> Unit,
+    onAddMcpServer: (url: String, label: String, toolset: String?) -> Unit,
     onRemoveMcpServer: (url: String) -> Unit,
     onToggleReadOnly: (url: String, readOnly: Boolean) -> Unit,
     modifier: Modifier = Modifier
@@ -53,6 +53,7 @@ fun ToolsTab(
     var showAddServer by remember { mutableStateOf(false) }
     var newServerUrl by remember { mutableStateOf("") }
     var newServerLabel by remember { mutableStateOf("") }
+    var newServerToolset by remember { mutableStateOf("") }
 
     Column(
         modifier = modifier
@@ -101,6 +102,13 @@ fun ToolsTab(
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
+                        if (server.toolset != null) {
+                            Text(
+                                "Toolset: ${server.toolset}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.tertiary
+                            )
+                        }
                     }
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -158,6 +166,14 @@ fun ToolsTab(
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true
                 )
+                OutlinedTextField(
+                    value = newServerToolset,
+                    onValueChange = { newServerToolset = it },
+                    label = { Text("Toolset (optional)") },
+                    placeholder = { Text("job_management") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -168,9 +184,13 @@ fun ToolsTab(
                     ) { Text("Cancel") }
                     Button(
                         onClick = {
-                            onAddMcpServer(newServerUrl, newServerLabel)
+                            onAddMcpServer(
+                                newServerUrl, newServerLabel,
+                                newServerToolset.ifBlank { null }
+                            )
                             newServerUrl = ""
                             newServerLabel = ""
+                            newServerToolset = ""
                             showAddServer = false
                         },
                         modifier = Modifier.weight(1f),


### PR DESCRIPTION
## Summary

- Add `toolset` field to `McpServerConfig` for tracking which AAP MCP toolset a server config targets
- Auto-detect creates 3 per-toolset configs (`job_management`, `inventory_management`, `system_monitoring`) instead of 1 catch-all `/mcp`, reducing tool count from ~50-100 to ~4-15 per connection
- `ToolRouter` uses toolset as a category routing hint — tools from known toolsets skip prefix-matching
- Manual server add form includes optional "Toolset" field; server cards display toolset metadata

## Test plan

- [ ] Build succeeds (`./gradlew assembleDebug`)
- [ ] All existing tests pass (`./gradlew test`)
- [ ] Toggle MCP off and on — verify 3 per-toolset server configs appear (Jobs, Inventory, Monitoring)
- [ ] If AAP MCP server has toolsets configured: verify connections succeed with fewer tools
- [ ] If server doesn't have toolsets: verify error icons appear, user can manually add `/mcp` catch-all
- [ ] Manual add: fill URL + Label + Toolset, verify `toolset` shows on card
- [ ] Backup/restore: export, verify JSON contains `toolset` fields, re-import

Closes #52

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>