### PR TITLE
Fix F-Droid repo auto-update on releases

### DIFF
--- a/.github/workflows/fdroid-repo.yml
+++ b/.github/workflows/fdroid-repo.yml
@@ -1,8 +1,9 @@
 name: Update F-Droid repo
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Build and Release"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -17,6 +18,9 @@ concurrency:
 jobs:
   update-repo:
     name: Build and deploy F-Droid repo
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- Switch F-Droid workflow trigger from `release: [published]` to `workflow_run` chained after "Build and Release"
- Add guard to skip when upstream build failed

## Problem
The `github-pages` environment has a deployment branch policy allowing only `main`. When a release is published, `github.ref` is the tag ref (e.g., `refs/tags/v0.7.3-alpha.0`), which doesn't match `main` — so the deployment was silently blocked. The workflow only ever ran via manual `workflow_dispatch`.

## Fix
`workflow_run` triggers run on the default branch (`main`), satisfying the environment policy. The `if` condition ensures it only runs when the release build succeeds.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>