### PR TITLE
feat: UI polish batch — haptic, splash, icon, pinned templates

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -4,8 +4,8 @@
     android:height="108dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
-    <!-- Ansible "A" letterform centered in adaptive icon safe zone -->
+    <!-- Same "A" letterform, single color for themed icon tinting -->
     <path
-        android:fillColor="#FFFFFF"
+        android:fillColor="#000000"
         android:pathData="M54,28 L72,76 L65,76 L61,65 L47,65 L43,76 L36,76 Z M49.5,59 L58.5,59 L54,46 Z" />
 </vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.AnsibleJane" parent="android:Theme.Material.Light.NoActionBar">
-        <item name="android:windowSplashScreenBackground">#FFFFFF</item>
+        <item name="android:windowSplashScreenBackground">#1C1B1F</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
     </style>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -3,5 +3,6 @@
     <style name="Theme.AnsibleJane" parent="android:Theme.Material.NoActionBar">
         <item name="android:windowSplashScreenBackground">#1C1B1F</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="android:windowSplashScreenIconBackgroundColor">#EE0000</item>
     </style>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.AnsibleJane" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.AnsibleJane" parent="android:Theme.Material.NoActionBar">
         <item name="android:windowSplashScreenBackground">#1C1B1F</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
     </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,5 +3,6 @@
     <style name="Theme.AnsibleJane" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:windowSplashScreenBackground">#FFFFFF</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="android:windowSplashScreenIconBackgroundColor">#EE0000</item>
     </style>
 </resources>

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeUserPreferencesRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeUserPreferencesRepository.kt
@@ -27,4 +27,15 @@ class FakeUserPreferencesRepository : IUserPreferencesRepository {
     override suspend fun setThemeMode(mode: ThemeMode) {
         _themeMode.value = mode
     }
+
+    private val _favoriteTemplateIds = MutableStateFlow<Set<Int>>(emptySet())
+    override val favoriteTemplateIds: Flow<Set<Int>> = _favoriteTemplateIds
+
+    override suspend fun toggleFavoriteTemplate(templateId: Int) {
+        _favoriteTemplateIds.value = if (templateId in _favoriteTemplateIds.value) {
+            _favoriteTemplateIds.value - templateId
+        } else {
+            _favoriteTemplateIds.value + templateId
+        }
+    }
 }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeUserPreferencesRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeUserPreferencesRepository.kt
@@ -28,14 +28,13 @@ class FakeUserPreferencesRepository : IUserPreferencesRepository {
         _themeMode.value = mode
     }
 
-    private val _favoriteTemplateIds = MutableStateFlow<Set<Int>>(emptySet())
-    override val favoriteTemplateIds: Flow<Set<Int>> = _favoriteTemplateIds
+    private val _favorites = mutableMapOf<String, MutableStateFlow<Set<Int>>>()
 
-    override suspend fun toggleFavoriteTemplate(templateId: Int) {
-        _favoriteTemplateIds.value = if (templateId in _favoriteTemplateIds.value) {
-            _favoriteTemplateIds.value - templateId
-        } else {
-            _favoriteTemplateIds.value + templateId
-        }
+    override fun favoriteTemplateIds(instanceId: String): Flow<Set<Int>> =
+        _favorites.getOrPut(instanceId) { MutableStateFlow(emptySet()) }
+
+    override suspend fun toggleFavoriteTemplate(instanceId: String, templateId: Int) {
+        val flow = _favorites.getOrPut(instanceId) { MutableStateFlow(emptySet()) }
+        flow.value = if (templateId in flow.value) flow.value - templateId else flow.value + templateId
     }
 }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModelTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import io.github.leogallego.ansiblejane.MainDispatcherRule
 import io.github.leogallego.ansiblejane.fakes.FakeTemplateRepository
 import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
+import io.github.leogallego.ansiblejane.fakes.FakeUserPreferencesRepository
 import io.github.leogallego.ansiblejane.model.AppError
 import io.github.leogallego.ansiblejane.testInstance
 import io.github.leogallego.ansiblejane.testJobTemplate
@@ -27,16 +28,18 @@ class TemplatesViewModelTest {
 
     private lateinit var fakeRepo: FakeTemplateRepository
     private lateinit var fakeTokenManager: FakeTokenManager
+    private lateinit var fakeUserPrefs: FakeUserPreferencesRepository
     private lateinit var viewModel: TemplatesViewModel
 
     @Before
     fun setup() {
         fakeRepo = FakeTemplateRepository()
         fakeTokenManager = FakeTokenManager()
+        fakeUserPrefs = FakeUserPreferencesRepository()
     }
 
     private fun createViewModel(): TemplatesViewModel {
-        return TemplatesViewModel(fakeRepo, fakeTokenManager)
+        return TemplatesViewModel(fakeRepo, fakeTokenManager, fakeUserPrefs)
     }
 
     // --- Init / active instance ---

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/ui/templates/TemplateListScreenTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/ui/templates/TemplateListScreenTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import io.github.leogallego.ansiblejane.MainDispatcherRule
 import io.github.leogallego.ansiblejane.fakes.FakeTemplateRepository
 import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
+import io.github.leogallego.ansiblejane.fakes.FakeUserPreferencesRepository
 import io.github.leogallego.ansiblejane.model.JobTemplate
 import io.github.leogallego.ansiblejane.model.JobTemplateSummaryFields
 import io.github.leogallego.ansiblejane.model.LabelSummary
@@ -32,6 +33,7 @@ class TemplateListScreenTest {
 
     private val fakeRepo = FakeTemplateRepository()
     private val fakeTokenManager = FakeTokenManager()
+    private val fakeUserPrefs = FakeUserPreferencesRepository()
 
     private fun launchableTemplate(
         id: Int = 1,
@@ -52,7 +54,7 @@ class TemplateListScreenTest {
     private fun setUpScreen(
         onNavigateToJobStatus: (Int) -> Unit = {}
     ) {
-        val viewModel = TemplatesViewModel(fakeRepo, fakeTokenManager)
+        val viewModel = TemplatesViewModel(fakeRepo, fakeTokenManager, fakeUserPrefs)
         composeTestRule.setContent {
             MaterialTheme {
                 TemplateListScreen(

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModel.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModel.kt
@@ -14,6 +14,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -34,7 +37,12 @@ class TemplatesViewModel(
     private val _searchQuery = MutableStateFlow("")
     val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
 
-    val favoriteIds: StateFlow<Set<Int>> = userPreferences.favoriteTemplateIds
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    val favoriteIds: StateFlow<Set<Int>> = tokenManager.activeInstance
+        .flatMapLatest { instance ->
+            if (instance != null) userPreferences.favoriteTemplateIds(instance.id)
+            else flowOf(emptySet())
+        }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptySet())
 
     private val _showFavoritesOnly = MutableStateFlow(false)
@@ -126,8 +134,9 @@ class TemplatesViewModel(
     }
 
     fun toggleFavorite(templateId: Int) {
+        val instanceId = tokenManager.activeInstance.value?.id ?: return
         viewModelScope.launch {
-            userPreferences.toggleFavoriteTemplate(templateId)
+            userPreferences.toggleFavoriteTemplate(instanceId, templateId)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.github.leogallego.ansiblejane.data.ITemplateRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
 import io.github.leogallego.ansiblejane.model.AppError
 import io.github.leogallego.ansiblejane.model.JobTemplate
 import io.github.leogallego.ansiblejane.model.Label
@@ -13,12 +14,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class TemplatesViewModel(
     private val templateRepository: ITemplateRepository,
-    private val tokenManager: ITokenManager
+    private val tokenManager: ITokenManager,
+    private val userPreferences: IUserPreferencesRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<TemplatesUiState>(TemplatesUiState.Idle)
@@ -29,6 +33,12 @@ class TemplatesViewModel(
 
     private val _searchQuery = MutableStateFlow("")
     val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    val favoriteIds: StateFlow<Set<Int>> = userPreferences.favoriteTemplateIds
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptySet())
+
+    private val _showFavoritesOnly = MutableStateFlow(false)
+    val showFavoritesOnly: StateFlow<Boolean> = _showFavoritesOnly.asStateFlow()
 
     private var currentPage = 1
     private var currentSearch: String? = null
@@ -113,6 +123,16 @@ class TemplatesViewModel(
         viewModelScope.launch {
             fetchTemplates()
         }
+    }
+
+    fun toggleFavorite(templateId: Int) {
+        viewModelScope.launch {
+            userPreferences.toggleFavoriteTemplate(templateId)
+        }
+    }
+
+    fun toggleShowFavoritesOnly() {
+        _showFavoritesOnly.update { !it }
     }
 
     fun requestLaunch(template: JobTemplate) {

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.collectAsState
@@ -48,6 +50,7 @@ fun ApprovalDetailScreen(
     viewModel: ApprovalDetailViewModel = koinViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val haptic = LocalHapticFeedback.current
 
     var showConfirmDialog by remember { mutableStateOf<String?>(null) }
 
@@ -121,6 +124,7 @@ fun ApprovalDetailScreen(
             confirmButton = {
                 TextButton(
                     onClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                         showConfirmDialog = null
                         if (action == "approve") viewModel.approve() else viewModel.deny()
                     }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/LabelChips.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/LabelChips.kt
@@ -17,9 +17,10 @@ fun LabelChips(
     labels: List<Label>,
     selectedLabel: Label?,
     onLabelSelected: (Label?) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    extraContent: @Composable (() -> Unit)? = null
 ) {
-    if (labels.isEmpty()) return
+    if (labels.isEmpty() && extraContent == null) return
 
     Row(
         modifier = modifier
@@ -27,6 +28,7 @@ fun LabelChips(
             .padding(horizontal = 16.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
+        extraContent?.invoke()
         labels.forEach { label ->
             FilterChip(
                 selected = selectedLabel?.id == label.id,

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/LaunchConfirmDialog.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/LaunchConfirmDialog.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 
 @Composable
 fun LaunchConfirmDialog(
@@ -36,6 +38,8 @@ fun LaunchConfirmDialog(
         label = "dialogAlpha"
     )
 
+    val haptic = LocalHapticFeedback.current
+
     LaunchedEffect(Unit) { visible = true }
 
     AlertDialog(
@@ -43,7 +47,10 @@ fun LaunchConfirmDialog(
         title = { Text("Launch Job") },
         text = { Text("Launch \"$templateName\"?") },
         confirmButton = {
-            TextButton(onClick = onConfirm) {
+            TextButton(onClick = {
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                onConfirm()
+            }) {
                 Text("Launch")
             }
         },

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/TemplateCard.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/TemplateCard.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
@@ -24,6 +26,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -43,9 +47,12 @@ fun TemplateCard(
     onClick: () -> Unit,
     onLaunch: () -> Unit,
     modifier: Modifier = Modifier,
+    isFavorite: Boolean = false,
+    onToggleFavorite: (() -> Unit)? = null,
     testTagPrefix: String = ""
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    val haptic = LocalHapticFeedback.current
     ElevatedCard(
         onClick = onClick,
         interactionSource = interactionSource,
@@ -101,21 +108,41 @@ fun TemplateCard(
                 }
             }
 
-            if (template.canStart) {
-                val launchTag = if (testTagPrefix.isNotEmpty()) {
-                    Modifier.testTag("${testTagPrefix}_launch_${template.id}")
-                } else {
-                    Modifier
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                if (onToggleFavorite != null) {
+                    IconButton(
+                        onClick = onToggleFavorite,
+                        modifier = Modifier
+                            .size(40.dp)
+                            .testTag("button_favorite_${template.id}")
+                    ) {
+                        Icon(
+                            imageVector = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                            contentDescription = if (isFavorite) "Remove from favorites" else "Add to favorites",
+                            tint = if (isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
                 }
-                IconButton(
-                    onClick = onLaunch,
-                    modifier = Modifier.size(48.dp).then(launchTag)
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.PlayArrow,
-                        contentDescription = "Launch ${template.name}",
-                        tint = MaterialTheme.colorScheme.primary
-                    )
+                if (template.canStart) {
+                    val launchTag = if (testTagPrefix.isNotEmpty()) {
+                        Modifier.testTag("${testTagPrefix}_launch_${template.id}")
+                    } else {
+                        Modifier
+                    }
+                    IconButton(
+                        onClick = {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onLaunch()
+                        },
+                        modifier = Modifier.size(48.dp).then(launchTag)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.PlayArrow,
+                            contentDescription = "Launch ${template.name}",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/templates/TemplateListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/templates/TemplateListScreen.kt
@@ -3,7 +3,6 @@ package io.github.leogallego.ansiblejane.ui.templates
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.lazy.LazyColumn

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/templates/TemplateListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/templates/TemplateListScreen.kt
@@ -3,13 +3,21 @@ package io.github.leogallego.ansiblejane.ui.templates
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -53,6 +61,8 @@ fun TemplateListScreen(
     val uiState by viewModel.uiState.collectAsState()
     val launchState by viewModel.launchState.collectAsState()
     val searchQuery by viewModel.searchQuery.collectAsState()
+    val favoriteIds by viewModel.favoriteIds.collectAsState()
+    val showFavoritesOnly by viewModel.showFavoritesOnly.collectAsState()
     var selectedLabel by remember { mutableStateOf<Label?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
     var isRefreshing by remember { mutableStateOf(false) }
@@ -121,6 +131,23 @@ fun TemplateListScreen(
                         onLabelSelected = { label ->
                             selectedLabel = label
                             viewModel.filterByLabel(label)
+                        },
+                        extraContent = {
+                            if (favoriteIds.isNotEmpty()) {
+                                FilterChip(
+                                    selected = showFavoritesOnly,
+                                    onClick = { viewModel.toggleShowFavoritesOnly() },
+                                    label = { Text("Favorites") },
+                                    leadingIcon = {
+                                        Icon(
+                                            Icons.Filled.Star,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(16.dp)
+                                        )
+                                    },
+                                    modifier = Modifier.testTag("chip_favorites")
+                                )
+                            }
                         }
                     )
 
@@ -132,15 +159,23 @@ fun TemplateListScreen(
                         },
                         modifier = Modifier.fillMaxSize()
                     ) {
-                        if (state.templates.isEmpty()) {
-                            EmptyState(message = "No templates available")
+                        val displayTemplates = if (showFavoritesOnly) {
+                            state.templates.filter { it.id in favoriteIds }
+                        } else {
+                            state.templates.sortedByDescending { it.id in favoriteIds }
+                        }
+
+                        if (displayTemplates.isEmpty()) {
+                            EmptyState(
+                                message = if (showFavoritesOnly) "No favorite templates" else "No templates available"
+                            )
                         } else {
                             val listState = rememberLazyListState()
 
-                            if (state.hasMore) {
+                            if (state.hasMore && !showFavoritesOnly) {
                                 PaginationEffect(
                                     listState = listState,
-                                    itemCount = state.templates.size,
+                                    itemCount = displayTemplates.size,
                                     onLoadMore = { viewModel.loadMore() }
                                 )
                             }
@@ -150,18 +185,20 @@ fun TemplateListScreen(
                                 modifier = Modifier.fillMaxSize().testTag("list_templates")
                             ) {
                                 items(
-                                    items = state.templates,
+                                    items = displayTemplates,
                                     key = { it.id }
                                 ) { template ->
                                     TemplateCard(
                                         template = template,
                                         onClick = { viewModel.requestLaunch(template) },
                                         onLaunch = { viewModel.requestLaunch(template) },
+                                        isFavorite = template.id in favoriteIds,
+                                        onToggleFavorite = { viewModel.toggleFavorite(template.id) },
                                         testTagPrefix = "button"
                                     )
                                 }
 
-                                if (state.isLoadingMore) {
+                                if (state.isLoadingMore && !showFavoritesOnly) {
                                     item { LoadMoreIndicator() }
                                 }
                             }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IUserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IUserPreferencesRepository.kt
@@ -8,7 +8,9 @@ interface IUserPreferencesRepository {
     val timezoneId: Flow<String?>
     val timeFormat: Flow<TimeFormat>
     val themeMode: Flow<ThemeMode>
+    val favoriteTemplateIds: Flow<Set<Int>>
     suspend fun setTimezoneId(zoneId: String?)
     suspend fun setTimeFormat(format: TimeFormat)
     suspend fun setThemeMode(mode: ThemeMode)
+    suspend fun toggleFavoriteTemplate(templateId: Int)
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IUserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IUserPreferencesRepository.kt
@@ -8,9 +8,9 @@ interface IUserPreferencesRepository {
     val timezoneId: Flow<String?>
     val timeFormat: Flow<TimeFormat>
     val themeMode: Flow<ThemeMode>
-    val favoriteTemplateIds: Flow<Set<Int>>
+    fun favoriteTemplateIds(instanceId: String): Flow<Set<Int>>
     suspend fun setTimezoneId(zoneId: String?)
     suspend fun setTimeFormat(format: TimeFormat)
     suspend fun setThemeMode(mode: ThemeMode)
-    suspend fun toggleFavoriteTemplate(templateId: Int)
+    suspend fun toggleFavoriteTemplate(instanceId: String, templateId: Int)
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/UserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/UserPreferencesRepository.kt
@@ -6,7 +6,6 @@ import io.github.leogallego.ansiblejane.ui.components.TimeFormat
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 class UserPreferencesRepository(
@@ -62,9 +61,13 @@ class UserPreferencesRepository(
     }
 
     override suspend fun toggleFavoriteTemplate(templateId: Int) {
-        val current = favoriteTemplateIds.first()
-        val updated = if (templateId in current) current - templateId else current + templateId
         dataStore.edit { prefs ->
+            val current = prefs[KEY_FAVORITE_TEMPLATES]
+                ?.split(",")
+                ?.mapNotNull { it.trim().toIntOrNull() }
+                ?.toSet()
+                ?: emptySet()
+            val updated = if (templateId in current) current - templateId else current + templateId
             if (updated.isEmpty()) {
                 prefs.remove(KEY_FAVORITE_TEMPLATES)
             } else {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/UserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/UserPreferencesRepository.kt
@@ -6,6 +6,7 @@ import io.github.leogallego.ansiblejane.ui.components.TimeFormat
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 class UserPreferencesRepository(
@@ -52,9 +53,30 @@ class UserPreferencesRepository(
         }
     }
 
+    override val favoriteTemplateIds: Flow<Set<Int>> = dataStore.data.map { prefs ->
+        prefs[KEY_FAVORITE_TEMPLATES]
+            ?.split(",")
+            ?.mapNotNull { it.trim().toIntOrNull() }
+            ?.toSet()
+            ?: emptySet()
+    }
+
+    override suspend fun toggleFavoriteTemplate(templateId: Int) {
+        val current = favoriteTemplateIds.first()
+        val updated = if (templateId in current) current - templateId else current + templateId
+        dataStore.edit { prefs ->
+            if (updated.isEmpty()) {
+                prefs.remove(KEY_FAVORITE_TEMPLATES)
+            } else {
+                prefs[KEY_FAVORITE_TEMPLATES] = updated.joinToString(",")
+            }
+        }
+    }
+
     companion object {
         private val KEY_TIMEZONE = stringPreferencesKey("timezone_override")
         private val KEY_TIME_FORMAT = stringPreferencesKey("time_format")
         private val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
+        private val KEY_FAVORITE_TEMPLATES = stringPreferencesKey("favorite_template_ids")
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/UserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/UserPreferencesRepository.kt
@@ -52,26 +52,28 @@ class UserPreferencesRepository(
         }
     }
 
-    override val favoriteTemplateIds: Flow<Set<Int>> = dataStore.data.map { prefs ->
-        prefs[KEY_FAVORITE_TEMPLATES]
-            ?.split(",")
-            ?.mapNotNull { it.trim().toIntOrNull() }
-            ?.toSet()
-            ?: emptySet()
-    }
+    override fun favoriteTemplateIds(instanceId: String): Flow<Set<Int>> =
+        dataStore.data.map { prefs ->
+            prefs[favoritesKey(instanceId)]
+                ?.split(",")
+                ?.mapNotNull { it.trim().toIntOrNull() }
+                ?.toSet()
+                ?: emptySet()
+        }
 
-    override suspend fun toggleFavoriteTemplate(templateId: Int) {
+    override suspend fun toggleFavoriteTemplate(instanceId: String, templateId: Int) {
+        val key = favoritesKey(instanceId)
         dataStore.edit { prefs ->
-            val current = prefs[KEY_FAVORITE_TEMPLATES]
+            val current = prefs[key]
                 ?.split(",")
                 ?.mapNotNull { it.trim().toIntOrNull() }
                 ?.toSet()
                 ?: emptySet()
             val updated = if (templateId in current) current - templateId else current + templateId
             if (updated.isEmpty()) {
-                prefs.remove(KEY_FAVORITE_TEMPLATES)
+                prefs.remove(key)
             } else {
-                prefs[KEY_FAVORITE_TEMPLATES] = updated.joinToString(",")
+                prefs[key] = updated.joinToString(",")
             }
         }
     }
@@ -80,6 +82,8 @@ class UserPreferencesRepository(
         private val KEY_TIMEZONE = stringPreferencesKey("timezone_override")
         private val KEY_TIME_FORMAT = stringPreferencesKey("time_format")
         private val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
-        private val KEY_FAVORITE_TEMPLATES = stringPreferencesKey("favorite_template_ids")
+
+        private fun favoritesKey(instanceId: String) =
+            stringPreferencesKey("favorite_templates_$instanceId")
     }
 }


### PR DESCRIPTION
## Summary

Batch of 4 UI polish items from #2 (UI Modernization):

- **Haptic feedback** on template launch button, launch confirm dialog, and workflow approval confirm dialog via `LocalHapticFeedback`
- **Android 12+ splash screen** using native theme attributes (`windowSplashScreenAnimatedIcon`, `windowSplashScreenBackground`) with light/dark variants
- **App icon polish** — updated foreground to Ansible "A" letterform, added Android 13 monochrome variant for themed icons
- **Pinned/favorite templates** — star toggle on `TemplateCard`, DataStore persistence in `UserPreferencesRepository`, favorites filter chip on template list, favorites sorted to top

Also created issues for deferred items: #266 (swipe gestures), #267 (job output highlighting), #268 (landscape/tablet layout).

## Changed files

| Area | Files | What |
|------|-------|------|
| Haptic | TemplateCard, LaunchConfirmDialog, ApprovalDetailScreen | `performHapticFeedback` on action buttons |
| Splash | themes.xml, values-night/themes.xml | Native Android 12 splash screen attributes |
| Icon | ic_launcher_foreground.xml, ic_launcher_monochrome.xml, ic_launcher.xml | "A" letterform + monochrome layer |
| Favorites | IUserPreferencesRepository, UserPreferencesRepository, TemplatesViewModel, TemplateCard, TemplateListScreen, LabelChips | Full pinned templates feature |
| Tests | FakeUserPreferencesRepository, TemplatesViewModelTest, TemplateListScreenTest | Updated for new `userPreferences` constructor param |

## Test plan

- [ ] Build compiles (`./gradlew :app:compileDebugKotlin` passes)
- [ ] Existing template/VM tests pass (updated for new constructor param)
- [ ] Haptic feedback fires on launch button tap
- [ ] Splash screen shows app icon on cold start (light + dark)
- [ ] Star toggle on template cards persists across app restart
- [ ] Favorites filter chip appears when favorites exist, filters correctly
- [ ] Monochrome icon renders in Android 13+ themed icon mode

Closes no issues — updates #2 checklist (4 items checked off).

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>