### PR TITLE
Fix PaginationEffect: use snapshotFlow to prevent load-more stall

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/PaginationEffect.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/PaginationEffect.kt
@@ -3,9 +3,9 @@ package io.github.leogallego.ansiblejane.ui.components
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 
 @Composable
 fun PaginationEffect(
@@ -14,14 +14,13 @@ fun PaginationEffect(
     threshold: Int = 3,
     onLoadMore: () -> Unit
 ) {
-    val shouldLoadMore by remember {
-        derivedStateOf {
+    LaunchedEffect(listState) {
+        snapshotFlow {
             val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
             itemCount > threshold && lastVisibleItem >= itemCount - threshold
         }
-    }
-
-    LaunchedEffect(shouldLoadMore) {
-        if (shouldLoadMore) onLoadMore()
+            .distinctUntilChanged()
+            .filter { it }
+            .collect { onLoadMore() }
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/PaginationEffect.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/PaginationEffect.kt
@@ -3,6 +3,8 @@ package io.github.leogallego.ansiblejane.ui.components
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -14,13 +16,15 @@ fun PaginationEffect(
     threshold: Int = 3,
     onLoadMore: () -> Unit
 ) {
-    LaunchedEffect(listState) {
+    val currentOnLoadMore by rememberUpdatedState(onLoadMore)
+
+    LaunchedEffect(listState, itemCount) {
         snapshotFlow {
             val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
             itemCount > threshold && lastVisibleItem >= itemCount - threshold
         }
             .distinctUntilChanged()
             .filter { it }
-            .collect { onLoadMore() }
+            .collect { currentOnLoadMore() }
     }
 }


### PR DESCRIPTION
## Summary

- Replace `LaunchedEffect(shouldLoadMore)` with `snapshotFlow` + `distinctUntilChanged` + `filter` pattern in `PaginationEffect.kt`
- The old approach only re-triggered when the boolean *changed* — if the user stayed near the bottom after a page loaded, `shouldLoadMore` remained `true` and pagination silently stalled
- The new approach continuously observes scroll position and item count via snapshot flow, firing `onLoadMore` each time the bottom threshold is newly crossed

## Test plan

- [ ] Open a screen with 3+ pages of data (templates, jobs, hosts)
- [ ] Scroll to bottom — verify page 2 loads automatically
- [ ] Stay at bottom — verify page 3+ loads without needing to scroll up and back down
- [ ] Verify no duplicate load-more calls while already loading (check logcat)
- [ ] Verify pagination still works correctly on all list screens (templates, workflows, jobs, hosts, inventories, schedules, EDA)

Fixes #186

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>