### PR TITLE
Fix security: logging, MCP token leakage, LLM key encryption

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/AssistantModule.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/AssistantModule.kt
@@ -54,7 +54,8 @@ val assistantModule = module {
     single(named("llm")) {
         OkHttpClient.Builder()
             .addInterceptor(HttpLoggingInterceptor().apply {
-                level = HttpLoggingInterceptor.Level.BODY
+                level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
+                        else HttpLoggingInterceptor.Level.NONE
             })
             .build()
     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/AssistantModule.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/AssistantModule.kt
@@ -9,6 +9,7 @@ import io.github.leogallego.ansiblejane.network.CertTrustManager
 import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
 import io.github.leogallego.ansiblejane.network.networkJson
 import io.github.leogallego.ansiblejane.presentation.settings.SettingsViewModel
+import io.github.leogallego.ansiblejane.BuildConfig
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.koin.core.module.dsl.viewModel
@@ -19,16 +20,21 @@ import org.koin.dsl.module
 val assistantModule = module {
     single {
         McpServerManager(
-            httpClientFactory = { instance ->
+            httpClientFactory = { instance, serverConfig ->
                 OkHttpClient.Builder()
-                    .addInterceptor(
-                        AuthInterceptor(
-                            tokenProvider = { instance.token },
-                            instanceIdProvider = { instance.id }
-                        )
-                    )
+                    .apply {
+                        if (serverConfig.useInstanceAuth) {
+                            addInterceptor(
+                                AuthInterceptor(
+                                    tokenProvider = { instance.token },
+                                    instanceIdProvider = { instance.id }
+                                )
+                            )
+                        }
+                    }
                     .addInterceptor(HttpLoggingInterceptor().apply {
-                        level = HttpLoggingInterceptor.Level.BODY
+                        level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
+                                else HttpLoggingInterceptor.Level.NONE
                     })
                     .apply {
                         if (instance.trustSelfSigned) {
@@ -43,7 +49,7 @@ val assistantModule = module {
         )
     }
 
-    single { AssistantRepository(get()) } bind IAssistantRepository::class
+    single { AssistantRepository(get(), get()) } bind IAssistantRepository::class
 
     single(named("llm")) {
         OkHttpClient.Builder()

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
@@ -10,6 +10,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
 import io.github.leogallego.ansiblejane.assistant.engine.Role
 import io.github.leogallego.ansiblejane.assistant.data.KnownProvider
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -25,7 +26,10 @@ private val Context.assistantDataStore: DataStore<Preferences> by preferencesDat
     name = "assistant_config"
 )
 
-class AssistantRepository(private val context: Context) : IAssistantRepository {
+class AssistantRepository(
+    private val context: Context,
+    private val tokenManager: ITokenManager
+) : IAssistantRepository {
 
     private val messages = mutableListOf<ChatMessage>()
     private val json = Json { ignoreUnknownKeys = true }
@@ -62,8 +66,17 @@ class AssistantRepository(private val context: Context) : IAssistantRepository {
         val providerKey = when (config) {
             is LlmProviderConfig.OpenAiCompatible -> KnownProvider.fromUrl(config.url).name
         }
-        val allConfigs = loadAllLlmConfigs().toMutableMap()
-        allConfigs[providerKey] = config
+
+        val apiKey = when (config) {
+            is LlmProviderConfig.OpenAiCompatible -> config.apiKey
+        }
+        if (!apiKey.isNullOrBlank()) {
+            tokenManager.saveLlmApiKey(providerKey, apiKey)
+        }
+        val strippedConfig = stripApiKey(config)
+
+        val allConfigs = loadAllLlmConfigsRaw().toMutableMap()
+        allConfigs[providerKey] = strippedConfig
         val mapJson = json.encodeToString(
             MapSerializer(String.serializer(), LlmProviderConfig.serializer()),
             allConfigs
@@ -77,13 +90,23 @@ class AssistantRepository(private val context: Context) : IAssistantRepository {
     override suspend fun loadLlmConfig(): LlmProviderConfig? {
         val prefs = context.assistantDataStore.data.first()
         val activeProvider = prefs[KEY_ACTIVE_PROVIDER] ?: return null
-        return loadAllLlmConfigs()[activeProvider]
+        val config = loadAllLlmConfigsRaw()[activeProvider] ?: return null
+        return mergeApiKey(activeProvider, config)
     }
 
     override suspend fun saveAllLlmConfigs(configs: Map<String, LlmProviderConfig>) {
+        for ((key, config) in configs) {
+            val apiKey = when (config) {
+                is LlmProviderConfig.OpenAiCompatible -> config.apiKey
+            }
+            if (!apiKey.isNullOrBlank()) {
+                tokenManager.saveLlmApiKey(key, apiKey)
+            }
+        }
+        val stripped = configs.mapValues { (_, config) -> stripApiKey(config) }
         val mapJson = json.encodeToString(
             MapSerializer(String.serializer(), LlmProviderConfig.serializer()),
-            configs
+            stripped
         )
         context.assistantDataStore.edit { prefs ->
             prefs[KEY_LLM_CONFIGS] = mapJson
@@ -91,6 +114,15 @@ class AssistantRepository(private val context: Context) : IAssistantRepository {
     }
 
     override suspend fun loadAllLlmConfigs(): Map<String, LlmProviderConfig> {
+        val raw = loadAllLlmConfigsRaw()
+        val keys = tokenManager.loadAllLlmApiKeys()
+        return raw.mapValues { (providerKey, config) ->
+            val apiKey = keys[providerKey]
+            if (apiKey != null) mergeApiKeyValue(config, apiKey) else config
+        }
+    }
+
+    private suspend fun loadAllLlmConfigsRaw(): Map<String, LlmProviderConfig> {
         val prefs = context.assistantDataStore.data.first()
         val mapJson = prefs[KEY_LLM_CONFIGS] ?: return emptyMap()
         return try {
@@ -104,6 +136,21 @@ class AssistantRepository(private val context: Context) : IAssistantRepository {
         }
     }
 
+    private suspend fun mergeApiKey(providerKey: String, config: LlmProviderConfig): LlmProviderConfig {
+        val apiKey = tokenManager.loadLlmApiKey(providerKey)
+        return if (apiKey != null) mergeApiKeyValue(config, apiKey) else config
+    }
+
+    private fun mergeApiKeyValue(config: LlmProviderConfig, apiKey: String): LlmProviderConfig =
+        when (config) {
+            is LlmProviderConfig.OpenAiCompatible -> config.copy(apiKey = apiKey)
+        }
+
+    private fun stripApiKey(config: LlmProviderConfig): LlmProviderConfig =
+        when (config) {
+            is LlmProviderConfig.OpenAiCompatible -> config.copy(apiKey = null)
+        }
+
     override val activeConfigFlow: Flow<LlmProviderConfig?> =
         context.assistantDataStore.data.map { prefs ->
             val key = prefs[KEY_ACTIVE_PROVIDER] ?: return@map null
@@ -113,7 +160,9 @@ class AssistantRepository(private val context: Context) : IAssistantRepository {
                     MapSerializer(String.serializer(), LlmProviderConfig.serializer()),
                     mapJson
                 )
-                configs[key]
+                val config = configs[key] ?: return@map null
+                val apiKey = tokenManager.loadLlmApiKey(key)
+                if (apiKey != null) mergeApiKeyValue(config, apiKey) else config
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to deserialize active config from flow", e)
                 null
@@ -124,10 +173,15 @@ class AssistantRepository(private val context: Context) : IAssistantRepository {
         context.assistantDataStore.data.map { prefs ->
             val mapJson = prefs[KEY_LLM_CONFIGS] ?: return@map emptyMap()
             try {
-                json.decodeFromString(
+                val configs = json.decodeFromString(
                     MapSerializer(String.serializer(), LlmProviderConfig.serializer()),
                     mapJson
                 )
+                val keys = tokenManager.loadAllLlmApiKeys()
+                configs.mapValues { (providerKey, config) ->
+                    val apiKey = keys[providerKey]
+                    if (apiKey != null) mergeApiKeyValue(config, apiKey) else config
+                }
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to deserialize saved configs from flow", e)
                 emptyMap()

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/AuthRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/AuthRepository.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
+import io.github.leogallego.ansiblejane.BuildConfig
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -153,7 +154,8 @@ class AuthRepository(
         val builder = OkHttpClient.Builder()
             .addInterceptor(AuthInterceptor { token })
             .addInterceptor(HttpLoggingInterceptor().apply {
-                level = HttpLoggingInterceptor.Level.BODY
+                level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
+                        else HttpLoggingInterceptor.Level.NONE
             })
 
         if (trustSelfSigned) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/ITokenManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/ITokenManager.kt
@@ -49,4 +49,9 @@ interface ITokenManager {
     )
 
     suspend fun clearCredentials()
+
+    suspend fun saveLlmApiKey(providerKey: String, apiKey: String)
+    suspend fun loadLlmApiKey(providerKey: String): String?
+    suspend fun loadAllLlmApiKeys(): Map<String, String>
+    suspend fun clearLlmApiKeys()
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
@@ -412,6 +412,7 @@ class TokenManager(private val context: Context) : ITokenManager {
      * Clear all instances (full logout).
      */
     override suspend fun clearCredentials() {
+        clearLlmApiKeys()
         context.credentialsDataStore.edit { it.clear() }
         _instances.value = emptyList()
         _activeInstance.value = null

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.nio.charset.StandardCharsets
@@ -85,6 +87,7 @@ class TokenManager(private val context: Context) : ITokenManager {
 
         // Multi-instance key
         val KEY_INSTANCES_JSON = stringPreferencesKey("instances_json")
+        val KEY_LLM_API_KEYS = stringPreferencesKey("llm_api_keys")
     }
 
     private fun encrypt(value: String): String {
@@ -357,6 +360,52 @@ class TokenManager(private val context: Context) : ITokenManager {
             } else serialized
         }
         writeState(state.copy(instances = updatedInstances))
+    }
+
+    private suspend fun readEncryptedLlmApiKeys(): Map<String, String> {
+        val prefs = context.credentialsDataStore.data.first()
+        val keysJson = prefs[KEY_LLM_API_KEYS] ?: return emptyMap()
+        return try {
+            json.decodeFromString(
+                MapSerializer(String.serializer(), String.serializer()),
+                keysJson
+            )
+        } catch (_: Exception) {
+            emptyMap()
+        }
+    }
+
+    private suspend fun writeEncryptedLlmApiKeys(keys: Map<String, String>) {
+        val keysJson = json.encodeToString(
+            MapSerializer(String.serializer(), String.serializer()),
+            keys
+        )
+        context.credentialsDataStore.edit { prefs ->
+            prefs[KEY_LLM_API_KEYS] = keysJson
+        }
+    }
+
+    override suspend fun saveLlmApiKey(providerKey: String, apiKey: String) {
+        val keys = readEncryptedLlmApiKeys().toMutableMap()
+        keys[providerKey] = encrypt(apiKey)
+        writeEncryptedLlmApiKeys(keys)
+    }
+
+    override suspend fun loadLlmApiKey(providerKey: String): String? {
+        val encrypted = readEncryptedLlmApiKeys()[providerKey] ?: return null
+        return try { decrypt(encrypted) } catch (_: Exception) { null }
+    }
+
+    override suspend fun loadAllLlmApiKeys(): Map<String, String> {
+        return readEncryptedLlmApiKeys().mapNotNull { (key, encrypted) ->
+            try { key to decrypt(encrypted) } catch (_: Exception) { null }
+        }.toMap()
+    }
+
+    override suspend fun clearLlmApiKeys() {
+        context.credentialsDataStore.edit { prefs ->
+            prefs.remove(KEY_LLM_API_KEYS)
+        }
     }
 
     /**

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/AapApiProvider.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/AapApiProvider.kt
@@ -4,6 +4,7 @@ import io.github.leogallego.ansiblejane.data.TokenManager
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import io.github.leogallego.ansiblejane.BuildConfig
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -98,7 +99,8 @@ class AapApiProvider(
                 instanceIdProvider = { instanceId }
             ))
             .addInterceptor(HttpLoggingInterceptor().apply {
-                level = HttpLoggingInterceptor.Level.BODY
+                level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
+                        else HttpLoggingInterceptor.Level.NONE
             })
 
         if (trustSelfSigned) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/NetworkModule.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/NetworkModule.kt
@@ -1,6 +1,7 @@
 package io.github.leogallego.ansiblejane.network
 
 import kotlinx.serialization.json.Json
+import io.github.leogallego.ansiblejane.BuildConfig
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.koin.dsl.bind
@@ -25,7 +26,8 @@ val networkModule = module {
     factory {
         OkHttpClient.Builder()
             .addInterceptor(HttpLoggingInterceptor().apply {
-                level = HttpLoggingInterceptor.Level.BODY
+                level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
+                        else HttpLoggingInterceptor.Level.NONE
             })
             .build()
     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManager.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 
 class McpServerManager(
-    private val httpClientFactory: (AapInstance) -> OkHttpClient,
+    private val httpClientFactory: (AapInstance, McpServerConfig) -> OkHttpClient,
     private val json: Json
 ) {
     private val _connections = MutableStateFlow<Map<String, McpConnectionState>>(emptyMap())
@@ -28,11 +28,10 @@ class McpServerManager(
         val configs = instance.mcpServerUrls?.filter { it.enabled } ?: return
         if (configs.isEmpty()) return
 
-        val httpClient = httpClientFactory(instance)
-
         coroutineScope {
             configs.map { config ->
                 async {
+                    val httpClient = httpClientFactory(instance, config)
                     connectServer(config, httpClient)
                 }
             }.forEach { deferred ->

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
@@ -109,6 +109,21 @@ class FakeTokenManager : ITokenManager {
     override suspend fun clearCredentials() {
         _instances.value = emptyList()
         _activeInstance.value = null
+        clearLlmApiKeys()
+    }
+
+    private val llmApiKeys = mutableMapOf<String, String>()
+
+    override suspend fun saveLlmApiKey(providerKey: String, apiKey: String) {
+        llmApiKeys[providerKey] = apiKey
+    }
+
+    override suspend fun loadLlmApiKey(providerKey: String): String? = llmApiKeys[providerKey]
+
+    override suspend fun loadAllLlmApiKeys(): Map<String, String> = llmApiKeys.toMap()
+
+    override suspend fun clearLlmApiKeys() {
+        llmApiKeys.clear()
     }
 
     fun setInstances(list: List<AapInstance>) {

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
@@ -52,7 +52,7 @@ class SettingsViewModelTest {
         fakeUserPreferences = FakeUserPreferencesRepository()
         fakeAssistantRepo = FakeAssistantRepository()
         mcpServerManager = McpServerManager(
-            httpClientFactory = { OkHttpClient() },
+            httpClientFactory = { _, _ -> OkHttpClient() },
             json = json
         )
     }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
@@ -41,7 +41,7 @@ class SettingsScreenTest {
     private val fakeAssistantRepo = FakeAssistantRepository()
     private val json = Json { ignoreUnknownKeys = true }
     private val mcpServerManager = McpServerManager(
-        httpClientFactory = { OkHttpClient() },
+        httpClientFactory = { _, _ -> OkHttpClient() },
         json = json
     )
 


### PR DESCRIPTION
## Summary

- Gate `HttpLoggingInterceptor.Level.BODY` behind `BuildConfig.DEBUG` in all 5 OkHttpClient builders. Release builds use `Level.NONE` — no bearer tokens or payloads in logcat.
- Honor `McpServerConfig.useInstanceAuth` in `McpServerManager`. AAP token is only attached to MCP servers that opt in. Non-AAP endpoints (e.g., community tool servers) no longer receive the AAP bearer token.
- Encrypt LLM API keys via Tink `Aead` (same keystore used for AAP tokens). `TokenManager` stores encrypted keys; `AssistantRepository` strips keys before writing to its plain DataStore and merges decrypted keys on read.

## Test plan

- [ ] Verify logcat shows no request/response bodies in release build
- [ ] Add a non-AAP MCP server with `useInstanceAuth: false` — confirm no `Authorization` header is sent
- [ ] Save an LLM config with API key, verify credentials DataStore contains encrypted (not plaintext) key
- [ ] Load config, verify decrypted key works for LLM requests
- [ ] Backup/restore with LLM configs — keys survive round-trip

Fixes #176

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>