### PR TITLE
Fix Gemini 429 rate limit surfacing as Content-Length mismatch (#161)

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/llm/GeminiLlmProvider.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/llm/GeminiLlmProvider.kt
@@ -65,7 +65,12 @@ class GeminiLlmProvider(
         is LlmServerException, is LlmTimeoutException -> e
         is LLMClientException -> {
             val cause = e.cause
-            if (cause != null) mapException(cause) else LlmServerException("LLM error: ${e.message}")
+            when {
+                cause != null -> mapException(cause)
+                e.message?.contains("Content-Length mismatch") == true ->
+                    LlmRateLimitException("Rate limited — try again later")
+                else -> LlmServerException("Gemini error: ${e.message}")
+            }
         }
         is KoogHttpClientException -> {
             val code = e.statusCode

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/llm/GeminiLlmProviderTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/llm/GeminiLlmProviderTest.kt
@@ -116,6 +116,13 @@ class GeminiLlmProviderTest {
     }
 
     @Test
+    fun `SHOULD throw LlmRateLimitException WHEN LLMClientException with Content-Length mismatch`() {
+        val ex = LLMClientException("google", "Content-Length mismatch: expected 1363 bytes, but received 0 bytes")
+        val mapped = provider.mapException(ex)
+        assertTrue(mapped is LlmRateLimitException)
+    }
+
+    @Test
     fun `SHOULD pass through already-mapped LlmAuthException`() {
         val ex = LlmAuthException("Already mapped")
         val mapped = provider.mapException(ex)


### PR DESCRIPTION
## Summary
- Detect Koog's `LLMClientException("Content-Length mismatch...")` as a rate limit error
- Map to `LlmRateLimitException` so users see "Rate limited — try again later" instead of a confusing parsing error
- Add test case for the workaround

## Test plan
- [x] Existing GeminiLlmProviderTest passes
- [x] New test: Content-Length mismatch → LlmRateLimitException
- [ ] Manual: rapid Gemini free-tier queries show "Rate limited" message

Closes #161

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>