### PR TITLE
Fix local tools not showing in Tools tab

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -52,6 +52,16 @@ class SettingsViewModel(
             val activeConfig = assistantRepository.loadLlmConfig()
             val initialActiveKey = assistantRepository.activeProviderKeyFlow.first()
 
+            val initialDisabledTools = assistantRepository.getDisabledTools()
+            val initialLocalTools = localTools.map { tool ->
+                LocalToolUiState(
+                    name = tool.spec.name,
+                    description = tool.spec.description,
+                    category = ToolRouter.getCategoryForTool(tool.spec.name) ?: "OTHER",
+                    isEnabled = "LOCAL:${tool.spec.name}" !in initialDisabledTools
+                )
+            }
+
             combine(
                 tokenManager.instances,
                 tokenManager.activeInstance,
@@ -76,8 +86,8 @@ class SettingsViewModel(
                     ?: io.github.leogallego.ansiblejane.ui.components.ThemeMode.SYSTEM
                 val preservedExpandedMcp = (current as? SettingsUiState.Ready)?.expandedMcpServers ?: emptySet()
                 val preservedExpandedCats = (current as? SettingsUiState.Ready)?.expandedCategories ?: emptySet()
-                val preservedLocalTools = (current as? SettingsUiState.Ready)?.localTools ?: emptyList()
-                val preservedDisabledTools = (current as? SettingsUiState.Ready)?.disabledTools ?: emptySet()
+                val preservedLocalTools = (current as? SettingsUiState.Ready)?.localTools ?: initialLocalTools
+                val preservedDisabledTools = (current as? SettingsUiState.Ready)?.disabledTools ?: initialDisabledTools
 
                 val mcpServerTools = connections.mapNotNull { (label, state) ->
                     if (state is McpConnectionState.Connected) {
@@ -142,18 +152,6 @@ class SettingsViewModel(
             }
         }
 
-        viewModelScope.launch {
-            val disabled = assistantRepository.getDisabledTools()
-            val toolUiStates = localTools.map { tool ->
-                LocalToolUiState(
-                    name = tool.spec.name,
-                    description = tool.spec.description,
-                    category = ToolRouter.getCategoryForTool(tool.spec.name) ?: "OTHER",
-                    isEnabled = "LOCAL:${tool.spec.name}" !in disabled
-                )
-            }
-            updateReady { copy(localTools = toolUiStates, disabledTools = disabled) }
-        }
     }
 
     // --- Tab ---


### PR DESCRIPTION
## Summary
- Fix race condition where local tools never appeared in Settings > Tools tab
- Load disabled tools and build tool UI state before the combine flow starts

## Problem
The `viewModelScope.launch` at init that built `LocalToolUiState` list called `updateReady()` before the combine flow emitted its first `Ready` state. Since `updateReady()` is a no-op when state is `Loading`, the tools were silently discarded. The combine then used `emptyList()` as fallback → "0 tools across 0 categories" permanently.

Unit tests didn't catch this because `MainDispatcherRule` makes coroutines synchronous, eliminating the race.

## Fix
Move disabled tools loading and tool list construction into the same `launch` block as the combine flow, before `combine()` starts collecting. These values then serve as initial fallback instead of `emptyList()`.

## Verified
- 60 tools across 8 categories now display correctly on device
- 395 unit tests pass

Fixes #208 (F6)

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>