### PR TITLE
Fix edge-to-edge: remove zeroed contentWindowInsets from MainScreen

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -205,13 +205,13 @@ fun MainScreen(
                 }
             }
         },
-        snackbarHost = { SnackbarHost(snackbarHostState) },
-        contentWindowInsets = WindowInsets(0, 0, 0, 0)
+        snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
+                .consumeWindowInsets(padding)
         ) {
             if (selectedTab.segments.size > 1) {
                 SingleChoiceSegmentedButtonRow(


### PR DESCRIPTION
## Summary

- Remove `contentWindowInsets = WindowInsets(0, 0, 0, 0)` from MainScreen's Scaffold — it was disabling all system bar inset handling
- Add `.consumeWindowInsets(padding)` to the content Column so child screens with their own inset handling (e.g., AssistantScreen's `.imePadding()`) don't get double padding
- Follows the pattern established in AuthScreen by PR #165

## Context

`enableEdgeToEdge()` is called in MainActivity, but MainScreen's Scaffold zeroed out all content insets. This meant M3's TopAppBar and NavigationBar handled their own insets correctly, but the content area between them had no safe area protection. The zeroed insets were likely a workaround to avoid double-padding with AssistantScreen's `.imePadding()`, but `consumeWindowInsets` is the correct way to handle this.

## Test plan

- [ ] Verify content doesn't clip under status bar on gesture navigation
- [ ] Verify content doesn't clip under navigation bar on 3-button navigation
- [ ] Verify chat input field still rises above soft keyboard (imePadding still works)
- [ ] Verify no double padding on any screen (dashboard, templates, jobs, chat, settings)
- [ ] Test on both gesture nav and 3-button nav modes

Fixes #188

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>