### PR TITLE
Fix F-Droid repo config: inline from secrets

### DIFF
--- a/.github/workflows/fdroid-repo.yml
+++ b/.github/workflows/fdroid-repo.yml
@@ -40,11 +40,24 @@ jobs:
         run: |
           mkdir -p fdroid/repo
           echo "$FDROID_KEYSTORE_B64" | base64 -d > fdroid/keystore.p12
-          echo "$FDROID_CONFIG_B64" | base64 -d > fdroid/config.yml
+          cat > fdroid/config.yml <<'CONF'
+          repo_url: https://leogallego.github.io/ansible-jane/fdroid/repo
+          repo_name: Ansible Jane F-Droid Repo
+          repo_description: Self-hosted F-Droid repository for Ansible Jane, a remote control app for Ansible Automation Platform.
+          repo_icon: icon.png
+          keystore: keystore.p12
+          CONF
+          echo "keystorepass: $FDROID_KEYSTORE_PASS" >> fdroid/config.yml
+          echo "keypass: $FDROID_KEY_PASS" >> fdroid/config.yml
+          echo "repo_keyalias: $FDROID_KEY_ALIAS" >> fdroid/config.yml
+          echo "keydname: CN=leogallego.github.io, OU=F-Droid Repo, O=Ansible Jane" >> fdroid/config.yml
+          sed -i 's/^          //' fdroid/config.yml
           chmod 0600 fdroid/config.yml
         env:
           FDROID_KEYSTORE_B64: ${{ secrets.FDROID_KEYSTORE }}
-          FDROID_CONFIG_B64: ${{ secrets.FDROID_CONFIG_YML }}
+          FDROID_KEYSTORE_PASS: ${{ secrets.FDROID_KEYSTORE_PASS }}
+          FDROID_KEY_PASS: ${{ secrets.FDROID_KEY_PASS }}
+          FDROID_KEY_ALIAS: ${{ secrets.FDROID_KEY_ALIAS }}
 
       - name: Download all release APKs
         run: |


### PR DESCRIPTION
## Summary
- Generate `config.yml` inline at workflow time instead of decoding from `FDROID_CONFIG_YML` secret
- Repo metadata (URL, name, description) is now version-controlled in the workflow file
- Only sensitive values (keystore/key passwords, alias) come from individual secrets

## Problem
The `FDROID_CONFIG_YML` base64 secret still had `repo_url: aapdroid` from before the rename to Ansible Jane. F-Droid clients read this address from the index and fail to resolve APK downloads since `aapdroid` 404s.

## Fix
No more opaque base64 config blob — repo metadata lives in the workflow YAML, passwords come from `FDROID_KEYSTORE_PASS`, `FDROID_KEY_PASS`, `FDROID_KEY_ALIAS` (already configured as separate secrets).

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>