### PR TITLE
Add screen reader accessibility to dashboard

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/dashboard/DashboardScreen.kt
@@ -39,6 +39,9 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -223,7 +226,7 @@ private fun SectionHeader(title: String, modifier: Modifier = Modifier) {
         text = title,
         style = MaterialTheme.typography.titleMedium,
         fontWeight = FontWeight.SemiBold,
-        modifier = modifier,
+        modifier = modifier.semantics { heading() },
     )
 }
 
@@ -439,6 +442,10 @@ private fun JobHistoryChart(
     val failColor = Color(0xFFD32F2F)
     val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
 
+    val totalPassed = days.sumOf { it.successful }
+    val totalFailed = days.sumOf { it.failed }
+    val chartDescription = "Job activity chart: $totalPassed passed, $totalFailed failed over ${days.size} days"
+
     Card(modifier = modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(
@@ -463,6 +470,7 @@ private fun JobHistoryChart(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(120.dp)
+                    .semantics { contentDescription = chartDescription }
             ) {
                 if (days.isEmpty()) return@Canvas
                 val barGroupWidth = size.width / days.size
@@ -612,7 +620,11 @@ private fun InstanceInfoCard(
             }
             HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Canvas(modifier = Modifier.size(10.dp)) {
+                Canvas(
+                    modifier = Modifier
+                        .size(10.dp)
+                        .semantics { contentDescription = "Health status: $healthLabel" }
+                ) {
                     drawCircle(color = healthColor, radius = size.minDimension / 2)
                 }
                 Spacer(Modifier.width(8.dp))

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/dashboard/DashboardScreen.kt
@@ -313,7 +313,8 @@ private fun AllClearCard(modifier: Modifier = Modifier) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(24.dp),
+                .padding(24.dp)
+                .semantics(mergeDescendants = true) { },
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -442,9 +443,11 @@ private fun JobHistoryChart(
     val failColor = Color(0xFFD32F2F)
     val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
 
-    val totalPassed = days.sumOf { it.successful }
-    val totalFailed = days.sumOf { it.failed }
-    val chartDescription = "Job activity chart: $totalPassed passed, $totalFailed failed over ${days.size} days"
+    val chartDescription = remember(days) {
+        val totalPassed = days.sumOf { it.successful }
+        val totalFailed = days.sumOf { it.failed }
+        "Job activity chart: $totalPassed passed, $totalFailed failed over ${days.size} days"
+    }
 
     Card(modifier = modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -531,7 +534,8 @@ private fun ScheduleItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(12.dp),
+                .padding(12.dp)
+                .semantics(mergeDescendants = true) { },
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
@@ -619,12 +623,13 @@ private fun InstanceInfoCard(
                 }
             }
             HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Canvas(
-                    modifier = Modifier
-                        .size(10.dp)
-                        .semantics { contentDescription = "Health status: $healthLabel" }
-                ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.semantics(mergeDescendants = true) {
+                    contentDescription = "Health status: $healthLabel"
+                },
+            ) {
+                Canvas(modifier = Modifier.size(10.dp)) {
                     drawCircle(color = healthColor, radius = size.minDimension / 2)
                 }
                 Spacer(Modifier.width(8.dp))


### PR DESCRIPTION
## Summary

- Add `semantics { heading() }` to `SectionHeader` composable — TalkBack announces section titles as headings for quick navigation
- Add dynamic `contentDescription` to `JobHistoryChart` Canvas (e.g., "Job activity chart: 21 passed, 8 failed over 7 days")
- Add `contentDescription` to health status indicator dot in `InstanceInfoCard`

## Test plan

- [x] Verified with `android layout` — all semantic properties visible in the accessibility tree
- [x] Chart description dynamically reflects actual data
- [x] Health dot description reflects current status ("Healthy"/"Degraded"/"Critical")
- [ ] Verify with TalkBack enabled — section headers navigable as headings, chart data announced

Fixes #189

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>