### PR TITLE
Fix list_tools fallback bypassed in TOOLS_ONLY mode

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -151,7 +151,10 @@ class AssistantViewModel(
             "${queryResult.tools.size} tools selected, mode=$mode")
 
         val noToolsForCategory = queryResult.categoryMatched && queryResult.tools.isEmpty()
-        val generalQueryInToolsOnly = !queryResult.categoryMatched && mode == TokenSavingMode.TOOLS_ONLY
+        val queryWords = text.lowercase().split(Regex("\\W+")).toSet()
+        val isToolDiscoveryQuery = TOOL_DISCOVERY_WORDS.any { it in queryWords }
+        val generalQueryInToolsOnly = !queryResult.categoryMatched &&
+            mode == TokenSavingMode.TOOLS_ONLY && !isToolDiscoveryQuery
 
         if (noToolsForCategory || generalQueryInToolsOnly) {
             Log.d(TAG, "ROUTE: no tools path — noToolsForCategory=$noToolsForCategory, " +
@@ -164,7 +167,8 @@ class AssistantViewModel(
                     "- **Users** — users, teams, organizations, roles\n" +
                     "- **Credentials** — credentials, secrets\n" +
                     "- **Monitoring** — system health, instance status\n" +
-                    "- **Configuration** — projects, settings, notifications"
+                    "- **Configuration** — projects, settings, notifications\n\n" +
+                    "You can also ask \"what tools do you have?\" to see all available tools."
             } else if (!hasMcp) {
                 "I don't have the right tools for that query. This may require an MCP server connection.\n\n" +
                     "I can help with:\n" +
@@ -358,5 +362,8 @@ class AssistantViewModel(
 
     companion object {
         private const val TAG = "AssistantVM"
+        private val TOOL_DISCOVERY_WORDS = setOf(
+            "tools", "tool", "capabilities", "capable", "help", "actions", "functions"
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Add `TOOL_DISCOVERY_WORDS` bypass for the TOOLS_ONLY mode guard in `AssistantViewModel`
- Queries containing "tools", "help", "capabilities", etc. now skip the canned response and reach the `ListToolsLocalTool` fallback, enabling dynamic tool discovery
- Non-discovery queries ("hi", "thanks") still get the zero-cost canned response, preserving TOOLS_ONLY token savings
- Canned response now includes a hint: "You can also ask 'what tools do you have?'"

## Behavior matrix

| Query | TOOLS_ONLY (before) | TOOLS_ONLY (after) | STANDARD/TOKEN_SAVER |
|-------|--------------------|--------------------|---------------------|
| "hi" | Canned guidance | Canned guidance (same) | LLM + list_tools |
| "what tools?" | Canned guidance (bug) | LLM + list_tools (fixed) | LLM + list_tools |
| "list hosts" | Routes to inventory | Routes to inventory (same) | Routes to inventory |

## Test plan
- [ ] In TOOLS_ONLY mode, send "what tools do you have?" — verify LLM calls `list_tools` and returns tool listing
- [ ] In TOOLS_ONLY mode, send "hi" — verify canned guidance response (no LLM call)
- [ ] In TOOLS_ONLY mode, send "help" — verify LLM calls `list_tools` (discovery word match)
- [ ] In STANDARD mode, verify all queries behave as before
- [ ] Category-matched queries ("list hosts", "show jobs") still route correctly in all modes

## Future work
ToolRouter singleton refactor tracked in #120 — would make `list_tools` a proper routed tool via META category instead of a ViewModel-level bypass.

Fixes #197

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>