### PR TITLE
Add @Preview composables for shared components and key screens

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
@@ -67,11 +67,15 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.ui.tooling.preview.Preview
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
+import io.github.leogallego.ansiblejane.assistant.engine.ResponseSource
 import io.github.leogallego.ansiblejane.assistant.engine.Role
 import io.github.leogallego.ansiblejane.assistant.presentation.AssistantUiState
 import io.github.leogallego.ansiblejane.assistant.presentation.AssistantViewModel
 import io.github.leogallego.ansiblejane.network.mcp.McpConnectionState
+import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
+import kotlinx.collections.immutable.persistentListOf
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -400,6 +404,58 @@ private fun StreamingIndicator(
             text = statusText,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Assistant - Empty Chat")
+@Composable
+private fun AssistantEmptyPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        ActiveChatContent(
+            state = AssistantUiState.Active(),
+            onSendMessage = {},
+            onStopGeneration = {},
+            onRegenerateLastMessage = {},
+            onConfirmApprove = {},
+            onConfirmDeny = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Assistant - With Messages")
+@Composable
+private fun AssistantWithMessagesPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        ActiveChatContent(
+            state = AssistantUiState.Active(
+                messages = persistentListOf(
+                    ChatMessage(
+                        role = Role.USER,
+                        content = "What job templates are available?",
+                    ),
+                    ChatMessage(
+                        role = Role.ASSISTANT,
+                        content = "I found 3 job templates:\n\n" +
+                            "1. **Deploy Web Application** - Deploys to production\n" +
+                            "2. **System Health Check** - Runs health checks\n" +
+                            "3. **Patch Management** - Applies security patches",
+                        source = ResponseSource.MIXED,
+                        toolsUsed = listOf("list_job_templates"),
+                    ),
+                    ChatMessage(
+                        role = Role.USER,
+                        content = "Launch the Deploy Web Application template",
+                    ),
+                ),
+                isGenerating = true,
+                streamingText = "Launching job template...",
+            ),
+            onSendMessage = {},
+            onStopGeneration = {},
+            onRegenerateLastMessage = {},
+            onConfirmApprove = {},
+            onConfirmDeny = {},
         )
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
@@ -67,7 +67,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
 import io.github.leogallego.ansiblejane.assistant.engine.ResponseSource
 import io.github.leogallego.ansiblejane.assistant.engine.Role
@@ -408,7 +408,7 @@ private fun StreamingIndicator(
     }
 }
 
-@Preview(showBackground = true, name = "Assistant - Empty Chat")
+@PreviewLightDark
 @Composable
 private fun AssistantEmptyPreview() {
     AnsibleJaneTheme(dynamicColor = false) {
@@ -423,7 +423,7 @@ private fun AssistantEmptyPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "Assistant - With Messages")
+@PreviewLightDark
 @Composable
 private fun AssistantWithMessagesPreview() {
     AnsibleJaneTheme(dynamicColor = false) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/EmptyState.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/EmptyState.kt
@@ -7,7 +7,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
 
 @Composable
@@ -27,7 +27,7 @@ fun EmptyState(
     }
 }
 
-@Preview(showBackground = true, name = "Empty State")
+@PreviewLightDark
 @Composable
 private fun EmptyStatePreview() {
     AnsibleJaneTheme(dynamicColor = false) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/EmptyState.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/EmptyState.kt
@@ -7,6 +7,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
 
 @Composable
 fun EmptyState(
@@ -22,5 +24,13 @@ fun EmptyState(
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+    }
+}
+
+@Preview(showBackground = true, name = "Empty State")
+@Composable
+private fun EmptyStatePreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        EmptyState(message = "No templates found")
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/ErrorMessage.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/ErrorMessage.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import io.github.leogallego.ansiblejane.R
 import io.github.leogallego.ansiblejane.model.AppError
 import io.github.leogallego.ansiblejane.model.ErrorDetail
@@ -146,7 +146,7 @@ fun ErrorMessage(
     }
 }
 
-@Preview(showBackground = true, name = "Error - Network with Retry")
+@PreviewLightDark
 @Composable
 private fun ErrorMessageNetworkPreview() {
     AnsibleJaneTheme(dynamicColor = false) {
@@ -154,7 +154,7 @@ private fun ErrorMessageNetworkPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "Error - Server with Details")
+@PreviewLightDark
 @Composable
 private fun ErrorMessageWithDetailsPreview() {
     AnsibleJaneTheme(dynamicColor = false) {
@@ -172,7 +172,7 @@ private fun ErrorMessageWithDetailsPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "Error - Auth without Retry")
+@PreviewLightDark
 @Composable
 private fun ErrorMessageNoRetryPreview() {
     AnsibleJaneTheme(dynamicColor = false) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/ErrorMessage.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/ErrorMessage.kt
@@ -30,9 +30,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
 import io.github.leogallego.ansiblejane.R
 import io.github.leogallego.ansiblejane.model.AppError
+import io.github.leogallego.ansiblejane.model.ErrorDetail
 import io.github.leogallego.ansiblejane.ui.icons.AapIcons
+import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
 
 @Composable
 fun ErrorMessage(
@@ -140,5 +143,39 @@ fun ErrorMessage(
                 }
             }
         }
+    }
+}
+
+@Preview(showBackground = true, name = "Error - Network with Retry")
+@Composable
+private fun ErrorMessageNetworkPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        ErrorMessage(error = AppError.Network(), onRetry = {})
+    }
+}
+
+@Preview(showBackground = true, name = "Error - Server with Details")
+@Composable
+private fun ErrorMessageWithDetailsPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        ErrorMessage(
+            error = AppError.Server(
+                statusCode = 500,
+                detail = ErrorDetail(
+                    statusCode = 500,
+                    url = "https://aap.example.com/api/v2/jobs/",
+                    rawMessage = "Internal Server Error"
+                )
+            ),
+            onRetry = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Error - Auth without Retry")
+@Composable
+private fun ErrorMessageNoRetryPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        ErrorMessage(error = AppError.Auth())
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/JobStatusBadge.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/JobStatusBadge.kt
@@ -6,6 +6,8 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -20,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.leogallego.ansiblejane.model.JobStatus
 import io.github.leogallego.ansiblejane.ui.icons.AapIcons
@@ -88,5 +91,20 @@ private fun statusConfig(status: JobStatus): StatusConfig {
         JobStatus.FAILED -> StatusConfig(scheme.error, AapIcons.Status.Failed, "Failed")
         JobStatus.ERROR -> StatusConfig(scheme.error, AapIcons.Status.Error, "Error")
         JobStatus.CANCELED -> StatusConfig(scheme.secondary, AapIcons.Status.Canceled, "Canceled")
+    }
+}
+
+@Preview(showBackground = true, name = "Job Status Badges - All Variants")
+@Composable
+private fun JobStatusBadgePreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            JobStatus.entries.forEach { status ->
+                JobStatusBadge(status = status)
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/JobStatusBadge.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/JobStatusBadge.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import io.github.leogallego.ansiblejane.model.JobStatus
 import io.github.leogallego.ansiblejane.ui.icons.AapIcons
@@ -94,7 +94,7 @@ private fun statusConfig(status: JobStatus): StatusConfig {
     }
 }
 
-@Preview(showBackground = true, name = "Job Status Badges - All Variants")
+@PreviewLightDark
 @Composable
 private fun JobStatusBadgePreview() {
     AnsibleJaneTheme(dynamicColor = false) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/LoadingList.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/LoadingList.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
 
 @Composable
 fun LoadingList(
@@ -12,5 +14,13 @@ fun LoadingList(
 ) {
     LazyColumn(modifier = modifier.fillMaxSize()) {
         items(count) { SkeletonCard() }
+    }
+}
+
+@Preview(showBackground = true, name = "Loading List")
+@Composable
+private fun LoadingListPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        LoadingList()
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/LoadingList.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/LoadingList.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
 
 @Composable
@@ -17,7 +17,7 @@ fun LoadingList(
     }
 }
 
-@Preview(showBackground = true, name = "Loading List")
+@PreviewLightDark
 @Composable
 private fun LoadingListPreview() {
     AnsibleJaneTheme(dynamicColor = false) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/ProviderSwitchChip.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/ProviderSwitchChip.kt
@@ -31,8 +31,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
 import io.github.leogallego.ansiblejane.assistant.data.KnownProvider
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
+import io.github.leogallego.ansiblejane.assistant.data.TokenSavingMode
+import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
 
 @Composable
 fun ProviderSwitchChip(
@@ -173,5 +176,39 @@ fun ProviderSwitchChip(
                 )
             }
         }
+    }
+}
+
+private val previewConfig = LlmProviderConfig.OpenAiCompatible(
+    url = "http://localhost:11434/v1",
+    model = "llama3.1:8b",
+    tokenSavingMode = TokenSavingMode.STANDARD
+)
+
+@Preview(showBackground = true, name = "Provider Chip - Active")
+@Composable
+private fun ProviderSwitchChipActivePreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        ProviderSwitchChip(
+            activeProviderKey = KnownProvider.OLLAMA.name,
+            activeConfig = previewConfig,
+            savedConfigs = mapOf(KnownProvider.OLLAMA.name to previewConfig),
+            onSwitchProvider = {},
+            onNavigateToSettings = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Provider Chip - No LLM")
+@Composable
+private fun ProviderSwitchChipNoLlmPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        ProviderSwitchChip(
+            activeProviderKey = null,
+            activeConfig = null,
+            savedConfigs = emptyMap(),
+            onSwitchProvider = {},
+            onNavigateToSettings = {}
+        )
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/ProviderSwitchChip.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/ProviderSwitchChip.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import io.github.leogallego.ansiblejane.assistant.data.KnownProvider
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.assistant.data.TokenSavingMode
@@ -185,7 +185,7 @@ private val previewConfig = LlmProviderConfig.OpenAiCompatible(
     tokenSavingMode = TokenSavingMode.STANDARD
 )
 
-@Preview(showBackground = true, name = "Provider Chip - Active")
+@PreviewLightDark
 @Composable
 private fun ProviderSwitchChipActivePreview() {
     AnsibleJaneTheme(dynamicColor = false) {
@@ -199,7 +199,7 @@ private fun ProviderSwitchChipActivePreview() {
     }
 }
 
-@Preview(showBackground = true, name = "Provider Chip - No LLM")
+@PreviewLightDark
 @Composable
 private fun ProviderSwitchChipNoLlmPreview() {
     AnsibleJaneTheme(dynamicColor = false) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/TemplateCard.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/TemplateCard.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import io.github.leogallego.ansiblejane.model.JobTemplate
 import io.github.leogallego.ansiblejane.model.JobTemplateSummaryFields
 import io.github.leogallego.ansiblejane.model.Label
@@ -135,7 +135,7 @@ private val previewTemplate = JobTemplate(
     )
 )
 
-@Preview(showBackground = true, name = "Template Card - Launchable")
+@PreviewLightDark
 @Composable
 private fun TemplateCardLaunchablePreview() {
     AnsibleJaneTheme(dynamicColor = false) {
@@ -147,7 +147,7 @@ private fun TemplateCardLaunchablePreview() {
     }
 }
 
-@Preview(showBackground = true, name = "Template Card - Read Only")
+@PreviewLightDark
 @Composable
 private fun TemplateCardReadOnlyPreview() {
     AnsibleJaneTheme(dynamicColor = false) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/TemplateCard.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/components/TemplateCard.kt
@@ -27,7 +27,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.leogallego.ansiblejane.model.JobTemplate
+import io.github.leogallego.ansiblejane.model.JobTemplateSummaryFields
+import io.github.leogallego.ansiblejane.model.Label
+import io.github.leogallego.ansiblejane.model.LabelSummary
 import io.github.leogallego.ansiblejane.model.LaunchableTemplate
+import io.github.leogallego.ansiblejane.model.UserCapabilities
+import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -112,5 +119,46 @@ fun TemplateCard(
                 }
             }
         }
+    }
+}
+
+private val previewTemplate = JobTemplate(
+    id = 1,
+    name = "Deploy Web Application",
+    description = "Deploys the web application to production servers with rolling updates",
+    summaryFields = JobTemplateSummaryFields(
+        labels = LabelSummary(
+            count = 2,
+            results = listOf(Label(1, "production"), Label(2, "deploy"))
+        ),
+        userCapabilities = UserCapabilities(start = true)
+    )
+)
+
+@Preview(showBackground = true, name = "Template Card - Launchable")
+@Composable
+private fun TemplateCardLaunchablePreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        TemplateCard(
+            template = previewTemplate,
+            onClick = {},
+            onLaunch = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Template Card - Read Only")
+@Composable
+private fun TemplateCardReadOnlyPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        TemplateCard(
+            template = previewTemplate.copy(
+                name = "System Health Check",
+                description = "Runs health checks across all managed hosts",
+                summaryFields = JobTemplateSummaryFields()
+            ),
+            onClick = {},
+            onLaunch = {}
+        )
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/dashboard/DashboardScreen.kt
@@ -55,6 +55,8 @@ import io.github.leogallego.ansiblejane.presentation.dashboard.DashboardViewMode
 import io.github.leogallego.ansiblejane.presentation.dashboard.DayJobStats
 import io.github.leogallego.ansiblejane.presentation.dashboard.HealthStatus
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.leogallego.ansiblejane.model.AppError
 import io.github.leogallego.ansiblejane.ui.components.ErrorMessage
 import io.github.leogallego.ansiblejane.ui.components.JobStatusBadge
 import io.github.leogallego.ansiblejane.ui.components.SkeletonCard
@@ -77,6 +79,24 @@ fun DashboardScreen(
         }
     }
 
+    DashboardContent(
+        uiState = uiState,
+        isRefreshing = isRefreshing,
+        onRefresh = { isRefreshing = true; viewModel.refresh() },
+        onRetry = { viewModel.refresh() },
+        onNavigateToJobStatus = onNavigateToJobStatus,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DashboardContent(
+    uiState: DashboardUiState,
+    isRefreshing: Boolean = false,
+    onRefresh: () -> Unit = {},
+    onRetry: () -> Unit = {},
+    onNavigateToJobStatus: (Int) -> Unit = {},
+) {
     Box(modifier = Modifier.fillMaxSize()) {
         when (val state = uiState) {
             is DashboardUiState.Loading -> {
@@ -87,17 +107,14 @@ fun DashboardScreen(
             is DashboardUiState.Error -> {
                 ErrorMessage(
                     error = state.error,
-                    onRetry = { viewModel.refresh() },
+                    onRetry = onRetry,
                     modifier = Modifier.align(Alignment.Center)
                 )
             }
             is DashboardUiState.Success -> {
                 PullToRefreshBox(
                     isRefreshing = isRefreshing,
-                    onRefresh = {
-                        isRefreshing = true
-                        viewModel.refresh()
-                    },
+                    onRefresh = onRefresh,
                     modifier = Modifier.fillMaxSize()
                 ) {
                     LazyColumn(
@@ -661,6 +678,60 @@ private fun InfoRow(label: String, value: String, modifier: Modifier = Modifier)
             text = value,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Dashboard - Loading")
+@Composable
+private fun DashboardLoadingPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        DashboardContent(uiState = DashboardUiState.Loading)
+    }
+}
+
+@Preview(showBackground = true, name = "Dashboard - Error")
+@Composable
+private fun DashboardErrorPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        DashboardContent(uiState = DashboardUiState.Error(AppError.Network()))
+    }
+}
+
+@Preview(showBackground = true, name = "Dashboard - Success")
+@Composable
+private fun DashboardContentPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        DashboardContent(
+            uiState = DashboardUiState.Success(
+                activeJobsCount = 3,
+                failedCount24h = 1,
+                successfulCount24h = 12,
+                recentFailures = emptyList(),
+                healthStatus = HealthStatus.GREEN,
+                inventoryCount = 5,
+                hostCount = 42,
+                templateCount = 18,
+                projectCount = 7,
+                jobHistory7d = listOf(
+                    DayJobStats("Mon", 8, 1),
+                    DayJobStats("Tue", 12, 0),
+                    DayJobStats("Wed", 6, 2),
+                    DayJobStats("Thu", 10, 1),
+                    DayJobStats("Fri", 14, 0),
+                    DayJobStats("Sat", 3, 0),
+                    DayJobStats("Sun", 2, 0),
+                ),
+                instanceInfo = InstanceInfo(
+                    controllerVersion = "4.6.0",
+                    gatewayVersion = "2.6.0",
+                    edaVersion = "1.1.0",
+                    platformType = "AAP",
+                    aapVersion = "2.6",
+                ),
+                instanceUrl = "https://aap.example.com",
+                instanceAlias = "Production AAP",
+            )
         )
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/dashboard/DashboardScreen.kt
@@ -92,12 +92,13 @@ fun DashboardScreen(
 @Composable
 internal fun DashboardContent(
     uiState: DashboardUiState,
+    modifier: Modifier = Modifier,
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
     onRetry: () -> Unit = {},
     onNavigateToJobStatus: (Int) -> Unit = {},
 ) {
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = modifier.fillMaxSize()) {
         when (val state = uiState) {
             is DashboardUiState.Loading -> {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/dashboard/DashboardScreen.kt
@@ -55,7 +55,7 @@ import io.github.leogallego.ansiblejane.presentation.dashboard.DashboardViewMode
 import io.github.leogallego.ansiblejane.presentation.dashboard.DayJobStats
 import io.github.leogallego.ansiblejane.presentation.dashboard.HealthStatus
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import io.github.leogallego.ansiblejane.model.AppError
 import io.github.leogallego.ansiblejane.ui.components.ErrorMessage
 import io.github.leogallego.ansiblejane.ui.components.JobStatusBadge
@@ -683,7 +683,7 @@ private fun InfoRow(label: String, value: String, modifier: Modifier = Modifier)
     }
 }
 
-@Preview(showBackground = true, name = "Dashboard - Loading")
+@PreviewLightDark
 @Composable
 private fun DashboardLoadingPreview() {
     AnsibleJaneTheme(dynamicColor = false) {
@@ -691,7 +691,7 @@ private fun DashboardLoadingPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "Dashboard - Error")
+@PreviewLightDark
 @Composable
 private fun DashboardErrorPreview() {
     AnsibleJaneTheme(dynamicColor = false) {
@@ -699,7 +699,7 @@ private fun DashboardErrorPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "Dashboard - Success")
+@PreviewLightDark
 @Composable
 private fun DashboardContentPreview() {
     AnsibleJaneTheme(dynamicColor = false) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/templates/TemplateListScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/templates/TemplateListScreen.kt
@@ -21,7 +21,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.leogallego.ansiblejane.model.JobTemplate
+import io.github.leogallego.ansiblejane.model.JobTemplateSummaryFields
 import io.github.leogallego.ansiblejane.model.Label
+import io.github.leogallego.ansiblejane.model.LabelSummary
+import io.github.leogallego.ansiblejane.model.UserCapabilities
 import io.github.leogallego.ansiblejane.presentation.templates.LaunchState
 import io.github.leogallego.ansiblejane.presentation.templates.TemplatesUiState
 import io.github.leogallego.ansiblejane.presentation.templates.TemplatesViewModel
@@ -35,6 +40,8 @@ import io.github.leogallego.ansiblejane.ui.components.LoadingList
 import io.github.leogallego.ansiblejane.ui.components.PaginationEffect
 import io.github.leogallego.ansiblejane.ui.components.SearchBar
 import io.github.leogallego.ansiblejane.ui.components.TemplateCard
+import io.github.leogallego.ansiblejane.model.AppError
+import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
 import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -178,5 +185,89 @@ fun TemplateListScreen(
             hostState = snackbarHostState,
             modifier = Modifier.align(Alignment.BottomCenter)
         )
+    }
+}
+
+private val previewTemplates = listOf(
+    JobTemplate(
+        id = 1,
+        name = "Deploy Web Application",
+        description = "Deploys the web application to production servers",
+        summaryFields = JobTemplateSummaryFields(
+            labels = LabelSummary(2, listOf(Label(1, "production"), Label(2, "deploy"))),
+            userCapabilities = UserCapabilities(start = true)
+        )
+    ),
+    JobTemplate(
+        id = 2,
+        name = "System Health Check",
+        description = "Runs health checks across all managed hosts",
+        summaryFields = JobTemplateSummaryFields(
+            labels = LabelSummary(1, listOf(Label(3, "monitoring"))),
+            userCapabilities = UserCapabilities(start = true)
+        )
+    ),
+    JobTemplate(
+        id = 3,
+        name = "Patch Management",
+        description = "Applies security patches and system updates",
+        summaryFields = JobTemplateSummaryFields(
+            userCapabilities = UserCapabilities(start = false)
+        )
+    ),
+)
+
+@Preview(showBackground = true, name = "Templates - Loading")
+@Composable
+private fun TemplateListLoadingPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            SearchBar(onSearch = {})
+            LoadingList()
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Templates - Empty")
+@Composable
+private fun TemplateListEmptyPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            SearchBar(onSearch = {})
+            EmptyState(message = "No templates available")
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Templates - Content")
+@Composable
+private fun TemplateListContentPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            SearchBar(onSearch = {})
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(
+                    items = previewTemplates,
+                    key = { it.id }
+                ) { template ->
+                    TemplateCard(
+                        template = template,
+                        onClick = {},
+                        onLaunch = {}
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Templates - Error")
+@Composable
+private fun TemplateListErrorPreview() {
+    AnsibleJaneTheme(dynamicColor = false) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            SearchBar(onSearch = {})
+            ErrorMessage(error = AppError.Network(), onRetry = {})
+        }
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/templates/TemplateListScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/templates/TemplateListScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import io.github.leogallego.ansiblejane.model.JobTemplate
 import io.github.leogallego.ansiblejane.model.JobTemplateSummaryFields
 import io.github.leogallego.ansiblejane.model.Label
@@ -217,7 +217,7 @@ private val previewTemplates = listOf(
     ),
 )
 
-@Preview(showBackground = true, name = "Templates - Loading")
+@PreviewLightDark
 @Composable
 private fun TemplateListLoadingPreview() {
     AnsibleJaneTheme(dynamicColor = false) {
@@ -228,7 +228,7 @@ private fun TemplateListLoadingPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "Templates - Empty")
+@PreviewLightDark
 @Composable
 private fun TemplateListEmptyPreview() {
     AnsibleJaneTheme(dynamicColor = false) {
@@ -239,7 +239,7 @@ private fun TemplateListEmptyPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "Templates - Content")
+@PreviewLightDark
 @Composable
 private fun TemplateListContentPreview() {
     AnsibleJaneTheme(dynamicColor = false) {
@@ -261,7 +261,7 @@ private fun TemplateListContentPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "Templates - Error")
+@PreviewLightDark
 @Composable
 private fun TemplateListErrorPreview() {
     AnsibleJaneTheme(dynamicColor = false) {


### PR DESCRIPTION
## Summary

Closes #89 (remaining @Preview coverage work)

- Add 19 `@Preview` functions across 9 files — shared components and key screens can now be iterated in Android Studio's preview pane without running the app
- **Shared components** (6 files): EmptyState, ErrorMessage (3 variants), LoadingList, JobStatusBadge (all 8 status variants), ProviderSwitchChip (active + no-LLM), TemplateCard (launchable + read-only)
- **Screen previews** (3 files): Dashboard (loading/error/success with sample data), TemplateList (loading/empty/content/error), AssistantChat (empty chat + conversation with streaming)
- Extract `DashboardContent` composable from `DashboardScreen` for preview-friendly state injection — no behavior change

## Test plan

- [x] `./gradlew compileDebugKotlin` passes
- [x] `./gradlew testDebugUnitTest` passes (all existing tests green)
- [x] `grep -rn '@Preview' app/src/main/kotlin/` confirms 19 preview annotations
- [ ] Open files in Android Studio and verify preview pane renders correctly

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>