### PR TITLE
Add EDA auto-detected MCP server (#171)

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -374,6 +374,10 @@ class SettingsViewModel(
                     url = "$base/platform_configuration/mcp", label = "Configuration",
                     isAutoDetected = true, readOnly = true, toolset = "platform_configuration"
                 ),
+                McpServerConfig(
+                    url = "$base/event_management/mcp", label = "EDA",
+                    isAutoDetected = true, readOnly = true, toolset = "event_management"
+                ),
             )
             val manualUrls = manualServers.map { it.url }.toSet()
             tokenManager.updateMcpConfig(


### PR DESCRIPTION
## Summary
- Add missing `event_management` auto-detected MCP server to `toggleMcpEnabled()`
- All 7 toolsets in `TOOLSET_CATEGORY_MAP` now have matching auto-detected servers
- Found during ToolRouter deep audit (#171, Bug 1)

## Test plan
- [ ] Toggle MCP on for an instance, verify 7 servers appear (including EDA)
- [ ] Existing MCP behavior unchanged for the other 6 toolsets

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>