### PR TITLE
Fix testTag sanitization, screenshot alignment, MCP race (#216)

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -187,8 +187,8 @@ class SettingsViewModel(
     }
 
     fun refreshInstanceInfo(instanceId: String) {
-        val instance = tokenManager.instances.value.find { it.id == instanceId } ?: return
         viewModelScope.launch {
+            val instance = tokenManager.instances.value.find { it.id == instanceId } ?: return@launch
             updateReady { copy(discoveryRefreshing = true, discoveryError = null) }
             try {
                 val client = buildDiscoveryClient(instance)
@@ -284,8 +284,8 @@ class SettingsViewModel(
     // --- Tools (MCP) ---
 
     fun toggleMcpEnabled(enabled: Boolean) {
-        val instance = tokenManager.activeInstance.value ?: return
         viewModelScope.launch {
+            val instance = tokenManager.activeInstance.value ?: return@launch
             if (!enabled) {
                 tokenManager.updateMcpConfig(instance.id, false, instance.mcpServerUrls)
                 return@launch
@@ -329,11 +329,11 @@ class SettingsViewModel(
     }
 
     fun addMcpServer(url: String, label: String, toolset: String? = null) {
-        val instance = tokenManager.activeInstance.value ?: return
-        val sanitizedUrl = url.trim().trimEnd('/')
-        val uri = try { java.net.URI(sanitizedUrl) } catch (_: Exception) { return }
-        if (uri.scheme?.lowercase() !in listOf("https", "wss")) return
         viewModelScope.launch {
+            val instance = tokenManager.activeInstance.value ?: return@launch
+            val sanitizedUrl = url.trim().trimEnd('/')
+            val uri = try { java.net.URI(sanitizedUrl) } catch (_: Exception) { return@launch }
+            if (uri.scheme?.lowercase() !in listOf("https", "wss")) return@launch
             val current = instance.mcpServerUrls?.toMutableList() ?: mutableListOf()
             current.add(McpServerConfig(url = sanitizedUrl, label = label, toolset = toolset))
             tokenManager.updateMcpConfig(instance.id, true, current)
@@ -341,8 +341,8 @@ class SettingsViewModel(
     }
 
     fun removeMcpServer(url: String) {
-        val instance = tokenManager.activeInstance.value ?: return
         viewModelScope.launch {
+            val instance = tokenManager.activeInstance.value ?: return@launch
             val updated = instance.mcpServerUrls?.filter { it.url != url }
             val enabled = !updated.isNullOrEmpty()
             tokenManager.updateMcpConfig(instance.id, enabled, updated)
@@ -358,8 +358,8 @@ class SettingsViewModel(
     }
 
     private fun updateMcpServer(url: String, transform: (McpServerConfig) -> McpServerConfig) {
-        val instance = tokenManager.activeInstance.value ?: return
         viewModelScope.launch {
+            val instance = tokenManager.activeInstance.value ?: return@launch
             val updated = instance.mcpServerUrls?.map {
                 if (it.url == url) transform(it) else it
             }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolItemRow.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolItemRow.kt
@@ -49,7 +49,7 @@ fun ToolItemRow(
         Switch(
             checked = isEnabled,
             onCheckedChange = onToggle,
-            modifier = Modifier.testTag("${testTagPrefix}_$name")
+            modifier = Modifier.testTag("${testTagPrefix}_${name.lowercase().replace(Regex("[^a-z0-9_]"), "_")}")
         )
     }
 }

--- a/app/src/screenshotTest/kotlin/io/github/leogallego/ansiblejane/screens/ToolsTabScreenshots.kt
+++ b/app/src/screenshotTest/kotlin/io/github/leogallego/ansiblejane/screens/ToolsTabScreenshots.kt
@@ -36,10 +36,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.android.tools.screenshot.PreviewTest
+import io.github.leogallego.ansiblejane.ui.settings.ToolItemRow
 import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
 
 private data class McpServerPreview(
@@ -137,18 +137,13 @@ private fun McpServerCardPreview(server: McpServerPreview) {
                 Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp)) {
                     HorizontalDivider()
                     server.tools.forEach { tool ->
-                        Row(
-                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(modifier = Modifier.weight(1f)) {
-                                Text(tool.name, style = MaterialTheme.typography.bodyMedium,
-                                    maxLines = 1, overflow = TextOverflow.Ellipsis)
-                                Text(tool.description, style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                            Switch(checked = tool.enabled, onCheckedChange = {})
-                        }
+                        ToolItemRow(
+                            name = tool.name,
+                            description = tool.description,
+                            isEnabled = tool.enabled,
+                            testTagPrefix = "switch_mcp_tool",
+                            onToggle = {}
+                        )
                     }
                 }
             }
@@ -179,17 +174,13 @@ private fun CategorySectionPreview(category: CategoryPreview) {
         AnimatedVisibility(visible = category.expanded, enter = expandVertically(), exit = shrinkVertically()) {
             Column(modifier = Modifier.padding(start = 8.dp)) {
                 category.tools.forEach { tool ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(tool.name, style = MaterialTheme.typography.bodyMedium)
-                            Text(tool.description, style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant)
-                        }
-                        Switch(checked = tool.enabled, onCheckedChange = {})
-                    }
+                    ToolItemRow(
+                        name = tool.name,
+                        description = tool.description,
+                        isEnabled = tool.enabled,
+                        testTagPrefix = "switch_local_tool",
+                        onToggle = {}
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Sanitize tool names in `ToolItemRow` testTags — regex replaces all non-alphanumeric characters (dots, hyphens, colons, slashes, spaces) with underscores for stable UI test selectors
- Replace inline `Row+Column+Text+Switch` in `ToolsTabScreenshots.kt` previews with `ToolItemRow` calls so screenshot tests match production UI
- Move `tokenManager.activeInstance.value` / `tokenManager.instances.value` reads inside `launch{}` blocks in `SettingsViewModel` to eliminate race condition between UI-thread capture and coroutine dispatch — affects `toggleMcpEnabled`, `addMcpServer`, `removeMcpServer`, `updateMcpServer`, and `refreshInstanceInfo`

## Test plan
- [x] Unit tests pass (`testDebugUnitTest`)
- [x] Screenshot tests compile (`compileDebugScreenshotTestKotlin`)
- [ ] Verify screenshot test output hasn't regressed (visual diff)
- [ ] Manual test: toggle MCP server settings while switching instances rapidly

Closes #216

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>