### PR TITLE
Add MCP server auth options (#217)

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/AssistantModule.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/AssistantModule.kt
@@ -26,10 +26,18 @@ val assistantModule = module {
         McpServerManager(
             ktorClientFactory = { instance, serverConfig ->
                 createPlatformHttpClient(trustSelfSigned = instance.trustSelfSigned) {
-                    if (serverConfig.useInstanceAuth) {
-                        defaultRequest {
+                    defaultRequest {
+                        if (serverConfig.useInstanceAuth) {
                             header(HttpHeaders.Authorization, "Bearer ${instance.token}")
                         }
+                        serverConfig.headers
+                            .filter { (key, _) ->
+                                !serverConfig.useInstanceAuth ||
+                                    !key.equals(HttpHeaders.Authorization, ignoreCase = true)
+                            }
+                            .forEach { (key, value) ->
+                                header(key, value)
+                            }
                     }
                     install(SSE)
                 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/mcp/PopularMcpServers.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/network/mcp/PopularMcpServers.kt
@@ -1,0 +1,30 @@
+package io.github.leogallego.ansiblejane.network.mcp
+
+data class PopularMcpServer(
+    val name: String,
+    val url: String,
+    val description: String
+)
+
+val popularMcpServers = listOf(
+    PopularMcpServer(
+        name = "Context7",
+        url = "https://mcp.context7.com/mcp",
+        description = "Up-to-date library & framework documentation"
+    ),
+    PopularMcpServer(
+        name = "Fetch",
+        url = "https://mcp-fetch.onrender.com/mcp",
+        description = "Fetch web content and convert to markdown"
+    ),
+    PopularMcpServer(
+        name = "DeepWiki",
+        url = "https://mcp.deepwiki.com/mcp",
+        description = "AI-generated docs for GitHub repositories"
+    ),
+    PopularMcpServer(
+        name = "Sequential Thinking",
+        url = "https://mcp-sequential-thinking.onrender.com/mcp",
+        description = "Step-by-step problem solving and analysis"
+    ),
+)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -391,16 +391,34 @@ class SettingsViewModel(
         }
     }
 
-    fun addMcpServer(url: String, label: String, toolset: String? = null) {
+    fun addMcpServer(
+        url: String,
+        label: String,
+        toolset: String? = null,
+        headers: Map<String, String> = emptyMap(),
+        useInstanceAuth: Boolean = true
+    ) {
         viewModelScope.launch {
             val instance = tokenManager.activeInstance.value ?: return@launch
             val sanitizedUrl = url.trim().trimEnd('/')
             val uri = try { java.net.URI(sanitizedUrl) } catch (_: Exception) { return@launch }
             if (uri.scheme?.lowercase() !in listOf("https", "wss")) return@launch
             val current = instance.mcpServerUrls?.toMutableList() ?: mutableListOf()
-            current.add(McpServerConfig(url = sanitizedUrl, label = label, toolset = toolset))
+            current.add(
+                McpServerConfig(
+                    url = sanitizedUrl,
+                    label = label,
+                    toolset = toolset,
+                    headers = headers,
+                    useInstanceAuth = useInstanceAuth
+                )
+            )
             tokenManager.updateMcpConfig(instance.id, true, current)
         }
+    }
+
+    fun toggleUseInstanceAuth(url: String, useInstanceAuth: Boolean) {
+        updateMcpServer(url) { it.copy(useInstanceAuth = useInstanceAuth) }
     }
 
     fun removeMcpServer(url: String) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/AddMcpServerSheet.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/AddMcpServerSheet.kt
@@ -1,5 +1,6 @@
 package io.github.leogallego.ansiblejane.ui.settings
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,36 +8,56 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.leogallego.ansiblejane.R
+import io.github.leogallego.ansiblejane.network.mcp.popularMcpServers
 import java.net.URI
+
+private data class HeaderEntry(val key: String = "", val value: String = "")
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddMcpServerSheet(
     onDismiss: () -> Unit,
-    onAdd: (url: String, label: String, toolset: String?) -> Unit
+    onAdd: (url: String, label: String, toolset: String?, headers: Map<String, String>, useInstanceAuth: Boolean) -> Unit
 ) {
     var name by remember { mutableStateOf("") }
     var url by remember { mutableStateOf("") }
     var toolset by remember { mutableStateOf("") }
     var urlError by remember { mutableStateOf<String?>(null) }
+    var useInstanceAuth by remember { mutableStateOf(true) }
+    val headers = remember { mutableStateListOf<HeaderEntry>() }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -45,6 +66,7 @@ fun AddMcpServerSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = 24.dp, vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
@@ -58,7 +80,9 @@ fun AddMcpServerSheet(
                 onValueChange = { name = it },
                 label = { Text(stringResource(R.string.tools_mcp_server_name)) },
                 placeholder = { Text("knowledge") },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("field_add_mcp_name"),
                 singleLine = true
             )
 
@@ -67,7 +91,9 @@ fun AddMcpServerSheet(
                 onValueChange = { url = it; urlError = null },
                 label = { Text(stringResource(R.string.tools_mcp_server_url)) },
                 placeholder = { Text("https://mcp-server:3000/mcp") },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("field_add_mcp_url"),
                 singleLine = true,
                 isError = urlError != null,
                 supportingText = urlError?.let { error -> { Text(error) } }
@@ -78,9 +104,87 @@ fun AddMcpServerSheet(
                 onValueChange = { toolset = it },
                 label = { Text(stringResource(R.string.tools_mcp_server_toolset)) },
                 placeholder = { Text("job_management") },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("field_add_mcp_toolset"),
                 singleLine = true
             )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.tools_mcp_use_instance_auth),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Switch(
+                    checked = useInstanceAuth,
+                    onCheckedChange = { useInstanceAuth = it },
+                    modifier = Modifier.testTag("switch_add_mcp_instance_auth")
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.tools_mcp_custom_headers),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                TextButton(
+                    onClick = { headers.add(HeaderEntry(key = "Authorization")) },
+                    modifier = Modifier.testTag("button_add_header")
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(16.dp))
+                    Text(
+                        stringResource(R.string.tools_mcp_add_header),
+                        modifier = Modifier.padding(start = 4.dp)
+                    )
+                }
+            }
+
+            headers.forEachIndexed { index, entry ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    OutlinedTextField(
+                        value = entry.key,
+                        onValueChange = { headers[index] = entry.copy(key = it) },
+                        label = { Text(stringResource(R.string.tools_mcp_header_name)) },
+                        placeholder = { Text("Authorization") },
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag("field_header_key_$index"),
+                        singleLine = true
+                    )
+                    OutlinedTextField(
+                        value = entry.value,
+                        onValueChange = { headers[index] = entry.copy(value = it) },
+                        label = { Text(stringResource(R.string.tools_mcp_header_value)) },
+                        placeholder = { Text("Bearer xxx") },
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag("field_header_value_$index"),
+                        singleLine = true
+                    )
+                    IconButton(
+                        onClick = { headers.removeAt(index) },
+                        modifier = Modifier.testTag("button_remove_header_$index")
+                    ) {
+                        Icon(
+                            Icons.Default.Close,
+                            contentDescription = stringResource(R.string.tools_mcp_remove_header),
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                }
+            }
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -96,7 +200,10 @@ fun AddMcpServerSheet(
                         if (error != null) {
                             urlError = error
                         } else {
-                            onAdd(url, name, toolset.ifBlank { null })
+                            val headersMap = headers
+                                .filter { it.key.isNotBlank() && it.value.isNotBlank() }
+                                .associate { it.key.trim() to it.value.trim() }
+                            onAdd(url, name, toolset.ifBlank { null }, headersMap, useInstanceAuth)
                             onDismiss()
                         }
                     },
@@ -105,6 +212,41 @@ fun AddMcpServerSheet(
                         .testTag("button_add_mcp_server"),
                     enabled = name.isNotBlank() && url.isNotBlank()
                 ) { Text(stringResource(R.string.tools_mcp_add_server)) }
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+            Text(
+                text = stringResource(R.string.tools_mcp_popular_servers),
+                style = MaterialTheme.typography.titleSmall
+            )
+
+            popularMcpServers.forEach { server ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("card_popular_${server.name}")
+                        .clickable {
+                            onAdd(server.url, server.name, null, emptyMap(), false)
+                            onDismiss()
+                        }
+                ) {
+                    Column(
+                        modifier = Modifier.padding(12.dp)
+                    ) {
+                        Text(
+                            text = server.name,
+                            style = MaterialTheme.typography.titleSmall
+                        )
+                        Text(
+                            text = server.description,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/McpServerCard.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/McpServerCard.kt
@@ -52,6 +52,7 @@ fun McpServerCard(
     onToggleExpand: () -> Unit,
     onToggleEnabled: (Boolean) -> Unit,
     onToggleReadOnly: (Boolean) -> Unit,
+    onToggleUseInstanceAuth: (Boolean) -> Unit,
     onToggleTool: (String, Boolean) -> Unit,
     onRefresh: () -> Unit,
     onRemove: () -> Unit,
@@ -162,6 +163,32 @@ fun McpServerCard(
                             checked = server.readOnly,
                             onCheckedChange = onToggleReadOnly,
                             modifier = Modifier.testTag("switch_mcp_readonly_${server.label}")
+                        )
+                    }
+
+                    if (!server.isAutoDetected) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = stringResource(R.string.tools_mcp_use_instance_auth),
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            Switch(
+                                checked = server.useInstanceAuth,
+                                onCheckedChange = onToggleUseInstanceAuth,
+                                modifier = Modifier.testTag("switch_mcp_instance_auth_${server.label}")
+                            )
+                        }
+                    }
+
+                    if (server.headers.isNotEmpty()) {
+                        Text(
+                            text = stringResource(R.string.tools_mcp_headers_count, server.headers.size),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.tertiary
                         )
                     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
@@ -63,9 +63,14 @@ fun SettingsScreen(
                     onFetchModels = { url, key -> viewModel.fetchAvailableModels(url, key) },
                     onClearFetchedModels = { viewModel.clearFetchedModels() },
                     onToggleMcp = { viewModel.toggleMcpEnabled(it) },
-                    onAddMcpServer = { url, label, toolset -> viewModel.addMcpServer(url, label, toolset) },
+                    onAddMcpServer = { url, label, toolset, headers, useInstanceAuth ->
+                        viewModel.addMcpServer(url, label, toolset, headers, useInstanceAuth)
+                    },
                     onRemoveMcpServer = { viewModel.removeMcpServer(it) },
                     onToggleReadOnly = { url, readOnly -> viewModel.toggleServerReadOnly(url, readOnly) },
+                    onToggleUseInstanceAuth = { url, useInstanceAuth ->
+                        viewModel.toggleUseInstanceAuth(url, useInstanceAuth)
+                    },
                     onToggleServerEnabled = { url, enabled -> viewModel.toggleServerEnabled(url, enabled) },
                     onToggleToolEnabled = { name, source, enabled -> viewModel.toggleToolEnabled(name, source, enabled) },
                     onToggleExpandMcpServer = { viewModel.toggleExpandMcpServer(it) },
@@ -100,9 +105,10 @@ private fun SettingsContent(
     onFetchModels: (String, String?) -> Unit,
     onClearFetchedModels: () -> Unit,
     onToggleMcp: (Boolean) -> Unit,
-    onAddMcpServer: (String, String, String?) -> Unit,
+    onAddMcpServer: (String, String, String?, Map<String, String>, Boolean) -> Unit,
     onRemoveMcpServer: (String) -> Unit,
     onToggleReadOnly: (String, Boolean) -> Unit,
+    onToggleUseInstanceAuth: (String, Boolean) -> Unit,
     onToggleServerEnabled: (String, Boolean) -> Unit,
     onToggleToolEnabled: (String, ToolSource, Boolean) -> Unit,
     onToggleExpandMcpServer: (String) -> Unit,
@@ -170,6 +176,7 @@ private fun SettingsContent(
                 onAddMcpServer = onAddMcpServer,
                 onRemoveMcpServer = onRemoveMcpServer,
                 onToggleReadOnly = onToggleReadOnly,
+                onToggleUseInstanceAuth = onToggleUseInstanceAuth,
                 onToggleServerEnabled = onToggleServerEnabled,
                 onToggleToolEnabled = onToggleToolEnabled,
                 onToggleExpandMcpServer = onToggleExpandMcpServer,

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolsTab.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolsTab.kt
@@ -47,9 +47,10 @@ fun ToolsTab(
     expandedMcpServers: Set<String>,
     expandedCategories: Set<String>,
     onToggleMcp: (Boolean) -> Unit,
-    onAddMcpServer: (url: String, label: String, toolset: String?) -> Unit,
+    onAddMcpServer: (url: String, label: String, toolset: String?, headers: Map<String, String>, useInstanceAuth: Boolean) -> Unit,
     onRemoveMcpServer: (url: String) -> Unit,
     onToggleReadOnly: (url: String, readOnly: Boolean) -> Unit,
+    onToggleUseInstanceAuth: (url: String, useInstanceAuth: Boolean) -> Unit,
     onToggleServerEnabled: (url: String, enabled: Boolean) -> Unit,
     onToggleToolEnabled: (name: String, source: ToolSource, enabled: Boolean) -> Unit,
     onToggleExpandMcpServer: (label: String) -> Unit,
@@ -104,6 +105,7 @@ fun ToolsTab(
                     onToggleExpand = { onToggleExpandMcpServer(server.label) },
                     onToggleEnabled = { onToggleServerEnabled(server.url, it) },
                     onToggleReadOnly = { onToggleReadOnly(server.url, it) },
+                    onToggleUseInstanceAuth = { onToggleUseInstanceAuth(server.url, it) },
                     onToggleTool = { name, enabled ->
                         onToggleToolEnabled(name, ToolSource.MCP, enabled)
                     },
@@ -167,7 +169,9 @@ fun ToolsTab(
     if (showAddServerSheet) {
         AddMcpServerSheet(
             onDismiss = { showAddServerSheet = false },
-            onAdd = onAddMcpServer
+            onAdd = { url, label, toolset, headers, useInstanceAuth ->
+                onAddMcpServer(url, label, toolset, headers, useInstanceAuth)
+            }
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,14 @@
     <string name="tools_mcp_remove">Remove</string>
     <string name="tools_mcp_read_only">Read Only</string>
     <string name="tools_mcp_error_retry">Tap Refresh to retry</string>
+    <string name="tools_mcp_use_instance_auth">Use instance auth</string>
+    <string name="tools_mcp_custom_headers">Custom headers</string>
+    <string name="tools_mcp_header_name">Header name</string>
+    <string name="tools_mcp_header_value">Header value</string>
+    <string name="tools_mcp_add_header">Add header</string>
+    <string name="tools_mcp_remove_header">Remove header</string>
+    <string name="tools_mcp_popular_servers">Popular Servers</string>
+    <string name="tools_mcp_headers_count">%1$d custom header(s)</string>
     <!-- Tools tab - Local -->
     <string name="tools_local_title">Local Tools</string>
     <string name="tools_local_description">%1$d tools across %2$d categories</string>

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
@@ -94,7 +94,7 @@ class TokenManager(
             apiVersion = serialized.apiVersion,
             trustSelfSigned = serialized.trustSelfSigned,
             certFingerprint = serialized.certFingerprint,
-            mcpServerUrls = serialized.mcpServerUrls,
+            mcpServerUrls = serialized.mcpServerUrls?.map { decryptHeaders(it) },
             mcpEnabled = serialized.mcpEnabled,
             instanceInfo = serialized.instanceInfo
         )
@@ -109,9 +109,23 @@ class TokenManager(
             apiVersion = instance.apiVersion,
             trustSelfSigned = instance.trustSelfSigned,
             certFingerprint = instance.certFingerprint,
-            mcpServerUrls = instance.mcpServerUrls,
+            mcpServerUrls = instance.mcpServerUrls?.map { encryptHeaders(it) },
             mcpEnabled = instance.mcpEnabled,
             instanceInfo = instance.instanceInfo
+        )
+    }
+
+    private fun encryptHeaders(config: McpServerConfig): McpServerConfig {
+        if (config.headers.isEmpty()) return config
+        return config.copy(headers = config.headers.mapValues { (_, v) -> encrypt(v) })
+    }
+
+    private fun decryptHeaders(config: McpServerConfig): McpServerConfig {
+        if (config.headers.isEmpty()) return config
+        return config.copy(
+            headers = config.headers.mapNotNull { (k, v) ->
+                try { k to decrypt(v) } catch (_: Exception) { null }
+            }.toMap()
         )
     }
 
@@ -316,7 +330,10 @@ class TokenManager(
         val state = readState()
         val updatedInstances = state.instances.map { serialized ->
             if (serialized.id == instanceId) {
-                serialized.copy(mcpEnabled = enabled, mcpServerUrls = servers)
+                serialized.copy(
+                    mcpEnabled = enabled,
+                    mcpServerUrls = servers?.map { encryptHeaders(it) }
+                )
             } else serialized
         }
         writeState(state.copy(instances = updatedInstances))

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/AapInstance.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/AapInstance.kt
@@ -10,7 +10,8 @@ data class McpServerConfig(
     val isAutoDetected: Boolean = false,
     val useInstanceAuth: Boolean = true,
     val readOnly: Boolean = false,
-    val toolset: String? = null
+    val toolset: String? = null,
+    val headers: Map<String, String> = emptyMap()
 )
 
 data class AapInstance(


### PR DESCRIPTION
## Summary

- Add `headers: Map<String, String>` to `McpServerConfig` for custom HTTP header auth (Bearer tokens, API keys, any header)
- Header values encrypted at rest via `SecureKeyStorage` in `TokenManager` — same pattern as instance tokens and LLM API keys
- Instance auth `Authorization` header takes precedence over custom headers (case-insensitive filter prevents duplicates)
- Add `useInstanceAuth` toggle to `McpServerCard` for manually-added servers
- Add Popular Servers section in `AddMcpServerSheet` — one-tap add for Context7, Fetch, DeepWiki, Sequential Thinking
- Dynamic header rows UI with add/remove in `AddMcpServerSheet`
- testTags on all new interactive elements

## Files changed (10)

| File | Change |
|------|--------|
| `shared/.../model/AapInstance.kt` | Add `headers` field to `McpServerConfig` |
| `shared/.../data/TokenManager.kt` | `encryptHeaders()`/`decryptHeaders()` + encrypt in `updateMcpConfig()` |
| `app/.../assistant/AssistantModule.kt` | Apply custom headers in `ktorClientFactory`, filter Authorization conflict |
| `app/.../network/mcp/PopularMcpServers.kt` | **NEW** — curated public MCP server list |
| `app/.../ui/settings/AddMcpServerSheet.kt` | Headers UI, instance auth toggle, popular servers section |
| `app/.../ui/settings/McpServerCard.kt` | `useInstanceAuth` toggle, header count indicator |
| `app/.../ui/settings/ToolsTab.kt` | Thread new callbacks |
| `app/.../ui/settings/SettingsScreen.kt` | Thread new callbacks |
| `app/.../presentation/settings/SettingsViewModel.kt` | `addMcpServer` with headers, `toggleUseInstanceAuth` |
| `app/src/main/res/values/strings.xml` | 8 new string resources |

## Security

- Header values encrypted via `SecureKeyStorage.encrypt()` + Base64 before DataStore persistence
- Decrypted only at runtime read path (`toAapInstance`)
- Authorization header conflict prevented: custom `Authorization` filtered when `useInstanceAuth=true`
- Backward compatible: old configs without `headers` field deserialize with `emptyMap()` default

## Test plan

- [ ] Add manual MCP server with custom headers — verify connection works
- [ ] Toggle useInstanceAuth off — verify instance token not sent
- [ ] Add popular server (Context7) — verify one-tap adds with correct URL
- [ ] Verify auto-detected AAP MCP servers unaffected (no useInstanceAuth toggle shown)
- [ ] Verify existing MCP connections still work after upgrade (backward compat)
- [ ] Check DataStore JSON — confirm header values are encrypted, not plaintext

Closes #217
Closes #260

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>