### PR TITLE
feat: token usage indicator for AI assistant (#218)

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.builtins.MapSerializer
@@ -51,7 +52,9 @@ class AssistantRepository(
 
     override fun addMessage(message: ChatMessage) {
         messages.add(message)
-        message.tokenUsage?.let { _sessionTokens.value += it.totalTokens }
+        message.tokenUsage?.let { usage ->
+            _sessionTokens.update { it + usage.totalTokens }
+        }
         if (messages.size > MAX_MESSAGES) {
             messages.removeAt(0)
         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
@@ -13,8 +13,11 @@ import io.github.leogallego.ansiblejane.assistant.data.KnownProvider
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -35,6 +38,8 @@ class AssistantRepository(
     private val json = Json { ignoreUnknownKeys = true }
     private val _onHistoryCleared = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     override val onHistoryCleared: SharedFlow<Unit> = _onHistoryCleared.asSharedFlow()
+    private val _sessionTokens = MutableStateFlow(0)
+    override val sessionTokensFlow: StateFlow<Int> = _sessionTokens.asStateFlow()
 
     private companion object {
         private const val TAG = "AssistantRepository"
@@ -46,6 +51,7 @@ class AssistantRepository(
 
     override fun addMessage(message: ChatMessage) {
         messages.add(message)
+        message.tokenUsage?.let { _sessionTokens.value += it.totalTokens }
         if (messages.size > MAX_MESSAGES) {
             messages.removeAt(0)
         }
@@ -65,6 +71,7 @@ class AssistantRepository(
 
     override fun clearHistory() {
         messages.clear()
+        _sessionTokens.value = 0
         _onHistoryCleared.tryEmit(Unit)
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt
@@ -3,6 +3,7 @@ package io.github.leogallego.ansiblejane.assistant.data
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 
 interface IAssistantRepository {
     fun addMessage(message: ChatMessage)
@@ -11,6 +12,7 @@ interface IAssistantRepository {
     fun removeLastUserMessage()
     fun clearHistory()
     val onHistoryCleared: SharedFlow<Unit>
+    val sessionTokensFlow: StateFlow<Int>
     suspend fun saveLlmConfig(config: LlmProviderConfig)
     suspend fun loadLlmConfig(): LlmProviderConfig?
     suspend fun saveAllLlmConfigs(configs: Map<String, LlmProviderConfig>)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
@@ -56,8 +56,13 @@ class ChatEngine(
         contextChars: Int = DEFAULT_CONTEXT_CHARS,
         onConfirmationRequired: (suspend (toolName: String, description: String, args: JsonObject) -> Boolean)? = null
     ): Flow<ChatEvent> = flow {
+        var accInputTokens = 0
+        var accOutputTokens = 0
+        var accTotalTokens = 0
+        var anyRealUsage = false
+        val messages = mutableListOf<ChatMessage>()
+
         try {
-            val messages = mutableListOf<ChatMessage>()
             messages.add(ChatMessage(role = Role.SYSTEM, content = SYSTEM_PROMPT))
             history.filter { it.role == Role.USER || it.role == Role.ASSISTANT }
                 .forEach { messages.add(it) }
@@ -76,10 +81,6 @@ class ChatEngine(
             var totalToolCalls = 0
             val toolCallHistory = mutableListOf<List<String>>()
             val softLimit = (contextChars * 0.9).toInt()
-            var accInputTokens = 0
-            var accOutputTokens = 0
-            var accTotalTokens = 0
-            var anyRealUsage = false
 
             loop@ while (iterations < maxIterations) {
                 iterations++
@@ -247,18 +248,23 @@ class ChatEngine(
             throw e
         } catch (e: LlmAuthException) {
             Log.e(TAG, "AUTH error: ${e.message}", e)
+            emitPartialTokenUsage(anyRealUsage, accInputTokens, accOutputTokens, accTotalTokens, messages)
             emit(ChatEvent.Error(e.message ?: "Authentication failed — check API key", e))
         } catch (e: LlmRateLimitException) {
             Log.w(TAG, "RATE_LIMIT: ${e.message}")
+            emitPartialTokenUsage(anyRealUsage, accInputTokens, accOutputTokens, accTotalTokens, messages)
             emit(ChatEvent.Error(e.message ?: "Rate limited — try again later", e))
         } catch (e: LlmTimeoutException) {
             Log.w(TAG, "TIMEOUT: ${e.message}")
+            emitPartialTokenUsage(anyRealUsage, accInputTokens, accOutputTokens, accTotalTokens, messages)
             emit(ChatEvent.Error("Response timed out", e))
         } catch (e: IOException) {
             Log.e(TAG, "IO error: ${e.message}", e)
+            emitPartialTokenUsage(anyRealUsage, accInputTokens, accOutputTokens, accTotalTokens, messages)
             emit(ChatEvent.Error("Unable to reach LLM server: ${e.message}", e))
         } catch (e: Exception) {
             Log.e(TAG, "Unexpected error: ${e.message}", e)
+            emitPartialTokenUsage(anyRealUsage, accInputTokens, accOutputTokens, accTotalTokens, messages)
             emit(ChatEvent.Error("Error: ${e.message}", e))
         }
     }
@@ -426,6 +432,22 @@ class ChatEngine(
 
         if (keepFrom > systemMessages.size) {
             messages.subList(systemMessages.size, keepFrom).clear()
+        }
+    }
+
+    private suspend fun kotlinx.coroutines.flow.FlowCollector<ChatEvent>.emitPartialTokenUsage(
+        anyRealUsage: Boolean,
+        accInputTokens: Int,
+        accOutputTokens: Int,
+        accTotalTokens: Int,
+        messages: List<ChatMessage>
+    ) {
+        if (anyRealUsage) {
+            emit(ChatEvent.TokenUsageReport(TokenUsage(
+                inputTokens = accInputTokens,
+                outputTokens = accOutputTokens,
+                totalTokens = accTotalTokens
+            )))
         }
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
@@ -38,6 +38,7 @@ sealed interface ChatEvent {
     ) : ChatEvent
     data class AssistantMessage(val fullText: String, val toolCallCount: Int) : ChatEvent
     data class Error(val message: String, val cause: Throwable? = null) : ChatEvent
+    data class TokenUsageReport(val usage: TokenUsage) : ChatEvent
 }
 
 class ChatEngine(
@@ -75,6 +76,10 @@ class ChatEngine(
             var totalToolCalls = 0
             val toolCallHistory = mutableListOf<List<String>>()
             val softLimit = (contextChars * 0.9).toInt()
+            var accInputTokens = 0
+            var accOutputTokens = 0
+            var accTotalTokens = 0
+            var anyRealUsage = false
 
             loop@ while (iterations < maxIterations) {
                 iterations++
@@ -115,7 +120,15 @@ class ChatEngine(
                             tc.args.clear()
                             tc.args.append(frame.content)
                         }
-                        is StreamFrame.End -> { /* handled after collect */ }
+                        is StreamFrame.End -> {
+                            val meta = frame.metaInfo
+                            if (meta.totalTokensCount != null) {
+                                accInputTokens += meta.inputTokensCount ?: 0
+                                accOutputTokens += meta.outputTokensCount ?: 0
+                                accTotalTokens += meta.totalTokensCount ?: 0
+                                anyRealUsage = true
+                            }
+                        }
                         else -> { /* ReasoningDelta etc — ignore */ }
                     }
                 }
@@ -142,6 +155,8 @@ class ChatEngine(
 
                     if (isRepeatingToolCalls(toolCallHistory)) {
                         Log.w(TAG, "ITER $iterations: repeat detected, stopping")
+                        val usage = buildTokenUsage(anyRealUsage, accInputTokens, accOutputTokens, accTotalTokens, messages, responseText)
+                        emit(ChatEvent.TokenUsageReport(usage))
                         emit(ChatEvent.AssistantMessage(
                             (responseText ?: "") + "\n\nStopped: the same tools were being called repeatedly.",
                             totalToolCalls
@@ -215,11 +230,15 @@ class ChatEngine(
                     } else {
                         responseText ?: textBuilder.toString()
                     }
+                    val usage = buildTokenUsage(anyRealUsage, accInputTokens, accOutputTokens, accTotalTokens, messages, finalText)
+                    emit(ChatEvent.TokenUsageReport(usage))
                     emit(ChatEvent.AssistantMessage(finalText, totalToolCalls))
                     return@flow
                 }
             }
 
+            val usage = buildTokenUsage(anyRealUsage, accInputTokens, accOutputTokens, accTotalTokens, messages, null)
+            emit(ChatEvent.TokenUsageReport(usage))
             emit(ChatEvent.AssistantMessage(
                 "I wasn't able to complete this request within the tool call limit.",
                 totalToolCalls
@@ -407,6 +426,32 @@ class ChatEngine(
 
         if (keepFrom > systemMessages.size) {
             messages.subList(systemMessages.size, keepFrom).clear()
+        }
+    }
+
+    private fun buildTokenUsage(
+        anyRealUsage: Boolean,
+        accInputTokens: Int,
+        accOutputTokens: Int,
+        accTotalTokens: Int,
+        messages: List<ChatMessage>,
+        responseText: String?
+    ): TokenUsage {
+        return if (anyRealUsage) {
+            TokenUsage(
+                inputTokens = accInputTokens,
+                outputTokens = accOutputTokens,
+                totalTokens = accTotalTokens
+            )
+        } else {
+            val totalChars = messages.sumOf { it.content.length } + (responseText?.length ?: 0)
+            val estimated = totalChars / 4
+            TokenUsage(
+                inputTokens = estimated * 2 / 3,
+                outputTokens = estimated / 3,
+                totalTokens = estimated,
+                isEstimated = true
+            )
         }
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatMessage.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatMessage.kt
@@ -14,14 +14,18 @@ data class TokenUsage(
     val totalTokens: Int,
     val isEstimated: Boolean = false
 ) {
-    fun formatTotal(): String {
-        val prefix = if (isEstimated) "~" else ""
-        return if (totalTokens >= 1000) {
-            val k = totalTokens / 1000
-            val remainder = (totalTokens % 1000) / 100
-            if (remainder > 0) "$prefix${k}.${remainder}K" else "$prefix${k}K"
-        } else {
-            "$prefix$totalTokens"
+    fun formatTotal(): String = formatTokenCount(totalTokens, isEstimated)
+
+    companion object {
+        fun formatTokenCount(count: Int, isEstimated: Boolean = false): String {
+            val prefix = if (isEstimated) "~" else ""
+            return if (count >= 1000) {
+                val k = count / 1000
+                val remainder = (count % 1000) / 100
+                if (remainder > 0) "$prefix${k}.${remainder}K" else "$prefix${k}K"
+            } else {
+                "$prefix$count"
+            }
         }
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatMessage.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatMessage.kt
@@ -8,6 +8,25 @@ enum class Role { USER, ASSISTANT, TOOL, SYSTEM }
 enum class ResponseSource { LOCAL, MCP, LLM, MIXED }
 
 @Immutable
+data class TokenUsage(
+    val inputTokens: Int,
+    val outputTokens: Int,
+    val totalTokens: Int,
+    val isEstimated: Boolean = false
+) {
+    fun formatTotal(): String {
+        val prefix = if (isEstimated) "~" else ""
+        return if (totalTokens >= 1000) {
+            val k = totalTokens / 1000
+            val remainder = (totalTokens % 1000) / 100
+            if (remainder > 0) "$prefix${k}.${remainder}K" else "$prefix${k}K"
+        } else {
+            "$prefix$totalTokens"
+        }
+    }
+}
+
+@Immutable
 data class ChatMessage(
     val role: Role,
     val content: String,
@@ -16,6 +35,7 @@ data class ChatMessage(
     val toolName: String? = null,
     val source: ResponseSource? = null,
     val toolsUsed: List<String> = emptyList(),
+    val tokenUsage: TokenUsage? = null,
     val timestamp: Long = System.currentTimeMillis(),
     val id: Long = nextId()
 ) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantUiState.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantUiState.kt
@@ -23,7 +23,8 @@ sealed interface AssistantUiState {
         val isGenerating: Boolean = false,
         val streamingText: String? = null,
         val connections: Map<String, McpConnectionState> = emptyMap(),
-        val pendingConfirmation: PendingConfirmation? = null
+        val pendingConfirmation: PendingConfirmation? = null,
+        val sessionTokens: Int = 0
     ) : AssistantUiState
     data class Error(val error: AppError) : AssistantUiState
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -309,6 +309,9 @@ class AssistantViewModel(
                                 )
                             }
                         }
+                        is ChatEvent.TokenUsageReport -> {
+                            // TODO: Task 4 - accumulate session tokens and attach to message
+                        }
                     }
                 }
         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -10,6 +10,7 @@ import io.github.leogallego.ansiblejane.assistant.engine.ChatEvent
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
 import io.github.leogallego.ansiblejane.assistant.engine.ResponseSource
 import io.github.leogallego.ansiblejane.assistant.engine.Role
+import io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
 import io.github.leogallego.ansiblejane.assistant.engine.ToolExecutor
 import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
 import io.github.leogallego.ansiblejane.assistant.llm.GeminiLlmProvider
@@ -103,6 +104,15 @@ class AssistantViewModel(
             mcpServerManager.connections.collect { connections ->
                 _uiState.update { current ->
                     if (current is AssistantUiState.Active) current.copy(connections = connections)
+                    else current
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            repository.sessionTokensFlow.collect { tokens ->
+                _uiState.update { current ->
+                    if (current is AssistantUiState.Active) current.copy(sessionTokens = tokens)
                     else current
                 }
             }
@@ -236,6 +246,7 @@ class AssistantViewModel(
             val textBuilder = StringBuilder()
             val usedSources = mutableSetOf<String>()
             val usedToolNames = mutableListOf<String>()
+            var pendingTokenUsage: TokenUsage? = null
             val localNames = matchedLocal.map { it.spec.name }.toSet()
 
             updateState { copy(streamingText = "Thinking...") }
@@ -284,7 +295,8 @@ class AssistantViewModel(
                                 role = Role.ASSISTANT,
                                 content = event.fullText,
                                 source = responseSource,
-                                toolsUsed = usedToolNames.distinct()
+                                toolsUsed = usedToolNames.distinct(),
+                                tokenUsage = pendingTokenUsage
                             )
                             repository.addMessage(finalMsg)
                             updateState {
@@ -310,7 +322,7 @@ class AssistantViewModel(
                             }
                         }
                         is ChatEvent.TokenUsageReport -> {
-                            // TODO: Task 4 - accumulate session tokens and attach to message
+                            pendingTokenUsage = event.usage
                         }
                     }
                 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
@@ -267,6 +267,7 @@ private fun ActiveChatContent(
                         content = message.content,
                         source = message.source,
                         toolsUsed = message.toolsUsed,
+                        tokenUsage = message.tokenUsage,
                         onCopy = {
                             clipboardManager.setText(AnnotatedString(message.content))
                         },

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ChatBubble.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ChatBubble.kt
@@ -35,6 +35,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
 import io.github.leogallego.ansiblejane.assistant.engine.ResponseSource
@@ -263,6 +266,7 @@ private fun SourceBand(
                     ),
                     color = color,
                     maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f, fill = false),
                 )
             }
@@ -278,6 +282,9 @@ private fun SourceBand(
                     text = "${tokenUsage.formatTotal()} tokens",
                     style = MaterialTheme.typography.labelSmall,
                     color = color,
+                    modifier = Modifier.semantics {
+                        contentDescription = "${tokenUsage.totalTokens} tokens"
+                    },
                 )
             }
         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ChatBubble.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ChatBubble.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
 import io.github.leogallego.ansiblejane.assistant.engine.ResponseSource
+import io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
 import com.mikepenz.markdown.compose.LocalBulletListHandler
 import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.compose.components.markdownComponents
@@ -99,6 +100,7 @@ fun AssistantMessage(
     content: String,
     source: ResponseSource? = null,
     toolsUsed: List<String> = emptyList(),
+    tokenUsage: TokenUsage? = null,
     onCopy: (() -> Unit)? = null,
     onRegenerate: (() -> Unit)? = null,
     modifier: Modifier = Modifier
@@ -145,7 +147,7 @@ fun AssistantMessage(
                     .padding(vertical = 4.dp)
             ) {
                 if (source != null) {
-                    SourceBand(source = source, toolsUsed = toolsUsed)
+                    SourceBand(source = source, toolsUsed = toolsUsed, tokenUsage = tokenUsage)
                 }
                 SelectionContainer {
                 val isDarkTheme = isSystemInDarkTheme()
@@ -225,6 +227,7 @@ fun AssistantMessage(
 private fun SourceBand(
     source: ResponseSource,
     toolsUsed: List<String>,
+    tokenUsage: TokenUsage? = null,
     modifier: Modifier = Modifier
 ) {
     val sourceLabel = when (source) {
@@ -261,6 +264,20 @@ private fun SourceBand(
                     color = color,
                     maxLines = 1,
                     modifier = Modifier.weight(1f, fill = false),
+                )
+            }
+            if (tokenUsage != null) {
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = "·",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = color,
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = "${tokenUsage.formatTotal()} tokens",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = color,
                 )
             }
         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
@@ -68,6 +68,7 @@ fun MainScreen(
     val activeConfig by assistantRepository.activeConfigFlow.collectAsStateWithLifecycle(null)
     val savedConfigs by assistantRepository.savedConfigsFlow.collectAsStateWithLifecycle(emptyMap())
     val activeProviderKey by assistantRepository.activeProviderKeyFlow.collectAsStateWithLifecycle(null)
+    val sessionTokens by assistantRepository.sessionTokensFlow.collectAsStateWithLifecycle()
 
     val tabs = TopLevelTab.entries
     val dashboardTabIndex = tabs.indexOfFirst { it is TopLevelTab.Dashboard }.coerceAtLeast(0)
@@ -139,6 +140,19 @@ fun MainScreen(
                         },
                         onNavigateToSettings = onNavigateToSettings
                     )
+                    if (selectedTab is TopLevelTab.Assistant && sessionTokens > 0) {
+                        val formatted = io.github.leogallego.ansiblejane.assistant.engine.TokenUsage(
+                            0, 0, sessionTokens
+                        ).formatTotal()
+                        Text(
+                            text = "$formatted tokens",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier
+                                .padding(end = 4.dp)
+                                .testTag("text_session_tokens"),
+                        )
+                    }
                     if (selectedTab is TopLevelTab.Assistant) {
                         IconButton(
                             onClick = { showClearChatConfirm = true },

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
@@ -43,6 +43,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.leogallego.ansiblejane.assistant.data.IAssistantRepository
@@ -141,16 +143,18 @@ fun MainScreen(
                         onNavigateToSettings = onNavigateToSettings
                     )
                     if (selectedTab is TopLevelTab.Assistant && sessionTokens > 0) {
-                        val formatted = io.github.leogallego.ansiblejane.assistant.engine.TokenUsage(
-                            0, 0, sessionTokens
-                        ).formatTotal()
+                        val formatted = io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
+                            .formatTokenCount(sessionTokens)
                         Text(
                             text = "$formatted tokens",
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier
                                 .padding(end = 4.dp)
-                                .testTag("text_session_tokens"),
+                                .testTag("text_session_tokens")
+                                .semantics {
+                                    contentDescription = "$sessionTokens tokens used this session"
+                                },
                         )
                     }
                     if (selectedTab is TopLevelTab.Assistant) {

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineStreamingTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineStreamingTest.kt
@@ -44,6 +44,9 @@ class ChatEngineStreamingTest {
             val delta = awaitItem()
             assertTrue(delta is ChatEvent.TextDelta)
 
+            val tokenReport = awaitItem()
+            assertTrue(tokenReport is ChatEvent.TokenUsageReport)
+
             val msg = awaitItem()
             assertTrue(msg is ChatEvent.AssistantMessage)
             assertEquals(1, (msg as ChatEvent.AssistantMessage).toolCallCount)

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineTest.kt
@@ -31,6 +31,9 @@ class ChatEngineTest {
             val delta = awaitItem()
             assertTrue(delta is ChatEvent.TextDelta)
 
+            val tokenReport = awaitItem()
+            assertTrue(tokenReport is ChatEvent.TokenUsageReport)
+
             val msg = awaitItem()
             assertTrue(msg is ChatEvent.AssistantMessage)
             assertEquals("Hello there!", (msg as ChatEvent.AssistantMessage).fullText)
@@ -65,6 +68,9 @@ class ChatEngineTest {
 
             val delta = awaitItem()
             assertTrue(delta is ChatEvent.TextDelta)
+
+            val tokenReport = awaitItem()
+            assertTrue(tokenReport is ChatEvent.TokenUsageReport)
 
             val msg = awaitItem()
             assertTrue(msg is ChatEvent.AssistantMessage)

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/TokenUsageTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/TokenUsageTest.kt
@@ -1,0 +1,51 @@
+package io.github.leogallego.ansiblejane.assistant.engine
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class TokenUsageFormatTest(
+    private val totalTokens: Int,
+    private val isEstimated: Boolean,
+    private val expected: String
+) {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "total={0}, estimated={1} -> \"{2}\"")
+        fun data() = listOf(
+            arrayOf<Any>(0, false, "0"),
+            arrayOf<Any>(1, false, "1"),
+            arrayOf<Any>(500, false, "500"),
+            arrayOf<Any>(999, false, "999"),
+            arrayOf<Any>(1000, false, "1K"),
+            arrayOf<Any>(1099, false, "1K"),
+            arrayOf<Any>(1100, false, "1.1K"),
+            arrayOf<Any>(2000, false, "2K"),
+            arrayOf<Any>(2050, false, "2K"),
+            arrayOf<Any>(2400, false, "2.4K"),
+            arrayOf<Any>(10000, false, "10K"),
+            arrayOf<Any>(12300, false, "12.3K"),
+            arrayOf<Any>(100000, false, "100K"),
+            arrayOf<Any>(0, true, "~0"),
+            arrayOf<Any>(500, true, "~500"),
+            arrayOf<Any>(1200, true, "~1.2K"),
+            arrayOf<Any>(2000, true, "~2K"),
+        )
+    }
+
+    @Test
+    fun `formatTotal produces expected output`() {
+        val usage = TokenUsage(0, 0, totalTokens, isEstimated)
+        assertEquals(expected, usage.formatTotal())
+    }
+
+    @Test
+    fun `formatTokenCount matches formatTotal`() {
+        assertEquals(
+            TokenUsage(0, 0, totalTokens, isEstimated).formatTotal(),
+            TokenUsage.formatTokenCount(totalTokens, isEstimated)
+        )
+    }
+}

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 class FakeAssistantRepository : IAssistantRepository {
     private val messages = mutableListOf<ChatMessage>()
@@ -36,7 +37,9 @@ class FakeAssistantRepository : IAssistantRepository {
 
     override fun addMessage(message: ChatMessage) {
         messages.add(message)
-        message.tokenUsage?.let { _sessionTokens.value += it.totalTokens }
+        message.tokenUsage?.let { usage ->
+            _sessionTokens.update { it + usage.totalTokens }
+        }
     }
 
     override fun getHistory(): List<ChatMessage> = messages.toList()

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
@@ -9,7 +9,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 class FakeAssistantRepository : IAssistantRepository {
     private val messages = mutableListOf<ChatMessage>()
@@ -20,6 +22,8 @@ class FakeAssistantRepository : IAssistantRepository {
 
     private val _onHistoryCleared = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     override val onHistoryCleared: SharedFlow<Unit> = _onHistoryCleared.asSharedFlow()
+    private val _sessionTokens = MutableStateFlow(0)
+    override val sessionTokensFlow: StateFlow<Int> = _sessionTokens.asStateFlow()
 
     private val _activeConfigFlow = MutableStateFlow<LlmProviderConfig?>(null)
     override val activeConfigFlow: Flow<LlmProviderConfig?> = _activeConfigFlow
@@ -32,6 +36,7 @@ class FakeAssistantRepository : IAssistantRepository {
 
     override fun addMessage(message: ChatMessage) {
         messages.add(message)
+        message.tokenUsage?.let { _sessionTokens.value += it.totalTokens }
     }
 
     override fun getHistory(): List<ChatMessage> = messages.toList()
@@ -48,6 +53,7 @@ class FakeAssistantRepository : IAssistantRepository {
 
     override fun clearHistory() {
         messages.clear()
+        _sessionTokens.value = 0
         _onHistoryCleared.tryEmit(Unit)
     }
 

--- a/docs/superpowers/plans/2026-05-28-token-usage-indicator.md
+++ b/docs/superpowers/plans/2026-05-28-token-usage-indicator.md
@@ -1,0 +1,708 @@
+# Token Usage Indicator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show per-message and session-level LLM token consumption in Jane's chat UI, using Koog's `ResponseMetaInfo` as the primary data source.
+
+**Architecture:** Extract token counts from `StreamFrame.End.metaInfo` in ChatEngine, propagate via a new `ChatEvent.TokenUsageReport`, store on `ChatMessage`, aggregate in UI state, and display in `SourceBand` (per-message) and top bar (session total).
+
+**Tech Stack:** Kotlin, Jetpack Compose, Koog 1.0.0 streaming API (`ResponseMetaInfo`), MVVM with StateFlow.
+
+**Issue:** #218
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `assistant/engine/ChatMessage.kt` | Modify | Add `TokenUsage` data class and `tokenUsage` field |
+| `assistant/engine/ChatEngine.kt` | Modify | Extract `ResponseMetaInfo`, emit `TokenUsageReport` event |
+| `assistant/presentation/AssistantUiState.kt` | Modify | Add `sessionTokens` to `Active` state |
+| `assistant/presentation/AssistantViewModel.kt` | Modify | Handle `TokenUsageReport`, attach to messages, aggregate |
+| `assistant/data/IAssistantRepository.kt` | Modify | Add `sessionTokensFlow` |
+| `assistant/data/AssistantRepository.kt` | Modify | Implement `sessionTokensFlow`, track on addMessage/clear |
+| `assistant/ui/ChatBubble.kt` | Modify | Extend `SourceBand` and `AssistantMessage` with token display |
+| `assistant/ui/AssistantScreen.kt` | Modify | Pass `tokenUsage` from `ChatMessage` to `AssistantMessage` |
+| `ui/main/MainScreen.kt` | Modify | Show session token counter in top bar |
+
+All paths relative to `app/src/main/kotlin/io/github/leogallego/ansiblejane/`.
+
+---
+
+### Task 1: Add `TokenUsage` data class and `ChatMessage` field
+
+**Files:**
+- Modify: `assistant/engine/ChatMessage.kt`
+
+- [ ] **Step 1: Add `TokenUsage` data class**
+
+In `ChatMessage.kt`, add the data class before `ChatMessage`:
+
+```kotlin
+@Immutable
+data class TokenUsage(
+    val inputTokens: Int,
+    val outputTokens: Int,
+    val totalTokens: Int,
+    val isEstimated: Boolean = false
+)
+```
+
+- [ ] **Step 2: Add `tokenUsage` field to `ChatMessage`**
+
+Add the field after `toolsUsed`:
+
+```kotlin
+@Immutable
+data class ChatMessage(
+    val role: Role,
+    val content: String,
+    val toolCallsJson: String? = null,
+    val toolCallId: String? = null,
+    val toolName: String? = null,
+    val source: ResponseSource? = null,
+    val toolsUsed: List<String> = emptyList(),
+    val tokenUsage: TokenUsage? = null,
+    val timestamp: Long = System.currentTimeMillis(),
+    val id: Long = nextId()
+)
+```
+
+- [ ] **Step 3: Add `formatTokenCount` utility**
+
+Add a companion function to `TokenUsage` for consistent formatting across UI:
+
+```kotlin
+@Immutable
+data class TokenUsage(
+    val inputTokens: Int,
+    val outputTokens: Int,
+    val totalTokens: Int,
+    val isEstimated: Boolean = false
+) {
+    fun formatTotal(): String {
+        val prefix = if (isEstimated) "~" else ""
+        return if (totalTokens >= 1000) {
+            val k = totalTokens / 1000
+            val remainder = (totalTokens % 1000) / 100
+            if (remainder > 0) "$prefix${k}.${remainder}K" else "$prefix${k}K"
+        } else {
+            "$prefix$totalTokens"
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Build to verify no compilation errors**
+
+Run: `./gradlew app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL (existing call sites use default `tokenUsage = null`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatMessage.kt
+git commit -m "feat: add TokenUsage data class and ChatMessage field (#218)"
+```
+
+---
+
+### Task 2: Add `TokenUsageReport` event and extract from `StreamFrame.End` in ChatEngine
+
+**Files:**
+- Modify: `assistant/engine/ChatEngine.kt:30-41` (ChatEvent sealed interface)
+- Modify: `assistant/engine/ChatEngine.kt:74-77` (accumulator vars)
+- Modify: `assistant/engine/ChatEngine.kt:118` (StreamFrame.End handler)
+- Modify: `assistant/engine/ChatEngine.kt:143-149` (repeat detection exit)
+- Modify: `assistant/engine/ChatEngine.kt:210-220` (normal completion exit)
+- Modify: `assistant/engine/ChatEngine.kt:222-226` (max iterations exit)
+
+- [ ] **Step 1: Add `TokenUsageReport` to `ChatEvent`**
+
+In `ChatEngine.kt`, add after the `Error` event (line 40):
+
+```kotlin
+sealed interface ChatEvent {
+    data class TextDelta(val text: String) : ChatEvent
+    data class ToolExecuting(val toolName: String, val args: JsonObject) : ChatEvent
+    data class ToolResult(val toolName: String, val result: io.github.leogallego.ansiblejane.assistant.tools.ToolResult) : ChatEvent
+    data class ConfirmationRequired(
+        val toolName: String,
+        val args: JsonObject,
+        val description: String
+    ) : ChatEvent
+    data class AssistantMessage(val fullText: String, val toolCallCount: Int) : ChatEvent
+    data class Error(val message: String, val cause: Throwable? = null) : ChatEvent
+    data class TokenUsageReport(val usage: TokenUsage) : ChatEvent
+}
+```
+
+- [ ] **Step 2: Add token accumulators before the loop**
+
+After `val softLimit = ...` (line 77), add:
+
+```kotlin
+var accInputTokens = 0
+var accOutputTokens = 0
+var accTotalTokens = 0
+var anyRealUsage = false
+```
+
+- [ ] **Step 3: Extract `ResponseMetaInfo` from `StreamFrame.End`**
+
+Replace line 118:
+
+```kotlin
+// OLD:
+is StreamFrame.End -> { /* handled after collect */ }
+
+// NEW:
+is StreamFrame.End -> {
+    val meta = frame.metaInfo
+    if (meta.totalTokensCount != null) {
+        accInputTokens += meta.inputTokensCount ?: 0
+        accOutputTokens += meta.outputTokensCount ?: 0
+        accTotalTokens += meta.totalTokensCount ?: 0
+        anyRealUsage = true
+    }
+}
+```
+
+- [ ] **Step 4: Add helper function to build `TokenUsage`**
+
+Add a private function in `ChatEngine`:
+
+```kotlin
+private fun buildTokenUsage(
+    anyRealUsage: Boolean,
+    accInputTokens: Int,
+    accOutputTokens: Int,
+    accTotalTokens: Int,
+    messages: List<ChatMessage>,
+    responseText: String?
+): TokenUsage {
+    return if (anyRealUsage) {
+        TokenUsage(
+            inputTokens = accInputTokens,
+            outputTokens = accOutputTokens,
+            totalTokens = accTotalTokens
+        )
+    } else {
+        val totalChars = messages.sumOf { it.content.length } + (responseText?.length ?: 0)
+        val estimated = totalChars / 4
+        TokenUsage(
+            inputTokens = estimated * 2 / 3,
+            outputTokens = estimated / 3,
+            totalTokens = estimated,
+            isEstimated = true
+        )
+    }
+}
+```
+
+- [ ] **Step 5: Emit `TokenUsageReport` at repeat-detection exit**
+
+At line 143-149, add the emit before `AssistantMessage`:
+
+```kotlin
+if (isRepeatingToolCalls(toolCallHistory)) {
+    Log.w(TAG, "ITER $iterations: repeat detected, stopping")
+    val usage = buildTokenUsage(anyRealUsage, accInputTokens, accOutputTokens, accTotalTokens, messages, responseText)
+    emit(ChatEvent.TokenUsageReport(usage))
+    emit(ChatEvent.AssistantMessage(
+        (responseText ?: "") + "\n\nStopped: the same tools were being called repeatedly.",
+        totalToolCalls
+    ))
+    return@flow
+}
+```
+
+- [ ] **Step 6: Emit `TokenUsageReport` at normal completion exit**
+
+At line 210-219, add the emit before `AssistantMessage`:
+
+```kotlin
+} else {
+    Log.d(TAG, "DONE: $iterations iterations, $totalToolCalls total tool calls, " +
+        "response=${responseText?.length ?: 0} chars")
+    val finalText = if (completedCalls.isNotEmpty() && iterations >= maxIterations) {
+        (responseText ?: "") + "\n\nI wasn't able to complete this request within the tool call limit."
+    } else {
+        responseText ?: textBuilder.toString()
+    }
+    val usage = buildTokenUsage(anyRealUsage, accInputTokens, accOutputTokens, accTotalTokens, messages, finalText)
+    emit(ChatEvent.TokenUsageReport(usage))
+    emit(ChatEvent.AssistantMessage(finalText, totalToolCalls))
+    return@flow
+}
+```
+
+- [ ] **Step 7: Emit `TokenUsageReport` at max-iterations exit**
+
+At line 222-226, add the emit:
+
+```kotlin
+val usage = buildTokenUsage(anyRealUsage, accInputTokens, accOutputTokens, accTotalTokens, messages, null)
+emit(ChatEvent.TokenUsageReport(usage))
+emit(ChatEvent.AssistantMessage(
+    "I wasn't able to complete this request within the tool call limit.",
+    totalToolCalls
+))
+```
+
+- [ ] **Step 8: Build to verify**
+
+Run: `./gradlew app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
+git commit -m "feat: extract token usage from Koog ResponseMetaInfo (#218)"
+```
+
+---
+
+### Task 3: Add session token tracking to repository and UI state
+
+**Files:**
+- Modify: `assistant/data/IAssistantRepository.kt:7-24`
+- Modify: `assistant/data/AssistantRepository.kt:34,47,66`
+- Modify: `assistant/presentation/AssistantUiState.kt:21-27`
+
+- [ ] **Step 1: Add `sessionTokensFlow` to `IAssistantRepository`**
+
+Add after `val onHistoryCleared`:
+
+```kotlin
+interface IAssistantRepository {
+    // ... existing members
+    val sessionTokensFlow: Flow<Int>
+    // ... rest unchanged
+}
+```
+
+Add `import kotlinx.coroutines.flow.StateFlow` if not already present.
+
+- [ ] **Step 2: Implement `sessionTokensFlow` in `AssistantRepository`**
+
+Add a `MutableStateFlow` and update `addMessage`/`clearHistory`:
+
+```kotlin
+class AssistantRepository(...) : IAssistantRepository {
+    // ... existing fields
+    private val _sessionTokens = MutableStateFlow(0)
+    override val sessionTokensFlow: Flow<Int> = _sessionTokens.asStateFlow()
+
+    override fun addMessage(message: ChatMessage) {
+        messages.add(message)
+        message.tokenUsage?.let { _sessionTokens.value += it.totalTokens }
+    }
+
+    override fun clearHistory() {
+        messages.clear()
+        _sessionTokens.value = 0
+        _onHistoryCleared.tryEmit(Unit)
+    }
+}
+```
+
+Add imports: `import kotlinx.coroutines.flow.MutableStateFlow`, `import kotlinx.coroutines.flow.asStateFlow`.
+
+- [ ] **Step 3: Add `sessionTokens` to `AssistantUiState.Active`**
+
+```kotlin
+@Immutable
+data class Active(
+    val messages: ImmutableList<ChatMessage> = persistentListOf(),
+    val isGenerating: Boolean = false,
+    val streamingText: String? = null,
+    val connections: Map<String, McpConnectionState> = emptyMap(),
+    val pendingConfirmation: PendingConfirmation? = null,
+    val sessionTokens: Int = 0
+) : AssistantUiState
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `./gradlew app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt \
+      app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt \
+      app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantUiState.kt
+git commit -m "feat: add session token tracking to repository and UI state (#218)"
+```
+
+---
+
+### Task 4: Handle `TokenUsageReport` in `AssistantViewModel`
+
+**Files:**
+- Modify: `assistant/presentation/AssistantViewModel.kt:236-313` (event collection)
+- Modify: `assistant/presentation/AssistantViewModel.kt:338-341` (clearHistory)
+
+- [ ] **Step 1: Add `pendingTokenUsage` variable and event handler**
+
+In the `sendMessage` method, after `val usedToolNames = mutableListOf<String>()` (line 238), add:
+
+```kotlin
+var pendingTokenUsage: TokenUsage? = null
+```
+
+In the `when (event)` block (line 258), add a new case before `is ChatEvent.AssistantMessage`:
+
+```kotlin
+is ChatEvent.TokenUsageReport -> {
+    pendingTokenUsage = event.usage
+}
+```
+
+- [ ] **Step 2: Attach `tokenUsage` to `ChatMessage` in `AssistantMessage` handler**
+
+Modify the `is ChatEvent.AssistantMessage` handler (line 276-296). Add `tokenUsage` to the `ChatMessage` constructor:
+
+```kotlin
+is ChatEvent.AssistantMessage -> {
+    val responseSource = when {
+        usedSources.isEmpty() -> ResponseSource.LLM
+        usedSources.size > 1 -> ResponseSource.MIXED
+        "local" in usedSources -> ResponseSource.LOCAL
+        else -> ResponseSource.MCP
+    }
+    val finalMsg = ChatMessage(
+        role = Role.ASSISTANT,
+        content = event.fullText,
+        source = responseSource,
+        toolsUsed = usedToolNames.distinct(),
+        tokenUsage = pendingTokenUsage
+    )
+    repository.addMessage(finalMsg)
+    updateState {
+        copy(
+            messages = repository.getHistory().toImmutableList(),
+            isGenerating = false,
+            streamingText = null
+        )
+    }
+}
+```
+
+Note: `sessionTokens` no longer needs updating here — it comes from the repository's `sessionTokensFlow` (wired in Task 5).
+
+- [ ] **Step 3: Add import for `TokenUsage`**
+
+Add at the top of `AssistantViewModel.kt`:
+
+```kotlin
+import io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `./gradlew app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+git commit -m "feat: handle TokenUsageReport in AssistantViewModel (#218)"
+```
+
+---
+
+### Task 5: Wire session tokens into UI state via repository flow
+
+**Files:**
+- Modify: `assistant/presentation/AssistantViewModel.kt:82-96` (init block where Active state is created)
+
+- [ ] **Step 1: Collect `sessionTokensFlow` and update Active state**
+
+In the ViewModel's `init` block, after the `tokenManager.activeInstance.collect` block that creates `AssistantUiState.Active`, add a second `launch` to observe session tokens:
+
+```kotlin
+init {
+    // ... existing launch for instance collection
+
+    viewModelScope.launch {
+        repository.sessionTokensFlow.collect { tokens ->
+            _uiState.update { current ->
+                if (current is AssistantUiState.Active) {
+                    current.copy(sessionTokens = tokens)
+                } else current
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `./gradlew app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+git commit -m "feat: wire session token flow into ViewModel UI state (#218)"
+```
+
+---
+
+### Task 6: Display per-message token count in `SourceBand`
+
+**Files:**
+- Modify: `assistant/ui/ChatBubble.kt:98-104` (AssistantMessage signature)
+- Modify: `assistant/ui/ChatBubble.kt:147-148` (SourceBand call)
+- Modify: `assistant/ui/ChatBubble.kt:224-273` (SourceBand composable)
+
+- [ ] **Step 1: Add `tokenUsage` parameter to `AssistantMessage`**
+
+Update the signature (line 98-104):
+
+```kotlin
+@Composable
+fun AssistantMessage(
+    content: String,
+    source: ResponseSource? = null,
+    toolsUsed: List<String> = emptyList(),
+    tokenUsage: TokenUsage? = null,
+    onCopy: (() -> Unit)? = null,
+    onRegenerate: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
+)
+```
+
+Add import at the top of `ChatBubble.kt`:
+
+```kotlin
+import io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
+```
+
+- [ ] **Step 2: Pass `tokenUsage` to `SourceBand`**
+
+Update the `SourceBand` call (line 147-148):
+
+```kotlin
+if (source != null) {
+    SourceBand(source = source, toolsUsed = toolsUsed, tokenUsage = tokenUsage)
+}
+```
+
+- [ ] **Step 3: Update `SourceBand` to accept and display `tokenUsage`**
+
+Replace the entire `SourceBand` composable (lines 224-273):
+
+```kotlin
+@Composable
+private fun SourceBand(
+    source: ResponseSource,
+    toolsUsed: List<String>,
+    tokenUsage: TokenUsage? = null,
+    modifier: Modifier = Modifier
+) {
+    val sourceLabel = when (source) {
+        ResponseSource.LOCAL -> "local"
+        ResponseSource.MCP -> "mcp"
+        ResponseSource.LLM -> "llm"
+        ResponseSource.MIXED -> "local + mcp"
+    }
+    val color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+
+    Column(modifier = modifier.fillMaxWidth().padding(bottom = 4.dp)) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = sourceLabel,
+                style = MaterialTheme.typography.labelSmall,
+                color = color,
+            )
+            if (toolsUsed.isNotEmpty()) {
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = "·",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = color,
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = toolsUsed.joinToString(", "),
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        fontFamily = FontFamily.Monospace
+                    ),
+                    color = color,
+                    maxLines = 1,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+            }
+            if (tokenUsage != null) {
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = "·",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = color,
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = "${tokenUsage.formatTotal()} tokens",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = color,
+                )
+            }
+        }
+        HorizontalDivider(
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+            thickness = 0.5.dp,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `./gradlew app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ChatBubble.kt
+git commit -m "feat: display per-message token count in SourceBand (#218)"
+```
+
+---
+
+### Task 7: Pass `tokenUsage` from `AssistantScreen` to `AssistantMessage`
+
+**Files:**
+- Modify: `assistant/ui/AssistantScreen.kt:266-275`
+
+- [ ] **Step 1: Add `tokenUsage` argument to `AssistantMessage` call**
+
+At line 266-275, add the parameter:
+
+```kotlin
+Role.ASSISTANT -> AssistantMessage(
+    content = message.content,
+    source = message.source,
+    toolsUsed = message.toolsUsed,
+    tokenUsage = message.tokenUsage,
+    onCopy = {
+        clipboardManager.setText(AnnotatedString(message.content))
+    },
+    onRegenerate = if (isLastAssistant) onRegenerateLastMessage
+        else null,
+)
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `./gradlew app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
+git commit -m "feat: pass tokenUsage from AssistantScreen to ChatBubble (#218)"
+```
+
+---
+
+### Task 8: Show session token counter in top bar
+
+**Files:**
+- Modify: `ui/main/MainScreen.kt:65-70` (state observation)
+- Modify: `ui/main/MainScreen.kt:130-141` (actions area, before clear chat button)
+
+- [ ] **Step 1: Observe `sessionTokensFlow` from repository**
+
+After line 70 (`val activeProviderKey ...`), add:
+
+```kotlin
+val sessionTokens by assistantRepository.sessionTokensFlow
+    .collectAsStateWithLifecycle(initialValue = 0)
+```
+
+Add import:
+
+```kotlin
+import io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
+```
+
+- [ ] **Step 2: Add session token counter in top bar actions**
+
+After the `ProviderSwitchChip(...)` block (line 141) and before the `if (selectedTab is TopLevelTab.Assistant)` block (line 142), add:
+
+```kotlin
+if (selectedTab is TopLevelTab.Assistant && sessionTokens > 0) {
+    val formatted = TokenUsage(0, 0, sessionTokens).formatTotal()
+    Text(
+        text = "$formatted tokens",
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .padding(end = 4.dp)
+            .testTag("text_session_tokens"),
+    )
+}
+```
+
+Add import for `testTag` if not already present:
+
+```kotlin
+import androidx.compose.ui.platform.testTag
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `./gradlew app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
+git commit -m "feat: show session token counter in top bar (#218)"
+```
+
+---
+
+### Task 9: Run tests and verify
+
+**Files:**
+- No new files
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `TMPDIR=$(pwd)/.tmp ./gradlew test`
+Expected: All existing tests pass (no regressions from adding defaulted `tokenUsage = null` field)
+
+- [ ] **Step 2: Run lint**
+
+Run: `TMPDIR=$(pwd)/.tmp ./gradlew lint`
+Expected: No new lint errors
+
+- [ ] **Step 3: Verify ChatEngine streaming test still passes**
+
+Run: `TMPDIR=$(pwd)/.tmp ./gradlew test --tests "*ChatEngine*"`
+Expected: PASS — the test creates `StreamFrame.End(finishReason = "stop")` which uses `metaInfo = ResponseMetaInfo.Empty`, so `totalTokensCount` will be null and the fallback path runs.
+
+- [ ] **Step 4: Final commit if any fixes needed**
+
+If tests required fixes, commit them:
+
+```bash
+git add -A
+git commit -m "fix: address test issues from token usage feature (#218)"
+```

--- a/docs/superpowers/specs/2026-05-28-token-usage-indicator-design.md
+++ b/docs/superpowers/specs/2026-05-28-token-usage-indicator-design.md
@@ -1,0 +1,265 @@
+# Token Usage Indicator — Design Spec
+
+## Summary
+
+Add a per-message and session-level token usage indicator to the AI assistant (Jane) chat UI. The indicator shows how many LLM tokens each response consumed and what source handled it (LLM/local/MCP), giving the user visibility into API cost and usage patterns.
+
+## Data Source
+
+Koog's streaming API provides token counts through `StreamFrame.End.metaInfo: ResponseMetaInfo` (Koog 1.0.0, verified from source at tag `1.0.0`).
+
+`ResponseMetaInfo` fields (from `Message.kt` in Koog source):
+
+```kotlin
+data class ResponseMetaInfo(
+    val timestamp: Instant,
+    val totalTokensCount: Int? = null,
+    val inputTokensCount: Int? = null,
+    val outputTokensCount: Int? = null,
+    val modelId: String? = null,
+    val metadata: JsonObject? = null
+)
+```
+
+All three providers the app supports populate these fields:
+
+| Provider | How Koog populates ResponseMetaInfo |
+|----------|-------------------------------------|
+| OpenAI-compatible | `OpenAILLMClient` extracts `usage.totalTokens`, `usage.promptTokens`, `usage.completionTokens` from API response |
+| Gemini | `GoogleLLMClient` extracts `usageMetadata` |
+| Ollama | `OllamaClient` extracts `prompt_eval_count` and `eval_count` |
+
+**Fallback:** When `totalTokensCount` is null (rare edge case — provider doesn't report usage), estimate from `totalChars / 4` and flag as estimated. The `~` prefix signals approximation to the user.
+
+## Data Model
+
+### New data class
+
+File: `assistant/engine/ChatMessage.kt`
+
+```kotlin
+@Immutable
+data class TokenUsage(
+    val inputTokens: Int,
+    val outputTokens: Int,
+    val totalTokens: Int,
+    val isEstimated: Boolean = false
+)
+```
+
+### ChatMessage extension
+
+Add one field to `ChatMessage`:
+
+```kotlin
+data class ChatMessage(
+    // ... existing fields unchanged
+    val tokenUsage: TokenUsage? = null
+)
+```
+
+### UI state extension
+
+Add session aggregate to `AssistantUiState.Active`:
+
+```kotlin
+data class Active(
+    // ... existing fields unchanged
+    val sessionTokens: Int = 0
+)
+```
+
+## Engine Changes
+
+### ChatEngine.kt
+
+**New ChatEvent:**
+
+```kotlin
+sealed interface ChatEvent {
+    // ... existing events unchanged
+    data class TokenUsageReport(val usage: TokenUsage) : ChatEvent
+}
+```
+
+**Token accumulation across agentic loop iterations:**
+
+Add mutable accumulators before the `loop@` block:
+
+```kotlin
+var accInputTokens = 0
+var accOutputTokens = 0
+var accTotalTokens = 0
+var anyRealUsage = false
+```
+
+In the `StreamFrame.End` handler (line 118), extract metaInfo:
+
+```kotlin
+is StreamFrame.End -> {
+    val meta = frame.metaInfo
+    if (meta.totalTokensCount != null) {
+        accInputTokens += meta.inputTokensCount ?: 0
+        accOutputTokens += meta.outputTokensCount ?: 0
+        accTotalTokens += meta.totalTokensCount ?: 0
+        anyRealUsage = true
+    }
+}
+```
+
+Before emitting `ChatEvent.AssistantMessage`, emit `TokenUsageReport`:
+
+```kotlin
+val usage = if (anyRealUsage) {
+    TokenUsage(
+        inputTokens = accInputTokens,
+        outputTokens = accOutputTokens,
+        totalTokens = accTotalTokens,
+        isEstimated = false
+    )
+} else {
+    // Fallback: estimate from total chars processed
+    val totalChars = messages.sumOf { it.content.length } + (responseText?.length ?: 0)
+    val estimated = totalChars / 4
+    TokenUsage(
+        inputTokens = estimated * 2 / 3,  // rough split
+        outputTokens = estimated / 3,
+        totalTokens = estimated,
+        isEstimated = true
+    )
+}
+emit(ChatEvent.TokenUsageReport(usage))
+emit(ChatEvent.AssistantMessage(finalText, totalToolCalls))
+```
+
+This `TokenUsageReport` is emitted at every exit point from the agentic loop (normal completion, max iterations, repeat detection).
+
+### Token accumulation behavior
+
+In the agentic loop, each LLM call triggers a `StreamFrame.End` with its own `metaInfo`. The accumulators sum across all iterations:
+
+```
+Iteration 1: LLM → 800 in + 200 out → tool call
+Iteration 2: LLM → 1200 in + 150 out → tool call
+Iteration 3: LLM → 1500 in + 300 out → final text
+Reported: 3500 in + 650 out = 4150 total
+```
+
+## ViewModel Changes
+
+### AssistantViewModel.kt
+
+In the `engine.processMessage().collect` block, add a handler for the new event:
+
+```kotlin
+var pendingTokenUsage: TokenUsage? = null
+
+// In the when block:
+is ChatEvent.TokenUsageReport -> {
+    pendingTokenUsage = event.usage
+}
+is ChatEvent.AssistantMessage -> {
+    val finalMsg = ChatMessage(
+        // ... existing fields
+        tokenUsage = pendingTokenUsage
+    )
+    repository.addMessage(finalMsg)
+    updateState {
+        copy(
+            messages = repository.getHistory().toImmutableList(),
+            isGenerating = false,
+            streamingText = null,
+            sessionTokens = sessionTokens + (pendingTokenUsage?.totalTokens ?: 0)
+        )
+    }
+}
+```
+
+Reset `sessionTokens` when chat is cleared — in the clear chat handler:
+
+```kotlin
+updateState {
+    copy(
+        messages = persistentListOf(),
+        sessionTokens = 0
+    )
+}
+```
+
+## UI Changes
+
+### Per-message indicator (ChatBubble.kt)
+
+Extend the existing `SourceBand` composable to accept and display token usage.
+
+**Updated signature:**
+
+```kotlin
+@Composable
+private fun SourceBand(
+    source: ResponseSource,
+    toolsUsed: List<String>,
+    tokenUsage: TokenUsage? = null,
+    modifier: Modifier = Modifier
+)
+```
+
+**Display format** — appended after tools list in the same Row:
+
+```
+local · list_jobs, get_job_status · 2.4K tokens
+llm · ~1.2K tokens
+local + mcp · ping, controller.list_hosts · 890 tokens
+```
+
+Formatting rules:
+- `< 1000`: show as-is (e.g., `890 tokens`)
+- `>= 1000`: show as `X.YK tokens` (e.g., `2.4K tokens`)
+- If `isEstimated`: prefix with `~` (e.g., `~1.2K tokens`)
+- Same `labelSmall` style, same muted color as existing source/tools text
+- Separated from tools list by the same `·` dot separator
+
+**Propagation:** `AssistantMessage` composable passes `tokenUsage` from `ChatMessage` to `SourceBand`.
+
+### Session aggregate (MainScreen.kt)
+
+Show a compact token counter in the top bar's `actions` area, only when the Assistant tab is selected.
+
+**Placement:** Before the clear-chat icon button, after `ProviderSwitchChip`.
+
+**Display format:**
+
+```
+12.4K ▼    [🗑]  [🔔]  [⚙]
+```
+
+- Same formatting rules as per-message (K suffix for >= 1000)
+- `labelSmall` style, `onSurfaceVariant` color
+- Only visible when `sessionTokens > 0`
+- The `▼` placeholder is for a future LLM model dropdown — for now, just the token count text
+
+**Data flow:** `MainScreen` observes `AssistantUiState.Active.sessionTokens` from the ViewModel and passes it to the top bar.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `assistant/engine/ChatMessage.kt` | Add `TokenUsage` data class, add `tokenUsage` field to `ChatMessage` |
+| `assistant/engine/ChatEngine.kt` | Extract `ResponseMetaInfo` from `StreamFrame.End`, accumulate across iterations, emit `TokenUsageReport` event |
+| `assistant/presentation/AssistantUiState.kt` | Add `sessionTokens: Int` to `Active` |
+| `assistant/presentation/AssistantViewModel.kt` | Handle `TokenUsageReport` event, attach to `ChatMessage`, update session total |
+| `assistant/ui/ChatBubble.kt` | Extend `SourceBand` to show token count, update `AssistantMessage` to pass token data |
+| `ui/main/MainScreen.kt` | Show session token counter in top bar when on Assistant tab |
+
+## Not in scope
+
+- Persisting token usage across sessions (DataStore) — tokens reset on app restart
+- Token budget/limit warnings — future enhancement
+- Prompt-tokenizer for context window management — separate issue for Token Saver mode improvement
+- Per-iteration breakdown UI — aggregated total only
+
+## Future considerations
+
+- **LLM model dropdown in top bar:** The session token counter is placed to co-exist with a future model selector
+- **Koog prompt-tokenizer for Token Saver:** Adding `ai.koog:prompt-tokenizer` to improve the existing char-based context trimming in `compactHistory`/`trimMessages` would be a natural follow-up, tracked separately
+- **Cost estimation:** With token counts and model name, we could calculate approximate API cost per message


### PR DESCRIPTION
## Summary

- Extract LLM token counts from Koog's `ResponseMetaInfo` (`StreamFrame.End.metaInfo`) and accumulate across agentic loop iterations in `ChatEngine`
- Display per-message token count in the existing `SourceBand` below each assistant response (e.g., `local · list_jobs · 2.4K tokens`)
- Show session-level aggregate token counter in the top bar when on the Assistant tab
- Fall back to char-based estimation (`totalChars / 4`, prefixed with `~`) when provider doesn't report tokens

## Test plan

- [x] All existing unit tests pass (updated 3 tests to expect new `TokenUsageReport` event)
- [x] `FakeAssistantRepository` updated with `sessionTokensFlow`
- [x] `./gradlew test` passes
- [x] `./gradlew app:compileDebugKotlin` passes
- [ ] Manual: verify per-message token count appears in SourceBand after each assistant response
- [ ] Manual: verify session counter appears in top bar and resets on clear chat
- [ ] Manual: verify estimated tokens show `~` prefix when using a provider that doesn't report usage

Closes #218

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>