### PR TITLE
Migrate inline UI strings to string resources (phase 1)

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/navigation/MainNavigation.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/navigation/MainNavigation.kt
@@ -1,6 +1,7 @@
 package io.github.leogallego.ansiblejane.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import io.github.leogallego.ansiblejane.assistant.ui.AssistantScreen
 import io.github.leogallego.ansiblejane.ui.components.PlaceholderScreen
 import io.github.leogallego.ansiblejane.ui.dashboard.DashboardScreen
@@ -23,7 +24,7 @@ fun TabContent(
     onNavigateToWorkflowTemplateDetail: (Int, String) -> Unit = { _, _ -> }
 ) {
     if (!segment.isImplemented) {
-        PlaceholderScreen(title = segment.label)
+        PlaceholderScreen(title = stringResource(segment.labelResId))
         return
     }
 
@@ -40,7 +41,7 @@ fun TabContent(
                     onNavigateToWorkflowJobStatus = onNavigateToWorkflowJobStatus,
                     onNavigateToTemplateDetail = onNavigateToWorkflowTemplateDetail
                 )
-                else -> PlaceholderScreen(title = segment.label)
+                else -> PlaceholderScreen(title = stringResource(segment.labelResId))
             }
         }
         is TopLevelTab.Activity -> {
@@ -50,14 +51,14 @@ fun TabContent(
                 )
                 "Schedules" -> SchedulesScreen()
                 "EDA" -> EdaAuditScreen()
-                else -> PlaceholderScreen(title = segment.label)
+                else -> PlaceholderScreen(title = stringResource(segment.labelResId))
             }
         }
         is TopLevelTab.Infrastructure -> {
             when (segment.label) {
                 "Inventories" -> InventoriesScreen()
                 "Hosts" -> HostsScreen()
-                else -> PlaceholderScreen(title = segment.label)
+                else -> PlaceholderScreen(title = stringResource(segment.labelResId))
             }
         }
         is TopLevelTab.Assistant -> {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/DetailSheetHeader.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/DetailSheetHeader.kt
@@ -12,7 +12,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import io.github.leogallego.ansiblejane.R
 
 @Composable
 fun DetailSheetHeader(
@@ -33,7 +35,7 @@ fun DetailSheetHeader(
             overflow = TextOverflow.Ellipsis
         )
         IconButton(onClick = onExpand) {
-            Icon(Icons.Default.OpenInFull, contentDescription = "Expand to full screen")
+            Icon(Icons.Default.OpenInFull, contentDescription = stringResource(R.string.cd_expand_fullscreen))
         }
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/ErrorMessage.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/ErrorMessage.kt
@@ -27,8 +27,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import io.github.leogallego.ansiblejane.R
 import io.github.leogallego.ansiblejane.model.AppError
 import io.github.leogallego.ansiblejane.ui.icons.AapIcons
 
@@ -87,13 +89,13 @@ fun ErrorMessage(
                         else AapIcons.Action.ExpandMore
                     Icon(
                         imageVector = toggleIcon,
-                        contentDescription = if (showDetails) "Hide details" else "Show details",
+                        contentDescription = stringResource(if (showDetails) R.string.hide_details else R.string.show_details),
                         tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(18.dp)
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = if (showDetails) "Hide details" else "Show details",
+                        text = stringResource(if (showDetails) R.string.hide_details else R.string.show_details),
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.primary
                     )
@@ -134,7 +136,7 @@ fun ErrorMessage(
             if (onRetry != null) {
                 Spacer(modifier = Modifier.height(16.dp))
                 Button(onClick = onRetry) {
-                    Text("Retry")
+                    Text(stringResource(R.string.action_retry))
                 }
             }
         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/PlaceholderScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/PlaceholderScreen.kt
@@ -14,15 +14,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import io.github.leogallego.ansiblejane.R
 
 @Composable
 fun PlaceholderScreen(
     title: String,
-    description: String = "This feature is planned for a future release.",
+    description: String? = null,
     modifier: Modifier = Modifier
 ) {
+    val resolvedDescription = description ?: stringResource(R.string.placeholder_coming_soon)
     Column(
         modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -42,7 +45,7 @@ fun PlaceholderScreen(
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(
-            text = description,
+            text = resolvedDescription,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/SearchBar.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/SearchBar.kt
@@ -16,7 +16,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import io.github.leogallego.ansiblejane.R
 import kotlinx.coroutines.delay
 
 @Composable
@@ -39,11 +41,11 @@ fun SearchBar(
         value = query,
         onValueChange = { hasUserTyped = true; query = it },
         placeholder = { Text(placeholder) },
-        leadingIcon = { Icon(Icons.Default.Search, contentDescription = "Search") },
+        leadingIcon = { Icon(Icons.Default.Search, contentDescription = stringResource(R.string.cd_search)) },
         trailingIcon = {
             if (query.isNotEmpty()) {
                 IconButton(onClick = { query = "" }) {
-                    Icon(Icons.Default.Clear, contentDescription = "Clear search")
+                    Icon(Icons.Default.Clear, contentDescription = stringResource(R.string.cd_clear_search))
                 }
             }
         },

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
@@ -42,9 +42,11 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.leogallego.ansiblejane.assistant.data.IAssistantRepository
+import io.github.leogallego.ansiblejane.R
 import io.github.leogallego.ansiblejane.data.TokenManager
 import io.github.leogallego.ansiblejane.presentation.notifications.NotificationsViewModel
 import io.github.leogallego.ansiblejane.ui.components.ProviderSwitchChip
@@ -90,16 +92,16 @@ fun MainScreen(
     if (showClearChatConfirm) {
         AlertDialog(
             onDismissRequest = { showClearChatConfirm = false },
-            title = { Text("Clear Chat History") },
-            text = { Text("This will remove all messages from the assistant chat. This cannot be undone.") },
+            title = { Text(stringResource(R.string.clear_chat_title)) },
+            text = { Text(stringResource(R.string.clear_chat_message)) },
             confirmButton = {
                 TextButton(onClick = {
                     showClearChatConfirm = false
                     assistantRepository.clearHistory()
-                }) { Text("Clear") }
+                }) { Text(stringResource(R.string.clear_chat_confirm)) }
             },
             dismissButton = {
-                TextButton(onClick = { showClearChatConfirm = false }) { Text("Cancel") }
+                TextButton(onClick = { showClearChatConfirm = false }) { Text(stringResource(R.string.action_cancel)) }
             }
         )
     }
@@ -109,12 +111,12 @@ fun MainScreen(
             TopAppBar(
                 title = {
                     AnimatedContent(
-                        targetState = selectedTab.label,
+                        targetState = selectedTab,
                         transitionSpec = { fadeIn() togetherWith fadeOut() },
                         label = "titleCrossfade"
-                    ) { label ->
+                    ) { tab ->
                         Column {
-                            Text(label)
+                            Text(stringResource(tab.labelResId))
                             activeInstance?.let { instance ->
                                 Text(
                                     text = instance.displayLabel,
@@ -144,7 +146,7 @@ fun MainScreen(
                         ) {
                             Icon(
                                 imageVector = Icons.Outlined.DeleteSweep,
-                                contentDescription = "Clear chat history"
+                                contentDescription = stringResource(R.string.cd_clear_chat)
                             )
                         }
                     }
@@ -165,7 +167,7 @@ fun MainScreen(
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Notifications,
-                                contentDescription = "Notifications"
+                                contentDescription = stringResource(R.string.cd_notifications)
                             )
                         }
                     }
@@ -175,7 +177,7 @@ fun MainScreen(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Settings,
-                            contentDescription = "Settings"
+                            contentDescription = stringResource(R.string.cd_settings)
                         )
                     }
                 }
@@ -191,12 +193,12 @@ fun MainScreen(
                         icon = {
                             Icon(
                                 imageVector = if (selectedTabIndex == index) tab.selectedIcon else tab.icon,
-                                contentDescription = tab.label
+                                contentDescription = stringResource(tab.labelResId)
                             )
                         },
                         label = {
                             Text(
-                                tab.label,
+                                stringResource(tab.labelResId),
                                 maxLines = 1,
                                 overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
                             )
@@ -232,7 +234,7 @@ fun MainScreen(
                                 count = selectedTab.segments.size
                             )
                         ) {
-                            Text(segment.label)
+                            Text(stringResource(segment.labelResId))
                         }
                     }
                 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/TabDefinitions.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/TabDefinitions.kt
@@ -1,5 +1,6 @@
 package io.github.leogallego.ansiblejane.ui.main
 
+import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Assistant
 import androidx.compose.material.icons.filled.Dashboard
@@ -12,9 +13,11 @@ import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Dns
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.ui.graphics.vector.ImageVector
+import io.github.leogallego.ansiblejane.R
 
 data class Segment(
     val label: String,
+    @param:StringRes val labelResId: Int,
     val isDefault: Boolean = false,
     val isImplemented: Boolean = false
 )
@@ -22,6 +25,7 @@ data class Segment(
 sealed class TopLevelTab(
     val route: String,
     val label: String,
+    @param:StringRes val labelResId: Int,
     val icon: ImageVector,
     val selectedIcon: ImageVector,
     val segments: List<Segment>
@@ -29,54 +33,59 @@ sealed class TopLevelTab(
     data object Dashboard : TopLevelTab(
         route = "main/dashboard",
         label = "Dashboard",
+        labelResId = R.string.tab_dashboard,
         icon = Icons.Outlined.Dashboard,
         selectedIcon = Icons.Filled.Dashboard,
         segments = listOf(
-            Segment(label = "Overview", isDefault = true, isImplemented = true)
+            Segment(label = "Overview", labelResId = R.string.segment_overview, isDefault = true, isImplemented = true)
         )
     )
 
     data object Templates : TopLevelTab(
         route = "main/templates",
         label = "Templates",
+        labelResId = R.string.tab_templates,
         icon = Icons.Outlined.Description,
         selectedIcon = Icons.Filled.Description,
         segments = listOf(
-            Segment(label = "Job Templates", isDefault = true, isImplemented = true),
-            Segment(label = "Workflows", isImplemented = true)
+            Segment(label = "Job Templates", labelResId = R.string.segment_job_templates, isDefault = true, isImplemented = true),
+            Segment(label = "Workflows", labelResId = R.string.segment_workflows, isImplemented = true)
         )
     )
 
     data object Infrastructure : TopLevelTab(
         route = "main/infrastructure",
         label = "Infrastructure",
+        labelResId = R.string.tab_infrastructure,
         icon = Icons.Outlined.Dns,
         selectedIcon = Icons.Filled.Dns,
         segments = listOf(
-            Segment(label = "Inventories", isDefault = true, isImplemented = true),
-            Segment(label = "Hosts", isImplemented = true)
+            Segment(label = "Inventories", labelResId = R.string.segment_inventories, isDefault = true, isImplemented = true),
+            Segment(label = "Hosts", labelResId = R.string.segment_hosts, isImplemented = true)
         )
     )
 
     data object Activity : TopLevelTab(
         route = "main/activity",
         label = "Activity",
+        labelResId = R.string.tab_activity,
         icon = Icons.Outlined.History,
         selectedIcon = Icons.Filled.History,
         segments = listOf(
-            Segment(label = "Jobs", isDefault = true, isImplemented = true),
-            Segment(label = "Schedules", isImplemented = true),
-            Segment(label = "EDA", isImplemented = true)
+            Segment(label = "Jobs", labelResId = R.string.segment_jobs, isDefault = true, isImplemented = true),
+            Segment(label = "Schedules", labelResId = R.string.segment_schedules, isImplemented = true),
+            Segment(label = "EDA", labelResId = R.string.segment_eda, isImplemented = true)
         )
     )
 
     data object Assistant : TopLevelTab(
         route = "main/assistant",
         label = "Jane",
+        labelResId = R.string.tab_assistant,
         icon = Icons.Outlined.Assistant,
         selectedIcon = Icons.Filled.Assistant,
         segments = listOf(
-            Segment(label = "Chat", isDefault = true, isImplemented = true)
+            Segment(label = "Chat", labelResId = R.string.segment_chat, isDefault = true, isImplemented = true)
         )
     )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <!-- Common actions -->
     <string name="action_retry">Retry</string>
     <string name="action_cancel">Cancel</string>
-    <string name="action_clear">Clear</string>
+
 
     <!-- Shared component text -->
     <string name="show_details">Show details</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Ansible Jane</string>
+
+    <!-- Navigation tabs -->
+    <string name="tab_dashboard">Dashboard</string>
+    <string name="tab_templates">Templates</string>
+    <string name="tab_infrastructure">Infrastructure</string>
+    <string name="tab_activity">Activity</string>
+    <string name="tab_assistant">Jane</string>
+
+    <!-- Tab segments -->
+    <string name="segment_overview">Overview</string>
+    <string name="segment_job_templates">Job Templates</string>
+    <string name="segment_workflows">Workflows</string>
+    <string name="segment_inventories">Inventories</string>
+    <string name="segment_hosts">Hosts</string>
+    <string name="segment_jobs">Jobs</string>
+    <string name="segment_schedules">Schedules</string>
+    <string name="segment_eda">EDA</string>
+    <string name="segment_chat">Chat</string>
+
+    <!-- Common actions -->
+    <string name="action_retry">Retry</string>
+    <string name="action_cancel">Cancel</string>
+    <string name="action_clear">Clear</string>
+
+    <!-- Shared component text -->
+    <string name="show_details">Show details</string>
+    <string name="hide_details">Hide details</string>
+    <string name="placeholder_coming_soon">This feature is planned for a future release.</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_back">Back</string>
+    <string name="cd_search">Search</string>
+    <string name="cd_clear_search">Clear search</string>
+    <string name="cd_expand_fullscreen">Expand to full screen</string>
+    <string name="cd_clear_chat">Clear chat history</string>
+    <string name="cd_notifications">Notifications</string>
+    <string name="cd_settings">Settings</string>
+
+    <!-- Clear chat dialog -->
+    <string name="clear_chat_title">Clear Chat History</string>
+    <string name="clear_chat_message">This will remove all messages from the assistant chat. This cannot be undone.</string>
+    <string name="clear_chat_confirm">Clear</string>
+</resources>


### PR DESCRIPTION
## Summary
- Create `strings.xml` with 25 string resources covering navigation tabs, segments, shared component text, content descriptions, and dialog strings
- Add `@StringRes labelResId` to `TopLevelTab` and `Segment` data classes, keeping `label` for routing/test-tag keys
- Migrate 7 files from hardcoded string literals to `stringResource()` calls: MainScreen, ErrorMessage, PlaceholderScreen, SearchBar, DetailSheetHeader, MainNavigation, TabDefinitions

## Test plan
- [x] `compileDebugKotlin` passes
- [x] `testDebugUnitTest` passes (all existing tests)
- [ ] Manual: verify navigation labels, segment buttons, error retry, placeholder text render correctly
- [ ] Manual: verify clear-chat dialog shows proper strings

Closes #190

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>