### PR TITLE
Fix write safety: MCP confirmation, cache, read-only filter, arg validation

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
@@ -176,7 +176,7 @@ class ChatEngine(
                         emit(ChatEvent.ToolExecuting(toolCall.tool, argsJson))
 
                         val tool = toolExecutor.findTool(toolCall.tool)
-                        val toolResult = if (tool != null && tool.destructive && onConfirmationRequired != null) {
+                        val toolResult = if (tool != null && tool.isDestructive && onConfirmationRequired != null) {
                             val description = descriptionForConfirmation(toolCall.tool, argsJson)
                             emit(ChatEvent.ConfirmationRequired(toolCall.tool, argsJson, description))
                             val approved = onConfirmationRequired(toolCall.tool, description, argsJson)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
@@ -12,7 +12,6 @@ import io.github.leogallego.ansiblejane.assistant.llm.LlmRateLimitException
 import io.github.leogallego.ansiblejane.assistant.llm.LlmServerException
 import io.github.leogallego.ansiblejane.assistant.llm.LlmTimeoutException
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
-import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
 import io.github.leogallego.ansiblejane.assistant.tools.toToolDescriptor
 import kotlinx.coroutines.CancellationException
@@ -177,7 +176,7 @@ class ChatEngine(
                         emit(ChatEvent.ToolExecuting(toolCall.tool, argsJson))
 
                         val tool = toolExecutor.findTool(toolCall.tool)
-                        val toolResult = if (tool is LocalTool && tool.destructive && onConfirmationRequired != null) {
+                        val toolResult = if (tool != null && tool.destructive && onConfirmationRequired != null) {
                             val description = descriptionForConfirmation(toolCall.tool, argsJson)
                             emit(ChatEvent.ConfirmationRequired(toolCall.tool, argsJson, description))
                             val approved = onConfirmationRequired(toolCall.tool, description, argsJson)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
@@ -35,7 +35,7 @@ class ToolExecutor(
                 )
             }
 
-        val isDestructive = tool.destructive
+        val isDestructive = tool.isDestructive
         val cacheKey = "${toolCall.tool}:${toolCall.args.hashCode()}"
         if (!isDestructive) {
             val cached = resultCache[cacheKey]

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
@@ -3,7 +3,6 @@ package io.github.leogallego.ansiblejane.assistant.engine
 import ai.koog.prompt.message.MessagePart
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 import io.github.leogallego.ansiblejane.assistant.tools.ErrorType
-import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
 import kotlinx.coroutines.TimeoutCancellationException
@@ -36,7 +35,7 @@ class ToolExecutor(
                 )
             }
 
-        val isDestructive = tool is LocalTool && tool.destructive
+        val isDestructive = tool.destructive
         val cacheKey = "${toolCall.tool}:${toolCall.args.hashCode()}"
         if (!isDestructive) {
             val cached = resultCache[cacheKey]
@@ -49,8 +48,12 @@ class ToolExecutor(
         val argsJson = try {
             val parsed = json.parseToJsonElement(toolCall.args)
             if (parsed is JsonObject) parsed else JsonObject(emptyMap())
-        } catch (_: Exception) {
-            JsonObject(emptyMap())
+        } catch (e: Exception) {
+            Log.w(TAG, "EXEC: malformed args for ${toolCall.tool}: ${e.message}")
+            return ToolResult(
+                success = false,
+                data = "Invalid tool arguments: ${e.message}"
+            )
         }
 
         Log.d(TAG, "EXEC: ${toolCall.tool}(${toolCall.args.take(200)})")

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -342,7 +342,7 @@ class ToolRouter {
             var score = overlap * 10
             if (tool.spec.name.contains("list") || tool.spec.name.contains("ping")) score += 3
             if (tool.spec.name.contains("get") || tool.spec.name.contains("read")) score += 1
-            if (overlap > 0 && tool.destructive) score -= 5
+            if (overlap > 0 && tool.isDestructive) score -= 5
             tool to score
         }
         Log.d(TAG, "SCORES: ${scored.map { "${it.first.spec.name}=${it.second}" }}")

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -206,7 +206,9 @@ class ToolRouter {
 
         private val WRITE_ACTIONS = setOf(
             "_create", "_update", "_delete",
-            "_launch", "_relaunch", "_cancel"
+            "_launch", "_relaunch", "_cancel",
+            "_partial_update", "_approve", "_deny",
+            "_copy", "_sync"
         )
 
         private val STOP_WORDS = setOf(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -204,12 +204,7 @@ class ToolRouter {
         private val MCP_TOOLS_WITH_LOCAL_OVERLAP: Set<String> =
             OVERLAP_MAPPING.values.flatten().toSet()
 
-        private val WRITE_ACTIONS = setOf(
-            "_create", "_update", "_delete",
-            "_launch", "_relaunch", "_cancel",
-            "_partial_update", "_approve", "_deny",
-            "_copy", "_sync"
-        )
+        private val WRITE_ACTIONS = Tool.WRITE_SUFFIXES
 
         private val STOP_WORDS = setOf(
             "list", "get", "show", "what", "are", "the", "is", "a", "an",
@@ -347,7 +342,7 @@ class ToolRouter {
             var score = overlap * 10
             if (tool.spec.name.contains("list") || tool.spec.name.contains("ping")) score += 3
             if (tool.spec.name.contains("get") || tool.spec.name.contains("read")) score += 1
-            if (overlap > 0 && tool is LocalTool && tool.destructive) score -= 5
+            if (overlap > 0 && tool.destructive) score -= 5
             tool to score
         }
         Log.d(TAG, "SCORES: ${scored.map { "${it.first.spec.name}=${it.second}" }}")

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/AapLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/AapLocalTool.kt
@@ -25,7 +25,7 @@ abstract class AapLocalTool<TArgs : Any>(
     private val argsSerializer: KSerializer<TArgs>,
     name: String,
     description: String,
-    override val destructive: Boolean = false
+    override val isDestructive: Boolean = false
 ) : SimpleTool<TArgs>(argsType, name, description), LocalTool {
 
     override val spec: ToolSpec by lazy { descriptorToSpec(descriptor) }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/LocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/LocalTool.kt
@@ -3,6 +3,6 @@ package io.github.leogallego.ansiblejane.assistant.tools
 enum class ToolSource { LOCAL, MCP }
 
 interface LocalTool : Tool {
-    val destructive: Boolean
+    override val destructive: Boolean
         get() = false
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/LocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/LocalTool.kt
@@ -3,6 +3,6 @@ package io.github.leogallego.ansiblejane.assistant.tools
 enum class ToolSource { LOCAL, MCP }
 
 interface LocalTool : Tool {
-    override val destructive: Boolean
+    override val isDestructive: Boolean
         get() = false
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
@@ -23,7 +23,7 @@ class McpTool(
         private val WRITE_SUFFIXES = Tool.WRITE_SUFFIXES
     }
 
-    override val destructive: Boolean =
+    override val isDestructive: Boolean =
         WRITE_SUFFIXES.any { mcpToolDef.name.endsWith(it) }
 
     override val spec: ToolSpec = ToolSpec(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
@@ -20,7 +20,16 @@ class McpTool(
     companion object {
         const val MAX_PAGE_SIZE = 10
         private const val MAX_DESCRIPTION_CHARS = 300
+        private val WRITE_SUFFIXES = setOf(
+            "_create", "_update", "_delete",
+            "_launch", "_relaunch", "_cancel",
+            "_partial_update", "_approve", "_deny",
+            "_copy", "_sync"
+        )
     }
+
+    override val destructive: Boolean =
+        WRITE_SUFFIXES.any { mcpToolDef.name.endsWith(it) }
 
     override val spec: ToolSpec = ToolSpec(
         name = mcpToolDef.name,

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
@@ -20,12 +20,7 @@ class McpTool(
     companion object {
         const val MAX_PAGE_SIZE = 10
         private const val MAX_DESCRIPTION_CHARS = 300
-        private val WRITE_SUFFIXES = setOf(
-            "_create", "_update", "_delete",
-            "_launch", "_relaunch", "_cancel",
-            "_partial_update", "_approve", "_deny",
-            "_copy", "_sync"
-        )
+        private val WRITE_SUFFIXES = Tool.WRITE_SUFFIXES
     }
 
     override val destructive: Boolean =

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolSpec.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolSpec.kt
@@ -10,6 +10,8 @@ data class ToolSpec(
 
 interface Tool {
     val spec: ToolSpec
+    val destructive: Boolean
+        get() = false
     suspend fun execute(args: JsonObject): ToolResult
 }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolSpec.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolSpec.kt
@@ -10,7 +10,7 @@ data class ToolSpec(
 
 interface Tool {
     val spec: ToolSpec
-    val destructive: Boolean
+    val isDestructive: Boolean
         get() = false
     suspend fun execute(args: JsonObject): ToolResult
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolSpec.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolSpec.kt
@@ -13,6 +13,15 @@ interface Tool {
     val destructive: Boolean
         get() = false
     suspend fun execute(args: JsonObject): ToolResult
+
+    companion object {
+        val WRITE_SUFFIXES = setOf(
+            "_create", "_update", "_delete",
+            "_launch", "_relaunch", "_cancel",
+            "_partial_update", "_approve", "_deny",
+            "_copy", "_sync"
+        )
+    }
 }
 
 data class ToolResult(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ApproveWorkflowLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ApproveWorkflowLocalTool.kt
@@ -13,7 +13,7 @@ class ApproveWorkflowLocalTool(
     typeToken<Args>(), Args.serializer(),
     name = "approve_workflow",
     description = "Approve a pending workflow approval step",
-    destructive = true
+    isDestructive = true
 ) {
     @Serializable
     data class Args(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/DenyWorkflowLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/DenyWorkflowLocalTool.kt
@@ -13,7 +13,7 @@ class DenyWorkflowLocalTool(
     typeToken<Args>(), Args.serializer(),
     name = "deny_workflow",
     description = "Deny a pending workflow approval step",
-    destructive = true
+    isDestructive = true
 ) {
     @Serializable
     data class Args(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/LaunchJobLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/LaunchJobLocalTool.kt
@@ -13,7 +13,7 @@ class LaunchJobLocalTool(
     typeToken<Args>(), Args.serializer(),
     name = "launch_job",
     description = "Launch a job template by ID with optional extra variables",
-    destructive = true
+    isDestructive = true
 ) {
     @Serializable
     data class Args(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/LaunchWorkflowLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/LaunchWorkflowLocalTool.kt
@@ -13,7 +13,7 @@ class LaunchWorkflowLocalTool(
     typeToken<Args>(), Args.serializer(),
     name = "launch_workflow",
     description = "Launch a workflow job template by ID with optional extra variables",
-    destructive = true
+    isDestructive = true
 ) {
     @Serializable
     data class Args(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ToggleScheduleLocalTool.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ToggleScheduleLocalTool.kt
@@ -15,7 +15,7 @@ class ToggleScheduleLocalTool(
     typeToken<Args>(), Args.serializer(),
     name = "toggle_schedule",
     description = "Enable or disable a schedule by ID",
-    destructive = true
+    isDestructive = true
 ) {
     @Serializable
     data class Args(

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -24,7 +24,7 @@ class ToolRouterTest {
 
     private fun localTool(name: String, destructive: Boolean = false) = object : LocalTool {
         override val spec = ToolSpec(name, "Local: $name", JsonObject(emptyMap()))
-        override val destructive = destructive
+        override val isDestructive = destructive
         override suspend fun execute(args: JsonObject) = ToolResult(success = true)
     }
 
@@ -204,8 +204,8 @@ class ToolRouterTest {
         val launchTool = all.first { it.first.spec.name == "launch_job" }.first as LocalTool
         val listTool = all.first { it.first.spec.name == "list_jobs" }.first as LocalTool
 
-        assertTrue(launchTool.destructive)
-        assertFalse(listTool.destructive)
+        assertTrue(launchTool.isDestructive)
+        assertFalse(listTool.isDestructive)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add `destructive` property to `Tool` interface — `McpTool` computes it from write-action suffixes at construction time. ChatEngine and ToolExecutor check `tool.destructive` uniformly (no type checks).
- MCP write tools now trigger confirmation prompts and bypass the 2-minute result cache, same as local destructive tools.
- Expand `WRITE_ACTIONS` to include `_partial_update`, `_approve`, `_deny`, `_copy`, `_sync` — read-only MCP servers correctly block these.
- Return validation error for malformed tool arguments instead of silently executing with empty `{}` args.

## Test plan

- [ ] Trigger an MCP write tool (e.g., `controller.schedules_partial_update`) — confirm it asks for user approval
- [ ] Call the same MCP write tool twice — confirm second call actually executes (not cached)
- [ ] Connect a read-only MCP server — verify `_partial_update` and `_approve` tools are filtered out
- [ ] Send a malformed tool call — verify the LLM receives an error message, not empty args execution

Fixes #178

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>