### PR TITLE
Extract shared DetailScaffold composable

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material3.AlertDialog
@@ -19,15 +18,11 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -43,10 +38,10 @@ import io.github.leogallego.ansiblejane.presentation.approval.ApprovalDetailUiSt
 import io.github.leogallego.ansiblejane.presentation.approval.ApprovalDetailViewModel
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import io.github.leogallego.ansiblejane.ui.components.DetailRowHorizontal
+import io.github.leogallego.ansiblejane.ui.components.DetailScaffold
 import io.github.leogallego.ansiblejane.ui.components.ErrorMessage
 import org.koin.compose.viewmodel.koinViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ApprovalDetailScreen(
     onNavigateBack: () -> Unit,
@@ -56,23 +51,7 @@ fun ApprovalDetailScreen(
 
     var showConfirmDialog by remember { mutableStateOf<String?>(null) }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Workflow Approval") },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                }
-            )
-        }
-    ) { padding ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-        ) {
+    DetailScaffold(title = "Workflow Approval", onNavigateBack = onNavigateBack) {
             when (val state = uiState) {
                 is ApprovalDetailUiState.Loading -> {
                     CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
@@ -116,9 +95,7 @@ fun ApprovalDetailScreen(
                 }
             }
         }
-    }
-
-    // Confirmation dialog
+    // Confirmation dialog is intentionally outside DetailScaffold
     showConfirmDialog?.let { action ->
         val approvalName = when (val state = uiState) {
             is ApprovalDetailUiState.Ready -> state.approval.name

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/DetailScaffold.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/DetailScaffold.kt
@@ -1,0 +1,58 @@
+package io.github.leogallego.ansiblejane.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DetailScaffold(
+    title: String,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    titleContent: @Composable (() -> Unit)? = null,
+    floatingActionButton: @Composable () -> Unit = {},
+    snackbarHost: @Composable () -> Unit = {},
+    content: @Composable BoxScope.() -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { titleContent?.invoke() ?: Text(title) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onNavigateBack,
+                        modifier = Modifier.testTag("button_back")
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
+        },
+        floatingActionButton = floatingActionButton,
+        snackbarHost = snackbarHost,
+        modifier = modifier
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            content = content
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/DetailScaffold.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/DetailScaffold.kt
@@ -46,7 +46,7 @@ fun DetailScaffold(
         },
         floatingActionButton = floatingActionButton,
         snackbarHost = snackbarHost,
-        modifier = modifier
+        modifier = modifier.testTag("scaffold_detail")
     ) { padding ->
         Box(
             modifier = Modifier

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/jobs/JobStatusScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/jobs/JobStatusScreen.kt
@@ -12,25 +12,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.leogallego.ansiblejane.model.Job
@@ -38,11 +30,11 @@ import io.github.leogallego.ansiblejane.presentation.jobs.JobStatusUiState
 import io.github.leogallego.ansiblejane.presentation.jobs.JobStatusViewModel
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import io.github.leogallego.ansiblejane.ui.components.DetailRowHorizontal
+import io.github.leogallego.ansiblejane.ui.components.DetailScaffold
 import io.github.leogallego.ansiblejane.ui.components.ErrorMessage
 import io.github.leogallego.ansiblejane.ui.components.JobStatusBadge
 import org.koin.compose.viewmodel.koinViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun JobStatusScreen(
     onNavigateBack: () -> Unit,
@@ -55,23 +47,7 @@ fun JobStatusScreen(
         onDispose { viewModel.stopPolling() }
     }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Job Status") },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack, modifier = Modifier.testTag("button_back")) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                }
-            )
-        }
-    ) { padding ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-        ) {
+    DetailScaffold(title = "Job Status", onNavigateBack = onNavigateBack) {
             when (val state = uiState) {
                 is JobStatusUiState.Loading -> {
                     CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
@@ -92,7 +68,6 @@ fun JobStatusScreen(
             }
         }
     }
-}
 
 @Composable
 private fun JobDetailContent(job: Job, isActive: Boolean, stdout: String? = null) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
@@ -9,16 +9,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -30,9 +23,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.leogallego.ansiblejane.presentation.settings.SettingsTab
 import io.github.leogallego.ansiblejane.presentation.settings.SettingsUiState
 import io.github.leogallego.ansiblejane.presentation.settings.SettingsViewModel
+import io.github.leogallego.ansiblejane.ui.components.DetailScaffold
 import org.koin.compose.viewmodel.koinViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     onLogout: () -> Unit,
@@ -42,24 +35,9 @@ fun SettingsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Settings") },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack, modifier = Modifier.testTag("button_back")) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                }
-            )
-        }
-    ) { padding ->
+    DetailScaffold(title = "Settings", onNavigateBack = onNavigateBack) {
         when (val state = uiState) {
             is SettingsUiState.Loading -> {
-                // Could show a loading indicator, but transition is fast
             }
             is SettingsUiState.Ready -> {
                 SettingsContent(
@@ -84,9 +62,7 @@ fun SettingsScreen(
                     onAddMcpServer = { url, label, toolset -> viewModel.addMcpServer(url, label, toolset) },
                     onRemoveMcpServer = { viewModel.removeMcpServer(it) },
                     onToggleReadOnly = { url, readOnly -> viewModel.toggleServerReadOnly(url, readOnly) },
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(padding)
+                    modifier = Modifier.fillMaxSize()
                 )
             }
         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/workflows/WorkflowJobStatusScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/workflows/WorkflowJobStatusScreen.kt
@@ -11,17 +11,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -36,11 +29,11 @@ import io.github.leogallego.ansiblejane.presentation.workflows.NodeStdoutState
 import io.github.leogallego.ansiblejane.presentation.workflows.WorkflowJobStatusUiState
 import io.github.leogallego.ansiblejane.presentation.workflows.WorkflowJobStatusViewModel
 import io.github.leogallego.ansiblejane.ui.components.DetailRowHorizontal
+import io.github.leogallego.ansiblejane.ui.components.DetailScaffold
 import io.github.leogallego.ansiblejane.ui.components.ErrorMessage
 import io.github.leogallego.ansiblejane.ui.components.JobStatusBadge
 import org.koin.compose.viewmodel.koinViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WorkflowJobStatusScreen(
     onNavigateBack: () -> Unit,
@@ -55,23 +48,7 @@ fun WorkflowJobStatusScreen(
         onDispose { viewModel.stopPolling() }
     }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Workflow Job Status") },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                }
-            )
-        }
-    ) { padding ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-        ) {
+    DetailScaffold(title = "Workflow Job Status", onNavigateBack = onNavigateBack) {
             when (val state = uiState) {
                 is WorkflowJobStatusUiState.Loading -> {
                     CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
@@ -106,7 +83,6 @@ fun WorkflowJobStatusScreen(
             }
         }
     }
-}
 
 @Composable
 private fun WorkflowJobDetailContent(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/workflows/WorkflowTemplateDetailScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/workflows/WorkflowTemplateDetailScreen.kt
@@ -11,20 +11,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -37,10 +32,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.leogallego.ansiblejane.presentation.workflows.LaunchFromDetailState
 import io.github.leogallego.ansiblejane.presentation.workflows.WorkflowTemplateDetailUiState
 import io.github.leogallego.ansiblejane.presentation.workflows.WorkflowTemplateDetailViewModel
+import io.github.leogallego.ansiblejane.ui.components.DetailScaffold
 import io.github.leogallego.ansiblejane.ui.components.ErrorMessage
 import org.koin.compose.viewmodel.koinViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WorkflowTemplateDetailScreen(
     onNavigateBack: () -> Unit,
@@ -65,21 +60,14 @@ fun WorkflowTemplateDetailScreen(
         }
     }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = viewModel.templateName.ifBlank { "Workflow Template" },
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                }
+    DetailScaffold(
+        title = "Workflow Template",
+        onNavigateBack = onNavigateBack,
+        titleContent = {
+            Text(
+                text = viewModel.templateName.ifBlank { "Workflow Template" },
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
         },
         floatingActionButton = {
@@ -98,12 +86,7 @@ fun WorkflowTemplateDetailScreen(
             }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }
-    ) { padding ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-        ) {
+    ) {
             when (val state = uiState) {
                 is WorkflowTemplateDetailUiState.Loading -> {
                     CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
@@ -148,7 +131,6 @@ fun WorkflowTemplateDetailScreen(
             }
         }
     }
-}
 
 @Composable
 private fun TemplateNodeCard(orderedNode: OrderedTemplateNode) {


### PR DESCRIPTION
## Summary
- Create shared `DetailScaffold` composable that wraps `Scaffold` + `TopAppBar` + back navigation + `Box` content wrapper
- Migrate 5 detail screens: `JobStatusScreen`, `WorkflowJobStatusScreen`, `WorkflowTemplateDetailScreen`, `ApprovalDetailScreen`, `SettingsScreen`
- Standardize `testTag("button_back")` on all back buttons
- Support optional `titleContent`, `floatingActionButton`, and `snackbarHost` slots

Net -56 lines (78 added, 134 removed).

Closes #154

## Test plan
- [x] `compileDebugKotlin` passes
- [x] `testDebugUnitTest` passes
- [ ] Visual verification: all 5 detail screens render with correct top bar, back navigation, and content

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>