### PR TITLE
Migrate ViewModels to _uiState.update{} for atomic state mutations

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -57,7 +57,7 @@ class AssistantViewModel(
         viewModelScope.launch {
             repository.activeConfigFlow.collect { config ->
                 val oldKey = cachedProviderKey
-                _llmConfig.value = config
+                _llmConfig.update { config }
                 if (config != null && oldKey != null) {
                     val newKey = when (config) {
                         is LlmProviderConfig.OpenAiCompatible ->

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/approval/ApprovalDetailViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/approval/ApprovalDetailViewModel.kt
@@ -9,6 +9,7 @@ import io.github.leogallego.ansiblejane.model.WorkflowApproval
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 sealed interface ApprovalDetailUiState {
@@ -35,20 +36,18 @@ class ApprovalDetailViewModel(
 
     fun loadApproval() {
         if (approvalId <= 0) {
-            _uiState.value = ApprovalDetailUiState.Error(
-                AppError.Unknown("Invalid approval ID")
-            )
+            _uiState.update { ApprovalDetailUiState.Error(AppError.Unknown("Invalid approval ID")) }
             return
         }
 
-        _uiState.value = ApprovalDetailUiState.Loading
+        _uiState.update { ApprovalDetailUiState.Loading }
         viewModelScope.launch {
             workflowRepository.getWorkflowApproval(approvalId).fold(
                 onSuccess = { approval ->
-                    _uiState.value = ApprovalDetailUiState.Ready(approval)
+                    _uiState.update { ApprovalDetailUiState.Ready(approval) }
                 },
                 onFailure = { e ->
-                    _uiState.value = ApprovalDetailUiState.Error(AppError.from(e))
+                    _uiState.update { ApprovalDetailUiState.Error(AppError.from(e)) }
                 }
             )
         }
@@ -61,14 +60,14 @@ class ApprovalDetailViewModel(
             else -> return
         }
 
-        _uiState.value = ApprovalDetailUiState.ActionInProgress(approval, "approve")
+        _uiState.update { ApprovalDetailUiState.ActionInProgress(approval, "approve") }
         viewModelScope.launch {
             workflowRepository.approveWorkflow(approvalId).fold(
                 onSuccess = {
-                    _uiState.value = ApprovalDetailUiState.Completed(approval, "approved")
+                    _uiState.update { ApprovalDetailUiState.Completed(approval, "approved") }
                 },
                 onFailure = { e ->
-                    _uiState.value = ApprovalDetailUiState.Error(AppError.from(e))
+                    _uiState.update { ApprovalDetailUiState.Error(AppError.from(e)) }
                 }
             )
         }
@@ -81,14 +80,14 @@ class ApprovalDetailViewModel(
             else -> return
         }
 
-        _uiState.value = ApprovalDetailUiState.ActionInProgress(approval, "deny")
+        _uiState.update { ApprovalDetailUiState.ActionInProgress(approval, "deny") }
         viewModelScope.launch {
             workflowRepository.denyWorkflow(approvalId).fold(
                 onSuccess = {
-                    _uiState.value = ApprovalDetailUiState.Completed(approval, "denied")
+                    _uiState.update { ApprovalDetailUiState.Completed(approval, "denied") }
                 },
                 onFailure = { e ->
-                    _uiState.value = ApprovalDetailUiState.Error(AppError.from(e))
+                    _uiState.update { ApprovalDetailUiState.Error(AppError.from(e)) }
                 }
             )
         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/auth/AuthViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/auth/AuthViewModel.kt
@@ -8,6 +8,7 @@ import io.github.leogallego.ansiblejane.model.AppError
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class AuthViewModel(
@@ -28,13 +29,13 @@ class AuthViewModel(
         existingInstanceId: String? = null
     ) {
         if (baseUrl.isBlank() || token.isBlank()) {
-            _uiState.value = AuthUiState.Error(
-                AppError.Unknown(message = "URL and token are required")
-            )
+            _uiState.update {
+                AuthUiState.Error(AppError.Unknown(message = "URL and token are required"))
+            }
             return
         }
 
-        _uiState.value = AuthUiState.Loading
+        _uiState.update { AuthUiState.Loading }
         viewModelScope.launch {
             val result = authRepository.validateCredentials(
                 baseUrl = baseUrl,
@@ -43,20 +44,24 @@ class AuthViewModel(
                 alias = alias?.ifBlank { null },
                 existingInstanceId = existingInstanceId
             )
-            _uiState.value = result.fold(
-                onSuccess = { user -> AuthUiState.Success(user.username) },
-                onFailure = { error -> AuthUiState.Error(AppError.from(error)) }
-            )
+            _uiState.update {
+                result.fold(
+                    onSuccess = { user -> AuthUiState.Success(user.username) },
+                    onFailure = { error -> AuthUiState.Error(AppError.from(error)) }
+                )
+            }
         }
     }
 
     fun checkExistingCredentials() {
-        _uiState.value = AuthUiState.Loading
+        _uiState.update { AuthUiState.Loading }
         viewModelScope.launch {
-            _uiState.value = when (val status = authRepository.checkExistingCredentials()) {
-                is CredentialStatus.Valid -> AuthUiState.Success(status.user.username)
-                is CredentialStatus.NoCredentials -> AuthUiState.Idle
-                is CredentialStatus.ValidationFailed -> AuthUiState.Idle
+            _uiState.update {
+                when (val status = authRepository.checkExistingCredentials()) {
+                    is CredentialStatus.Valid -> AuthUiState.Success(status.user.username)
+                    is CredentialStatus.NoCredentials -> AuthUiState.Idle
+                    is CredentialStatus.ValidationFailed -> AuthUiState.Idle
+                }
             }
         }
     }
@@ -64,11 +69,11 @@ class AuthViewModel(
     fun logout() {
         viewModelScope.launch {
             authRepository.logout()
-            _uiState.value = AuthUiState.Idle
+            _uiState.update { AuthUiState.Idle }
         }
     }
 
     fun resetState() {
-        _uiState.value = AuthUiState.Idle
+        _uiState.update { AuthUiState.Idle }
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/dashboard/DashboardViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/dashboard/DashboardViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.ZoneId
@@ -52,13 +53,16 @@ class DashboardViewModel(
             tokenManager.activeInstance
                 .distinctUntilChangedBy { it?.instanceInfo }
                 .collect { instance ->
-                    val current = _uiState.value
-                    if (instance != null && current is DashboardUiState.Success) {
-                        _uiState.value = current.copy(
-                            instanceInfo = instance.instanceInfo,
-                            instanceUrl = instance.baseUrl,
-                            instanceAlias = instance.displayLabel,
-                        )
+                    if (instance != null) {
+                        _uiState.update { current ->
+                            if (current is DashboardUiState.Success) {
+                                current.copy(
+                                    instanceInfo = instance.instanceInfo,
+                                    instanceUrl = instance.baseUrl,
+                                    instanceAlias = instance.displayLabel,
+                                )
+                            } else current
+                        }
                     }
                 }
         }
@@ -70,7 +74,7 @@ class DashboardViewModel(
 
     private fun loadDashboard() {
         dashboardJob?.cancel()
-        _uiState.value = DashboardUiState.Loading
+        _uiState.update { DashboardUiState.Loading }
         dashboardJob = viewModelScope.launch {
             val instance = tokenManager.activeInstance.value ?: return@launch
             val since24h = Instant.now().minus(24, ChronoUnit.HOURS).toString()
@@ -135,7 +139,7 @@ class DashboardViewModel(
             if (firstError != null) {
                 val exception = firstError.exceptionOrNull()
                     ?: IllegalStateException("Unknown dashboard error")
-                _uiState.value = DashboardUiState.Error(AppError.from(exception))
+                _uiState.update { DashboardUiState.Error(AppError.from(exception)) }
                 return@launch
             }
 
@@ -157,24 +161,26 @@ class DashboardViewModel(
                 else -> HealthStatus.GREEN
             }
 
-            _uiState.value = DashboardUiState.Success(
-                activeJobsCount = activeCount,
-                failedCount24h = failedData.totalCount,
-                successfulCount24h = successCount,
-                recentFailures = failedData.jobs,
-                healthStatus = healthStatus,
-                inventoryCount = inventoryCount,
-                hostCount = hostCount,
-                templateCount = templateCount,
-                projectCount = projectCount,
-                edaActivationsCount = edaData?.first,
-                edaActiveRulebooksCount = edaData?.second,
-                jobHistory7d = jobHistory,
-                upcomingSchedules = schedules,
-                instanceInfo = instance?.instanceInfo,
-                instanceUrl = instance?.baseUrl,
-                instanceAlias = instance?.displayLabel,
-            )
+            _uiState.update {
+                DashboardUiState.Success(
+                    activeJobsCount = activeCount,
+                    failedCount24h = failedData.totalCount,
+                    successfulCount24h = successCount,
+                    recentFailures = failedData.jobs,
+                    healthStatus = healthStatus,
+                    inventoryCount = inventoryCount,
+                    hostCount = hostCount,
+                    templateCount = templateCount,
+                    projectCount = projectCount,
+                    edaActivationsCount = edaData?.first,
+                    edaActiveRulebooksCount = edaData?.second,
+                    jobHistory7d = jobHistory,
+                    upcomingSchedules = schedules,
+                    instanceInfo = instance?.instanceInfo,
+                    instanceUrl = instance?.baseUrl,
+                    instanceAlias = instance?.displayLabel,
+                )
+            }
         }
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/eda/EdaAuditViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/eda/EdaAuditViewModel.kt
@@ -80,7 +80,9 @@ class EdaAuditViewModel(
         val current = _uiState.value
         if (current is EdaAuditUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.update { current.copy(isLoadingMore = true) }
+            _uiState.update { state ->
+                (state as? EdaAuditUiState.Success)?.copy(isLoadingMore = true) ?: state
+            }
             fetchJob = viewModelScope.launch {
                 fetchAuditRules(append = true)
             }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/eda/EdaAuditViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/eda/EdaAuditViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
 
@@ -46,7 +47,7 @@ class EdaAuditViewModel(
     fun loadAuditRules() {
         currentPage = 1
         allAuditRules.clear()
-        _uiState.value = EdaAuditUiState.Loading
+        _uiState.update { EdaAuditUiState.Loading }
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             fetchAuditRules()
@@ -63,14 +64,14 @@ class EdaAuditViewModel(
     }
 
     fun search(query: String) {
-        _searchQuery.value = query
+        _searchQuery.update { query }
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
             delay(300)
             currentSearch = query.ifBlank { null }
             currentPage = 1
             allAuditRules.clear()
-            _uiState.value = EdaAuditUiState.Loading
+            _uiState.update { EdaAuditUiState.Loading }
             fetchAuditRules()
         }
     }
@@ -79,7 +80,7 @@ class EdaAuditViewModel(
         val current = _uiState.value
         if (current is EdaAuditUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.value = current.copy(isLoadingMore = true)
+            _uiState.update { current.copy(isLoadingMore = true) }
             fetchJob = viewModelScope.launch {
                 fetchAuditRules(append = true)
             }
@@ -96,22 +97,21 @@ class EdaAuditViewModel(
                     allAuditRules.clear()
                     allAuditRules.addAll(auditResult.auditRules)
                 }
-                if (allAuditRules.isEmpty()) {
-                    _uiState.value = EdaAuditUiState.Empty("No EDA audit events")
-                } else {
-                    _uiState.value = EdaAuditUiState.Success(
+                _uiState.update {
+                    if (allAuditRules.isEmpty()) EdaAuditUiState.Empty("No EDA audit events")
+                    else EdaAuditUiState.Success(
                         auditRules = allAuditRules.toList(),
                         hasMore = auditResult.hasMore
                     )
                 }
             },
             onFailure = { error ->
-                if (error is HttpException && error.code() in listOf(404, 502, 503)) {
-                    _uiState.value = EdaAuditUiState.Empty(
-                        "EDA is not configured on this AAP instance"
-                    )
-                } else {
-                    _uiState.value = EdaAuditUiState.Error(AppError.from(error))
+                _uiState.update {
+                    if (error is HttpException && error.code() in listOf(404, 502, 503)) {
+                        EdaAuditUiState.Empty("EDA is not configured on this AAP instance")
+                    } else {
+                        EdaAuditUiState.Error(AppError.from(error))
+                    }
                 }
             }
         )

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostsViewModel.kt
@@ -63,7 +63,9 @@ class HostsViewModel(
         val current = _uiState.value
         if (current is HostsUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.update { current.copy(isLoadingMore = true) }
+            _uiState.update { state ->
+                (state as? HostsUiState.Success)?.copy(isLoadingMore = true) ?: state
+            }
             viewModelScope.launch {
                 fetchHosts(append = true)
             }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostsViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class HostsViewModel(
@@ -42,7 +43,7 @@ class HostsViewModel(
     fun loadHosts() {
         currentPage = 1
         allHosts.clear()
-        _uiState.value = HostsUiState.Loading
+        _uiState.update { HostsUiState.Loading }
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             fetchHosts()
@@ -62,7 +63,7 @@ class HostsViewModel(
         val current = _uiState.value
         if (current is HostsUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.value = current.copy(isLoadingMore = true)
+            _uiState.update { current.copy(isLoadingMore = true) }
             viewModelScope.launch {
                 fetchHosts(append = true)
             }
@@ -76,7 +77,7 @@ class HostsViewModel(
             currentSearch = query.ifBlank { null }
             currentPage = 1
             allHosts.clear()
-            _uiState.value = HostsUiState.Loading
+            _uiState.update { HostsUiState.Loading }
             fetchHosts()
         }
     }
@@ -95,17 +96,16 @@ class HostsViewModel(
                     allHosts = listResult.hosts.toMutableList()
                 }
 
-                if (allHosts.isEmpty()) {
-                    _uiState.value = HostsUiState.Empty("No hosts found")
-                } else {
-                    _uiState.value = HostsUiState.Success(
+                _uiState.update {
+                    if (allHosts.isEmpty()) HostsUiState.Empty("No hosts found")
+                    else HostsUiState.Success(
                         hosts = allHosts.toList(),
                         hasMore = listResult.hasMore
                     )
                 }
             },
             onFailure = { error ->
-                _uiState.value = HostsUiState.Error(AppError.from(error))
+                _uiState.update { HostsUiState.Error(AppError.from(error)) }
             }
         )
     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/InventoryHostsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/InventoryHostsViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class InventoryHostsViewModel(
@@ -29,7 +30,7 @@ class InventoryHostsViewModel(
         currentInventoryId = inventoryId
         currentPage = 1
         allHosts.clear()
-        _uiState.value = InventoryHostsUiState.Loading
+        _uiState.update { InventoryHostsUiState.Loading }
         viewModelScope.launch {
             fetchHosts()
         }
@@ -47,7 +48,7 @@ class InventoryHostsViewModel(
         val current = _uiState.value
         if (current is InventoryHostsUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.value = current.copy(isLoadingMore = true)
+            _uiState.update { current.copy(isLoadingMore = true) }
             viewModelScope.launch {
                 fetchHosts(append = true)
             }
@@ -61,7 +62,7 @@ class InventoryHostsViewModel(
             currentSearch = query.ifBlank { null }
             currentPage = 1
             allHosts.clear()
-            _uiState.value = InventoryHostsUiState.Loading
+            _uiState.update { InventoryHostsUiState.Loading }
             fetchHosts()
         }
     }
@@ -80,17 +81,16 @@ class InventoryHostsViewModel(
                     allHosts.clear()
                     allHosts.addAll(hostResult.hosts)
                 }
-                if (allHosts.isEmpty()) {
-                    _uiState.value = InventoryHostsUiState.Empty("No hosts found")
-                } else {
-                    _uiState.value = InventoryHostsUiState.Success(
+                _uiState.update {
+                    if (allHosts.isEmpty()) InventoryHostsUiState.Empty("No hosts found")
+                    else InventoryHostsUiState.Success(
                         hosts = allHosts.toList(),
                         hasMore = hostResult.hasMore
                     )
                 }
             },
             onFailure = { error ->
-                _uiState.value = InventoryHostsUiState.Error(AppError.from(error))
+                _uiState.update { InventoryHostsUiState.Error(AppError.from(error)) }
             }
         )
     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/InventoryHostsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/InventoryHostsViewModel.kt
@@ -48,7 +48,9 @@ class InventoryHostsViewModel(
         val current = _uiState.value
         if (current is InventoryHostsUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.update { current.copy(isLoadingMore = true) }
+            _uiState.update { state ->
+                (state as? InventoryHostsUiState.Success)?.copy(isLoadingMore = true) ?: state
+            }
             viewModelScope.launch {
                 fetchHosts(append = true)
             }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/inventory/InventoriesViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/inventory/InventoriesViewModel.kt
@@ -79,7 +79,9 @@ class InventoriesViewModel(
         val current = _uiState.value
         if (current is InventoriesUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.update { current.copy(isLoadingMore = true) }
+            _uiState.update { state ->
+                (state as? InventoriesUiState.Success)?.copy(isLoadingMore = true) ?: state
+            }
             fetchJob = viewModelScope.launch {
                 fetchInventories(append = true)
             }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/inventory/InventoriesViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/inventory/InventoriesViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class InventoriesViewModel(
@@ -45,7 +46,7 @@ class InventoriesViewModel(
     fun loadInventories() {
         currentPage = 1
         allInventories.clear()
-        _uiState.value = InventoriesUiState.Loading
+        _uiState.update { InventoriesUiState.Loading }
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             fetchInventories()
@@ -62,14 +63,14 @@ class InventoriesViewModel(
     }
 
     fun search(query: String) {
-        _searchQuery.value = query
+        _searchQuery.update { query }
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
             delay(300)
             currentSearch = query.ifBlank { null }
             currentPage = 1
             allInventories.clear()
-            _uiState.value = InventoriesUiState.Loading
+            _uiState.update { InventoriesUiState.Loading }
             fetchInventories()
         }
     }
@@ -78,7 +79,7 @@ class InventoriesViewModel(
         val current = _uiState.value
         if (current is InventoriesUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.value = current.copy(isLoadingMore = true)
+            _uiState.update { current.copy(isLoadingMore = true) }
             fetchJob = viewModelScope.launch {
                 fetchInventories(append = true)
             }
@@ -95,17 +96,19 @@ class InventoriesViewModel(
                     allInventories.clear()
                     allInventories.addAll(inventoryResult.inventories)
                 }
-                if (allInventories.isEmpty()) {
-                    _uiState.value = InventoriesUiState.Empty("No inventories found")
-                } else {
-                    _uiState.value = InventoriesUiState.Success(
-                        inventories = allInventories.toList(),
-                        hasMore = inventoryResult.hasMore
-                    )
+                _uiState.update {
+                    if (allInventories.isEmpty()) {
+                        InventoriesUiState.Empty("No inventories found")
+                    } else {
+                        InventoriesUiState.Success(
+                            inventories = allInventories.toList(),
+                            hasMore = inventoryResult.hasMore
+                        )
+                    }
                 }
             },
             onFailure = { error ->
-                _uiState.value = InventoriesUiState.Error(AppError.from(error))
+                _uiState.update { InventoriesUiState.Error(AppError.from(error)) }
             }
         )
     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/jobs/JobStatusViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/jobs/JobStatusViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class JobStatusViewModel(
@@ -30,14 +31,13 @@ class JobStatusViewModel(
         pollingJob = viewModelScope.launch {
             jobRepository.pollJobStatus(jobId)
                 .catch { e ->
-                    _uiState.value = JobStatusUiState.Error(AppError.from(e))
+                    _uiState.update { JobStatusUiState.Error(AppError.from(e)) }
                 }
                 .collect { job ->
                     val stdout = jobRepository.getJobStdout(jobId).getOrNull()
-                    _uiState.value = if (job.status.isTerminal) {
-                        JobStatusUiState.Completed(job, stdout)
-                    } else {
-                        JobStatusUiState.Active(job, stdout)
+                    _uiState.update {
+                        if (job.status.isTerminal) JobStatusUiState.Completed(job, stdout)
+                        else JobStatusUiState.Active(job, stdout)
                     }
                 }
         }
@@ -49,7 +49,7 @@ class JobStatusViewModel(
     }
 
     fun retry() {
-        _uiState.value = JobStatusUiState.Loading
+        _uiState.update { JobStatusUiState.Loading }
         startPolling()
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/jobs/RecentJobsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/jobs/RecentJobsViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class RecentJobsViewModel(
@@ -46,7 +47,7 @@ class RecentJobsViewModel(
     fun loadRecentJobs() {
         currentPage = 1
         allJobs.clear()
-        _uiState.value = RecentJobsUiState.Loading
+        _uiState.update { RecentJobsUiState.Loading }
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             fetchJobs()
@@ -70,7 +71,7 @@ class RecentJobsViewModel(
         }
         currentPage = 1
         allJobs.clear()
-        _uiState.value = RecentJobsUiState.Loading
+        _uiState.update { RecentJobsUiState.Loading }
         viewModelScope.launch {
             fetchJobs()
         }
@@ -80,21 +81,21 @@ class RecentJobsViewModel(
         activeFilters.clear()
         currentPage = 1
         allJobs.clear()
-        _uiState.value = RecentJobsUiState.Loading
+        _uiState.update { RecentJobsUiState.Loading }
         viewModelScope.launch {
             fetchJobs()
         }
     }
 
     fun search(query: String) {
-        _searchQuery.value = query
+        _searchQuery.update { query }
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
             delay(300)
             currentSearch = query.ifBlank { null }
             currentPage = 1
             allJobs.clear()
-            _uiState.value = RecentJobsUiState.Loading
+            _uiState.update { RecentJobsUiState.Loading }
             fetchJobs()
         }
     }
@@ -105,7 +106,7 @@ class RecentJobsViewModel(
         val current = _uiState.value
         if (current is RecentJobsUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.value = current.copy(isLoadingMore = true)
+            _uiState.update { current.copy(isLoadingMore = true) }
             viewModelScope.launch {
                 fetchJobs(append = true)
             }
@@ -126,14 +127,16 @@ class RecentJobsViewModel(
                     allJobs.clear()
                     allJobs.addAll(jobsResult.jobs)
                 }
-                _uiState.value = RecentJobsUiState.Success(
-                    jobs = allJobs.toList(),
-                    hasMore = jobsResult.hasMore,
-                    activeFilters = activeFilters.toSet()
-                )
+                _uiState.update {
+                    RecentJobsUiState.Success(
+                        jobs = allJobs.toList(),
+                        hasMore = jobsResult.hasMore,
+                        activeFilters = activeFilters.toSet()
+                    )
+                }
             },
             onFailure = { error ->
-                _uiState.value = RecentJobsUiState.Error(AppError.from(error))
+                _uiState.update { RecentJobsUiState.Error(AppError.from(error)) }
             }
         )
     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/jobs/RecentJobsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/jobs/RecentJobsViewModel.kt
@@ -106,7 +106,9 @@ class RecentJobsViewModel(
         val current = _uiState.value
         if (current is RecentJobsUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.update { current.copy(isLoadingMore = true) }
+            _uiState.update { state ->
+                (state as? RecentJobsUiState.Success)?.copy(isLoadingMore = true) ?: state
+            }
             viewModelScope.launch {
                 fetchJobs(append = true)
             }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/notifications/NotificationsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/notifications/NotificationsViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 data class NotificationsUiState(
@@ -43,20 +44,24 @@ class NotificationsViewModel(
         val oldJob = refreshJob
         refreshJob = viewModelScope.launch {
             oldJob?.cancelAndJoin()
-            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            _uiState.update { it.copy(isLoading = true, error = null) }
             workflowRepository.getPendingApprovals(pageSize = 50).fold(
                 onSuccess = { result ->
                     lastFetchTime = System.currentTimeMillis()
-                    _uiState.value = NotificationsUiState(
-                        approvals = result.approvals,
-                        isLoading = false,
-                    )
+                    _uiState.update {
+                        NotificationsUiState(
+                            approvals = result.approvals,
+                            isLoading = false,
+                        )
+                    }
                 },
                 onFailure = { e ->
-                    _uiState.value = _uiState.value.copy(
-                        isLoading = false,
-                        error = e.message ?: "Failed to load approvals"
-                    )
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = e.message ?: "Failed to load approvals"
+                        )
+                    }
                 }
             )
         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/schedules/SchedulesViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/schedules/SchedulesViewModel.kt
@@ -66,7 +66,9 @@ class SchedulesViewModel(
         val current = _uiState.value
         if (current is SchedulesUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.update { current.copy(isLoadingMore = true) }
+            _uiState.update { state ->
+                (state as? SchedulesUiState.Success)?.copy(isLoadingMore = true) ?: state
+            }
             fetchJob = viewModelScope.launch {
                 fetchSchedules(append = true)
             }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/schedules/SchedulesViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/schedules/SchedulesViewModel.kt
@@ -9,6 +9,7 @@ import io.github.leogallego.ansiblejane.model.Schedule
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -45,7 +46,7 @@ class SchedulesViewModel(
     fun loadSchedules() {
         currentPage = 1
         allSchedules.clear()
-        _uiState.value = SchedulesUiState.Loading
+        _uiState.update { SchedulesUiState.Loading }
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             fetchSchedules()
@@ -65,7 +66,7 @@ class SchedulesViewModel(
         val current = _uiState.value
         if (current is SchedulesUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.value = current.copy(isLoadingMore = true)
+            _uiState.update { current.copy(isLoadingMore = true) }
             fetchJob = viewModelScope.launch {
                 fetchSchedules(append = true)
             }
@@ -97,9 +98,9 @@ class SchedulesViewModel(
     }
 
     private fun updateSuccessState() {
-        val current = _uiState.value
-        if (current is SchedulesUiState.Success) {
-            _uiState.value = current.copy(schedules = allSchedules.toList())
+        _uiState.update { current ->
+            if (current is SchedulesUiState.Success) current.copy(schedules = allSchedules.toList())
+            else current
         }
     }
 
@@ -113,13 +114,15 @@ class SchedulesViewModel(
                     allSchedules.clear()
                     allSchedules.addAll(schedulesResult.schedules)
                 }
-                _uiState.value = SchedulesUiState.Success(
-                    schedules = allSchedules.toList(),
-                    hasMore = schedulesResult.hasMore
-                )
+                _uiState.update {
+                    SchedulesUiState.Success(
+                        schedules = allSchedules.toList(),
+                        hasMore = schedulesResult.hasMore
+                    )
+                }
             },
             onFailure = { error ->
-                _uiState.value = SchedulesUiState.Error(AppError.from(error))
+                _uiState.update { SchedulesUiState.Error(AppError.from(error)) }
             }
         )
     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/BackupViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/BackupViewModel.kt
@@ -13,6 +13,7 @@ import io.github.leogallego.ansiblejane.network.ApiVersion
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 enum class ImportMode { MERGE, REPLACE }
@@ -47,26 +48,26 @@ class BackupViewModel(
 
     fun exportBackup(password: String, includeAssistantConfig: Boolean) {
         viewModelScope.launch {
-            _uiState.value = BackupUiState.Exporting
+            _uiState.update { BackupUiState.Exporting }
             try {
                 val instances = tokenManager.instances.value
                 if (instances.isEmpty()) {
-                    _uiState.value = BackupUiState.Error("No instances to export")
+                    _uiState.update { BackupUiState.Error("No instances to export") }
                     return@launch
                 }
                 val llmConfig = if (includeAssistantConfig) assistantRepository.loadLlmConfig() else null
                 val allConfigs = if (includeAssistantConfig) assistantRepository.loadAllLlmConfigs() else null
                 val data = backupManager.exportBackup(password, instances, llmConfig, allConfigs)
-                _uiState.value = BackupUiState.ExportReady(data)
+                _uiState.update { BackupUiState.ExportReady(data) }
             } catch (e: Exception) {
-                _uiState.value = BackupUiState.Error("Export failed: ${e.message}")
+                _uiState.update { BackupUiState.Error("Export failed: ${e.message}") }
             }
         }
     }
 
     fun startImport(data: ByteArray, password: String) {
         viewModelScope.launch {
-            _uiState.value = BackupUiState.Importing
+            _uiState.update { BackupUiState.Importing }
             try {
                 val envelope = backupManager.importBackup(data, password)
                 val existingUrls = tokenManager.instances.value
@@ -80,18 +81,20 @@ class BackupViewModel(
                 }
 
                 pendingEnvelope = envelope
-                _uiState.value = BackupUiState.ImportPreview(
-                    envelope = envelope,
-                    duplicateCount = duplicates,
-                    newCount = newOnes,
-                    instances = envelope.instances,
-                    llmConfig = envelope.llmConfig,
-                    hasExistingInstances = existingUrls.isNotEmpty()
-                )
+                _uiState.update {
+                    BackupUiState.ImportPreview(
+                        envelope = envelope,
+                        duplicateCount = duplicates,
+                        newCount = newOnes,
+                        instances = envelope.instances,
+                        llmConfig = envelope.llmConfig,
+                        hasExistingInstances = existingUrls.isNotEmpty()
+                    )
+                }
             } catch (e: BackupDecryptionException) {
-                _uiState.value = BackupUiState.Error(e.message ?: "Decryption failed")
+                _uiState.update { BackupUiState.Error(e.message ?: "Decryption failed") }
             } catch (e: Exception) {
-                _uiState.value = BackupUiState.Error("Import failed: ${e.message}")
+                _uiState.update { BackupUiState.Error("Import failed: ${e.message}") }
             }
         }
     }
@@ -99,7 +102,7 @@ class BackupViewModel(
     fun confirmImport(mode: ImportMode) {
         val envelope = pendingEnvelope ?: return
         viewModelScope.launch {
-            _uiState.value = BackupUiState.Importing
+            _uiState.update { BackupUiState.Importing }
             try {
                 // Validate all import data before mutating state
                 val validatedInstances = envelope.instances.map { inst ->
@@ -159,15 +162,15 @@ class BackupViewModel(
 
                 val llmNote = if (!envelope.llmConfigs.isNullOrEmpty() || envelope.llmConfig != null) " + LLM config" else ""
                 pendingEnvelope = null
-                _uiState.value = BackupUiState.Success("Imported $imported instance(s)$llmNote")
+                _uiState.update { BackupUiState.Success("Imported $imported instance(s)$llmNote") }
             } catch (e: Exception) {
-                _uiState.value = BackupUiState.Error("Import failed: ${e.message}")
+                _uiState.update { BackupUiState.Error("Import failed: ${e.message}") }
             }
         }
     }
 
     fun dismiss() {
         pendingEnvelope = null
-        _uiState.value = BackupUiState.Idle
+        _uiState.update { BackupUiState.Idle }
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -88,7 +88,7 @@ class SettingsViewModel(
                     connections = connections
                 )
             }.collect { state ->
-                _uiState.value = state
+                _uiState.update { state }
             }
         }
 
@@ -139,10 +139,9 @@ class SettingsViewModel(
     }
 
     fun showInstanceDetails(instanceId: String) {
-        val current = _uiState.value
-        if (current is SettingsUiState.Ready) {
-            val instance = current.instances.find { it.id == instanceId }
-            _uiState.value = current.copy(selectedInstanceForDetails = instance)
+        updateReady {
+            val instance = instances.find { it.id == instanceId }
+            copy(selectedInstanceForDetails = instance)
         }
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModel.kt
@@ -71,7 +71,9 @@ class TemplatesViewModel(
         val current = _uiState.value
         if (current is TemplatesUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.update { current.copy(isLoadingMore = true) }
+            _uiState.update { state ->
+                (state as? TemplatesUiState.Success)?.copy(isLoadingMore = true) ?: state
+            }
             fetchJob = viewModelScope.launch {
                 fetchTemplates(append = true)
             }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class TemplatesViewModel(
@@ -50,7 +51,7 @@ class TemplatesViewModel(
     fun loadTemplates() {
         currentPage = 1
         allTemplates.clear()
-        _uiState.value = TemplatesUiState.Loading
+        _uiState.update { TemplatesUiState.Loading }
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             fetchTemplates()
@@ -70,7 +71,7 @@ class TemplatesViewModel(
         val current = _uiState.value
         if (current is TemplatesUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.value = current.copy(isLoadingMore = true)
+            _uiState.update { current.copy(isLoadingMore = true) }
             fetchJob = viewModelScope.launch {
                 fetchTemplates(append = true)
             }
@@ -78,14 +79,14 @@ class TemplatesViewModel(
     }
 
     fun search(query: String) {
-        _searchQuery.value = query
+        _searchQuery.update { query }
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
             delay(300)
             currentSearch = query.ifBlank { null }
             currentPage = 1
             allTemplates.clear()
-            _uiState.value = TemplatesUiState.Loading
+            _uiState.update { TemplatesUiState.Loading }
             fetchTemplates()
         }
     }
@@ -94,29 +95,28 @@ class TemplatesViewModel(
         currentLabelFilter = label?.name
         currentPage = 1
         allTemplates.clear()
-        _uiState.value = TemplatesUiState.Loading
+        _uiState.update { TemplatesUiState.Loading }
         viewModelScope.launch {
             fetchTemplates()
         }
     }
 
     fun clearFilters() {
-        _searchQuery.value = ""
+        _searchQuery.update { "" }
         currentSearch = null
         currentLabelFilter = null
         currentPage = 1
         allTemplates.clear()
-        _uiState.value = TemplatesUiState.Loading
+        _uiState.update { TemplatesUiState.Loading }
         viewModelScope.launch {
             fetchTemplates()
         }
     }
 
     fun requestLaunch(template: JobTemplate) {
-        _launchState.value = if (template.askVariablesOnLaunch) {
-            LaunchState.EnteringVars(template)
-        } else {
-            LaunchState.Confirming(template)
+        _launchState.update {
+            if (template.askVariablesOnLaunch) LaunchState.EnteringVars(template)
+            else LaunchState.Confirming(template)
         }
     }
 
@@ -127,22 +127,24 @@ class TemplatesViewModel(
             else -> return
         }
 
-        _launchState.value = LaunchState.Launching
+        _launchState.update { LaunchState.Launching }
         viewModelScope.launch {
             val result = templateRepository.launchJob(template.id, extraVars)
-            _launchState.value = result.fold(
-                onSuccess = { jobId -> LaunchState.Launched(jobId) },
-                onFailure = { error -> LaunchState.LaunchError(AppError.from(error)) }
-            )
+            _launchState.update {
+                result.fold(
+                    onSuccess = { jobId -> LaunchState.Launched(jobId) },
+                    onFailure = { error -> LaunchState.LaunchError(AppError.from(error)) }
+                )
+            }
         }
     }
 
     fun cancelLaunch() {
-        _launchState.value = LaunchState.Idle
+        _launchState.update { LaunchState.Idle }
     }
 
     fun resetLaunchState() {
-        _launchState.value = LaunchState.Idle
+        _launchState.update { LaunchState.Idle }
     }
 
     private suspend fun fetchTemplates(append: Boolean = false) {
@@ -165,14 +167,16 @@ class TemplatesViewModel(
                     .distinctBy { it.id }
                     .sortedBy { it.name }
 
-                _uiState.value = TemplatesUiState.Success(
-                    templates = allTemplates.toList(),
-                    availableLabels = labels,
-                    hasMore = listResult.hasMore
-                )
+                _uiState.update {
+                    TemplatesUiState.Success(
+                        templates = allTemplates.toList(),
+                        availableLabels = labels,
+                        hasMore = listResult.hasMore
+                    )
+                }
             },
             onFailure = { error ->
-                _uiState.value = TemplatesUiState.Error(AppError.from(error))
+                _uiState.update { TemplatesUiState.Error(AppError.from(error)) }
             }
         )
     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowJobStatusViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowJobStatusViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 sealed interface NodeStdoutState {
@@ -44,14 +45,13 @@ class WorkflowJobStatusViewModel(
         pollingJob = viewModelScope.launch {
             workflowRepository.pollWorkflowJobStatus(workflowJobId)
                 .catch { e ->
-                    _uiState.value = WorkflowJobStatusUiState.Error(AppError.from(e))
+                    _uiState.update { WorkflowJobStatusUiState.Error(AppError.from(e)) }
                 }
                 .collect { workflowJob ->
                     val nodes = workflowRepository.getWorkflowNodes(workflowJobId).getOrDefault(emptyList())
-                    _uiState.value = if (workflowJob.status.isTerminal) {
-                        WorkflowJobStatusUiState.Completed(workflowJob, nodes)
-                    } else {
-                        WorkflowJobStatusUiState.Active(workflowJob, nodes)
+                    _uiState.update {
+                        if (workflowJob.status.isTerminal) WorkflowJobStatusUiState.Completed(workflowJob, nodes)
+                        else WorkflowJobStatusUiState.Active(workflowJob, nodes)
                     }
                 }
         }
@@ -59,9 +59,9 @@ class WorkflowJobStatusViewModel(
 
     fun toggleNodeExpansion(jobId: Int) {
         if (_expandedNodeId.value == jobId) {
-            _expandedNodeId.value = null
+            _expandedNodeId.update { null }
         } else {
-            _expandedNodeId.value = jobId
+            _expandedNodeId.update { jobId }
             if (_nodeStdout.value[jobId] == null) {
                 fetchNodeStdout(jobId)
             }
@@ -69,16 +69,18 @@ class WorkflowJobStatusViewModel(
     }
 
     private fun fetchNodeStdout(jobId: Int) {
-        _nodeStdout.value = _nodeStdout.value + (jobId to NodeStdoutState.Loading)
+        _nodeStdout.update { it + (jobId to NodeStdoutState.Loading) }
         viewModelScope.launch {
             val result = jobRepository.getJobStdout(jobId)
-            _nodeStdout.value = _nodeStdout.value + (jobId to result.fold(
-                onSuccess = { stdout ->
-                    if (stdout.isBlank()) NodeStdoutState.Loaded("No output available")
-                    else NodeStdoutState.Loaded(stdout)
-                },
-                onFailure = { e -> NodeStdoutState.Error(e.message ?: "Failed to load output") }
-            ))
+            _nodeStdout.update { current ->
+                current + (jobId to result.fold(
+                    onSuccess = { stdout ->
+                        if (stdout.isBlank()) NodeStdoutState.Loaded("No output available")
+                        else NodeStdoutState.Loaded(stdout)
+                    },
+                    onFailure = { e -> NodeStdoutState.Error(e.message ?: "Failed to load output") }
+                ))
+            }
         }
     }
 
@@ -88,7 +90,7 @@ class WorkflowJobStatusViewModel(
     }
 
     fun retry() {
-        _uiState.value = WorkflowJobStatusUiState.Loading
+        _uiState.update { WorkflowJobStatusUiState.Loading }
         startPolling()
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowTemplateDetailViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowTemplateDetailViewModel.kt
@@ -10,6 +10,7 @@ import java.net.URLDecoder
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 sealed interface WorkflowTemplateDetailUiState {
@@ -47,37 +48,37 @@ class WorkflowTemplateDetailViewModel(
 
     private fun loadNodes() {
         if (templateId <= 0) {
-            _uiState.value = WorkflowTemplateDetailUiState.Error(AppError.Unknown("Invalid workflow template"))
+            _uiState.update { WorkflowTemplateDetailUiState.Error(AppError.Unknown("Invalid workflow template")) }
             return
         }
-        _uiState.value = WorkflowTemplateDetailUiState.Loading
+        _uiState.update { WorkflowTemplateDetailUiState.Loading }
         viewModelScope.launch {
             workflowRepository.getWorkflowTemplateNodes(templateId)
                 .onSuccess { nodes ->
-                    _uiState.value = WorkflowTemplateDetailUiState.Success(nodes)
+                    _uiState.update { WorkflowTemplateDetailUiState.Success(nodes) }
                 }
                 .onFailure { e ->
-                    _uiState.value = WorkflowTemplateDetailUiState.Error(AppError.from(e))
+                    _uiState.update { WorkflowTemplateDetailUiState.Error(AppError.from(e)) }
                 }
         }
     }
 
     fun launch() {
         if (_launchState.value is LaunchFromDetailState.Launching) return
-        _launchState.value = LaunchFromDetailState.Launching
+        _launchState.update { LaunchFromDetailState.Launching }
         viewModelScope.launch {
             workflowRepository.launchWorkflow(templateId)
                 .onSuccess { jobId ->
-                    _launchState.value = LaunchFromDetailState.Launched(jobId)
+                    _launchState.update { LaunchFromDetailState.Launched(jobId) }
                 }
                 .onFailure { e ->
-                    _launchState.value = LaunchFromDetailState.Failed(e.message ?: "Launch failed")
+                    _launchState.update { LaunchFromDetailState.Failed(e.message ?: "Launch failed") }
                 }
         }
     }
 
     fun resetLaunchState() {
-        _launchState.value = LaunchFromDetailState.Idle
+        _launchState.update { LaunchFromDetailState.Idle }
     }
 
     fun retry() {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowTemplatesViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowTemplatesViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class WorkflowTemplatesViewModel(
@@ -50,7 +51,7 @@ class WorkflowTemplatesViewModel(
     fun loadTemplates() {
         currentPage = 1
         allTemplates.clear()
-        _uiState.value = WorkflowTemplatesUiState.Loading
+        _uiState.update { WorkflowTemplatesUiState.Loading }
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             fetchTemplates()
@@ -70,7 +71,7 @@ class WorkflowTemplatesViewModel(
         val current = _uiState.value
         if (current is WorkflowTemplatesUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.value = current.copy(isLoadingMore = true)
+            _uiState.update { current.copy(isLoadingMore = true) }
             fetchJob = viewModelScope.launch {
                 fetchTemplates(append = true)
             }
@@ -78,14 +79,14 @@ class WorkflowTemplatesViewModel(
     }
 
     fun search(query: String) {
-        _searchQuery.value = query
+        _searchQuery.update { query }
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
             delay(300)
             currentSearch = query.ifBlank { null }
             currentPage = 1
             allTemplates.clear()
-            _uiState.value = WorkflowTemplatesUiState.Loading
+            _uiState.update { WorkflowTemplatesUiState.Loading }
             fetchTemplates()
         }
     }
@@ -94,17 +95,16 @@ class WorkflowTemplatesViewModel(
         currentLabelFilter = label?.name
         currentPage = 1
         allTemplates.clear()
-        _uiState.value = WorkflowTemplatesUiState.Loading
+        _uiState.update { WorkflowTemplatesUiState.Loading }
         viewModelScope.launch {
             fetchTemplates()
         }
     }
 
     fun requestLaunch(template: WorkflowJobTemplate) {
-        _launchState.value = if (template.askVariablesOnLaunch) {
-            WorkflowLaunchState.EnteringVars(template)
-        } else {
-            WorkflowLaunchState.Confirming(template)
+        _launchState.update {
+            if (template.askVariablesOnLaunch) WorkflowLaunchState.EnteringVars(template)
+            else WorkflowLaunchState.Confirming(template)
         }
     }
 
@@ -115,22 +115,24 @@ class WorkflowTemplatesViewModel(
             else -> return
         }
 
-        _launchState.value = WorkflowLaunchState.Launching
+        _launchState.update { WorkflowLaunchState.Launching }
         viewModelScope.launch {
             val result = workflowRepository.launchWorkflow(template.id, extraVars)
-            _launchState.value = result.fold(
-                onSuccess = { workflowJobId -> WorkflowLaunchState.Launched(workflowJobId) },
-                onFailure = { error -> WorkflowLaunchState.LaunchError(AppError.from(error)) }
-            )
+            _launchState.update {
+                result.fold(
+                    onSuccess = { workflowJobId -> WorkflowLaunchState.Launched(workflowJobId) },
+                    onFailure = { error -> WorkflowLaunchState.LaunchError(AppError.from(error)) }
+                )
+            }
         }
     }
 
     fun cancelLaunch() {
-        _launchState.value = WorkflowLaunchState.Idle
+        _launchState.update { WorkflowLaunchState.Idle }
     }
 
     fun resetLaunchState() {
-        _launchState.value = WorkflowLaunchState.Idle
+        _launchState.update { WorkflowLaunchState.Idle }
     }
 
     private suspend fun fetchTemplates(append: Boolean = false) {
@@ -153,14 +155,16 @@ class WorkflowTemplatesViewModel(
                     .distinctBy { it.id }
                     .sortedBy { it.name }
 
-                _uiState.value = WorkflowTemplatesUiState.Success(
-                    templates = allTemplates.toList(),
-                    availableLabels = labels,
-                    hasMore = listResult.hasMore
-                )
+                _uiState.update {
+                    WorkflowTemplatesUiState.Success(
+                        templates = allTemplates.toList(),
+                        availableLabels = labels,
+                        hasMore = listResult.hasMore
+                    )
+                }
             },
             onFailure = { error ->
-                _uiState.value = WorkflowTemplatesUiState.Error(AppError.from(error))
+                _uiState.update { WorkflowTemplatesUiState.Error(AppError.from(error)) }
             }
         )
     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowTemplatesViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowTemplatesViewModel.kt
@@ -71,7 +71,9 @@ class WorkflowTemplatesViewModel(
         val current = _uiState.value
         if (current is WorkflowTemplatesUiState.Success && current.hasMore && !current.isLoadingMore) {
             currentPage++
-            _uiState.update { current.copy(isLoadingMore = true) }
+            _uiState.update { state ->
+                (state as? WorkflowTemplatesUiState.Success)?.copy(isLoadingMore = true) ?: state
+            }
             fetchJob = viewModelScope.launch {
                 fetchTemplates(append = true)
             }


### PR DESCRIPTION
## Summary

- Replaces `_uiState.value = ...` with `_uiState.update { ... }` across all 18 ViewModels (~98 occurrences)
- The `update()` function uses a compare-and-set loop that guarantees atomicity, preventing potential race conditions from concurrent coroutine state writes
- Also migrated secondary state flows (`_launchState`, `_searchQuery`, `_expandedNodeId`, `_nodeStdout`, `_llmConfig`) for consistency
- In SettingsViewModel, converted `showInstanceDetails()` to use the existing `updateReady` helper

## Test plan

- [x] `assembleDebug` — compiles cleanly
- [x] `testDebugUnitTest` — all unit tests pass
- [x] `validateDebugScreenshotTest` — all screenshot tests pass
- [x] No behavior change — purely mechanical replacement

Closes #195

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>