### PR TITLE
feat: workflow approval notification UX (#173)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,9 @@
                 <data android:scheme="ansiblejane" />
             </intent-filter>
         </activity>
+        <receiver
+            android:name=".notification.ApprovalActionReceiver"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
@@ -21,6 +21,7 @@ import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
@@ -61,21 +62,23 @@ class AnsibleJaneApp : Application() {
         val userPreferences: IUserPreferencesRepository by inject()
 
         appScope.launch {
-            var lastInterval: PollInterval? = null
-            userPreferences.approvalPollInterval.collect { interval ->
-                val policy = if (lastInterval == null)
-                    ExistingPeriodicWorkPolicy.KEEP
-                else
-                    ExistingPeriodicWorkPolicy.REPLACE
-                WorkManager.getInstance(this@AnsibleJaneApp).enqueueUniquePeriodicWork(
-                    ApprovalPollingWorker.WORK_NAME,
-                    policy,
-                    PeriodicWorkRequestBuilder<ApprovalPollingWorker>(
-                        interval.minutes.toLong(), TimeUnit.MINUTES
-                    ).build()
-                )
-                lastInterval = interval
-            }
+            var firstEmission = true
+            userPreferences.approvalPollInterval
+                .distinctUntilChanged()
+                .collect { interval ->
+                    val policy = if (firstEmission)
+                        ExistingPeriodicWorkPolicy.KEEP
+                    else
+                        ExistingPeriodicWorkPolicy.REPLACE
+                    WorkManager.getInstance(this@AnsibleJaneApp).enqueueUniquePeriodicWork(
+                        ApprovalPollingWorker.WORK_NAME,
+                        policy,
+                        PeriodicWorkRequestBuilder<ApprovalPollingWorker>(
+                            interval.minutes.toLong(), TimeUnit.MINUTES
+                        ).build()
+                    )
+                    firstEmission = false
+                }
         }
 
         appScope.launch {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
@@ -8,7 +8,7 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
-import io.github.leogallego.ansiblejane.data.PollInterval
+import io.github.leogallego.ansiblejane.model.PollInterval
 import io.github.leogallego.ansiblejane.data.dataModule
 import io.github.leogallego.ansiblejane.notification.ApprovalNotificationManager
 import io.github.leogallego.ansiblejane.notification.ApprovalPollingWorker

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
@@ -8,6 +8,7 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
+import io.github.leogallego.ansiblejane.data.PollInterval
 import io.github.leogallego.ansiblejane.data.dataModule
 import io.github.leogallego.ansiblejane.notification.ApprovalNotificationManager
 import io.github.leogallego.ansiblejane.notification.ApprovalPollingWorker
@@ -57,13 +58,26 @@ class AnsibleJaneApp : Application() {
 
         ApprovalNotificationManager.createChannel(this)
 
-        WorkManager.getInstance(this).enqueueUniquePeriodicWork(
-            ApprovalPollingWorker.WORK_NAME,
-            ExistingPeriodicWorkPolicy.KEEP,
-            PeriodicWorkRequestBuilder<ApprovalPollingWorker>(15, TimeUnit.MINUTES).build()
-        )
-
         val userPreferences: IUserPreferencesRepository by inject()
+
+        appScope.launch {
+            var lastInterval: PollInterval? = null
+            userPreferences.approvalPollInterval.collect { interval ->
+                val policy = if (lastInterval == null)
+                    ExistingPeriodicWorkPolicy.KEEP
+                else
+                    ExistingPeriodicWorkPolicy.REPLACE
+                WorkManager.getInstance(this@AnsibleJaneApp).enqueueUniquePeriodicWork(
+                    ApprovalPollingWorker.WORK_NAME,
+                    policy,
+                    PeriodicWorkRequestBuilder<ApprovalPollingWorker>(
+                        interval.minutes.toLong(), TimeUnit.MINUTES
+                    ).build()
+                )
+                lastInterval = interval
+            }
+        }
+
         appScope.launch {
             val savedZone = userPreferences.timezoneId.first()
             DateFormatter.zoneOverride = savedZone?.let {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/MainActivity.kt
@@ -1,24 +1,58 @@
 package io.github.leogallego.ansiblejane
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.core.content.ContextCompat
 import io.github.leogallego.ansiblejane.assistant.ui.AssistantScreen
+import io.github.leogallego.ansiblejane.navigation.ApprovalDetailRoute
+import io.github.leogallego.ansiblejane.navigation.JobStatusRoute
+import io.github.leogallego.ansiblejane.navigation.WorkflowJobStatusRoute
 import io.github.leogallego.ansiblejane.ui.settings.SettingsScreen
 import io.github.leogallego.ansiblejane.presentation.auth.AuthViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.koin.compose.viewmodel.koinViewModel
 
 class MainActivity : ComponentActivity() {
 
+    private val pendingDeepLink = MutableStateFlow<String?>(null)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        intent?.data?.toString()?.let { pendingDeepLink.value = it }
+
         enableEdgeToEdge()
         setContent {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                val launcher = rememberLauncherForActivityResult(
+                    ActivityResultContracts.RequestPermission()
+                ) {}
+                LaunchedEffect(Unit) {
+                    if (ContextCompat.checkSelfPermission(
+                            this@MainActivity,
+                            Manifest.permission.POST_NOTIFICATIONS
+                        ) != PackageManager.PERMISSION_GRANTED
+                    ) {
+                        launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    }
+                }
+            }
+
+            val deepLink by pendingDeepLink.collectAsState()
+
             App(
                 modifier = Modifier.semantics { testTagsAsResourceId = true },
                 assistantContent = { AssistantScreen() },
@@ -32,6 +66,17 @@ class MainActivity : ComponentActivity() {
                         onNavigateBack = onNavigateBack,
                         onAddInstance = onAddInstance
                     )
+                },
+                onHandleDeepLink = { navController ->
+                    deepLink?.let { uri ->
+                        val currentRoute = navController.currentDestination?.route
+                        if (currentRoute != null && currentRoute.contains("MainRoute")) {
+                            pendingDeepLink.value = null
+                            parseDeepLink(uri)?.let { route ->
+                                navController.navigate(route)
+                            }
+                        }
+                    }
                 }
             )
         }
@@ -39,5 +84,20 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        intent.data?.toString()?.let { pendingDeepLink.value = it }
+    }
+
+    companion object {
+        fun parseDeepLink(uri: String): Any? {
+            val segments = uri.removePrefix("ansiblejane://").split("/")
+            if (segments.size < 2) return null
+            val id = segments[1].toIntOrNull() ?: return null
+            return when (segments[0]) {
+                "approval" -> ApprovalDetailRoute(id)
+                "job" -> JobStatusRoute(id)
+                "workflow" -> WorkflowJobStatusRoute(id)
+                else -> null
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/MainActivity.kt
@@ -70,7 +70,7 @@ class MainActivity : ComponentActivity() {
                 onHandleDeepLink = { navController ->
                     deepLink?.let { uri ->
                         val currentRoute = navController.currentDestination?.route
-                        if (currentRoute != null && currentRoute.contains("MainRoute")) {
+                        if (currentRoute != null && (currentRoute == "MainRoute" || currentRoute.startsWith("MainRoute/"))) {
                             pendingDeepLink.value = null
                             parseDeepLink(uri)?.let { route ->
                                 navController.navigate(route)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/MainActivity.kt
@@ -88,10 +88,16 @@ class MainActivity : ComponentActivity() {
     }
 
     companion object {
+        private const val SCHEME_PREFIX = "ansiblejane://"
+
         fun parseDeepLink(uri: String): Any? {
-            val segments = uri.removePrefix("ansiblejane://").split("/")
+            if (!uri.startsWith(SCHEME_PREFIX)) return null
+            val path = uri.removePrefix(SCHEME_PREFIX)
+            if (path.contains("..") || path.contains("//")) return null
+            val segments = path.split("/")
             if (segments.size < 2) return null
             val id = segments[1].toIntOrNull() ?: return null
+            if (id <= 0) return null
             return when (segments[0]) {
                 "approval" -> ApprovalDetailRoute(id)
                 "job" -> JobStatusRoute(id)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiver.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiver.kt
@@ -10,6 +10,7 @@ import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -26,6 +27,8 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
     }
 
     override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_APPROVE && intent.action != ACTION_DENY) return
+
         val approvalId = intent.getIntExtra(EXTRA_APPROVAL_ID, -1)
         if (approvalId <= 0) return
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiver.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiver.kt
@@ -25,14 +25,13 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
         private const val TAG = "ApprovalActionReceiver"
     }
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-
     override fun onReceive(context: Context, intent: Intent) {
         val approvalId = intent.getIntExtra(EXTRA_APPROVAL_ID, -1)
         if (approvalId <= 0) return
 
         val isApprove = intent.action == ACTION_APPROVE
         val pendingResult = goAsync()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
         scope.launch {
             try {
@@ -46,7 +45,7 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
                 }
 
                 val apiProvider: IAapApiProvider = get()
-                val result = if (isApprove) {
+                if (isApprove) {
                     apiProvider.getApiService().approveWorkflow(approvalId)
                 } else {
                     apiProvider.getApiService().denyWorkflow(approvalId)
@@ -59,6 +58,7 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
                 Log.e(TAG, "Failed to ${if (isApprove) "approve" else "deny"} $approvalId", e)
             } finally {
                 pendingResult.finish()
+                scope.cancel()
             }
         }
     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiver.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiver.kt
@@ -1,0 +1,65 @@
+package io.github.leogallego.ansiblejane.notification
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.app.NotificationManagerCompat
+import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+
+class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
+
+    companion object {
+        const val ACTION_APPROVE = "io.github.leogallego.ansiblejane.ACTION_APPROVE"
+        const val ACTION_DENY = "io.github.leogallego.ansiblejane.ACTION_DENY"
+        const val EXTRA_APPROVAL_ID = "approval_id"
+        private const val TAG = "ApprovalActionReceiver"
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val approvalId = intent.getIntExtra(EXTRA_APPROVAL_ID, -1)
+        if (approvalId <= 0) return
+
+        val isApprove = intent.action == ACTION_APPROVE
+        val pendingResult = goAsync()
+
+        scope.launch {
+            try {
+                val tokenManager: ITokenManager = get()
+                val instance = withTimeoutOrNull(5_000L) {
+                    tokenManager.activeInstance.firstOrNull { it != null }
+                }
+                if (instance == null) {
+                    Log.w(TAG, "No active instance, cannot ${if (isApprove) "approve" else "deny"} $approvalId")
+                    return@launch
+                }
+
+                val apiProvider: IAapApiProvider = get()
+                val result = if (isApprove) {
+                    apiProvider.getApiService().approveWorkflow(approvalId)
+                } else {
+                    apiProvider.getApiService().denyWorkflow(approvalId)
+                }
+
+                NotificationManagerCompat.from(context).cancel(approvalId)
+
+                Log.i(TAG, "Approval $approvalId ${if (isApprove) "approved" else "denied"}")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to ${if (isApprove) "approve" else "deny"} $approvalId", e)
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
@@ -21,6 +21,8 @@ class ApprovalNotificationManager {
     companion object {
         const val CHANNEL_ID = "workflow_approvals"
         const val CHANNEL_NAME = "Workflow Approvals"
+        private const val GROUP_KEY = "io.github.leogallego.ansiblejane.APPROVAL_GROUP"
+        private const val SUMMARY_ID = 0
 
         fun createChannel(context: Context) {
             val channel = NotificationChannel(
@@ -47,34 +49,70 @@ class ApprovalNotificationManager {
         }
 
         val deepLinkUri = Uri.parse("ansiblejane://approval/${approval.id}")
-        val intent = Intent(Intent.ACTION_VIEW, deepLinkUri, context, MainActivity::class.java).apply {
+        val contentIntent = Intent(Intent.ACTION_VIEW, deepLinkUri, context, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
-
-        val pendingIntent = PendingIntent.getActivity(
+        val contentPendingIntent = PendingIntent.getActivity(
             context,
             approval.id,
-            intent,
+            contentIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val approveIntent = Intent(context, ApprovalActionReceiver::class.java).apply {
+            action = ApprovalActionReceiver.ACTION_APPROVE
+            putExtra(ApprovalActionReceiver.EXTRA_APPROVAL_ID, approval.id)
+        }
+        val approvePendingIntent = PendingIntent.getBroadcast(
+            context,
+            approval.id * 2,
+            approveIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val denyIntent = Intent(context, ApprovalActionReceiver::class.java).apply {
+            action = ApprovalActionReceiver.ACTION_DENY
+            putExtra(ApprovalActionReceiver.EXTRA_APPROVAL_ID, approval.id)
+        }
+        val denyPendingIntent = PendingIntent.getBroadcast(
+            context,
+            approval.id * 2 + 1,
+            denyIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
         val templateName = approval.summaryFields.workflowJobTemplate?.name
         val bodyText = if (templateName != null) {
-            "Pending workflow approval for $templateName"
+            "Pending approval for $templateName"
         } else {
             "Pending workflow approval"
         }
 
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
-            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setSmallIcon(R.drawable.ic_notification_approval)
             .setContentTitle(approval.name)
             .setContentText(bodyText)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setContentIntent(pendingIntent)
+            .setContentIntent(contentPendingIntent)
             .setAutoCancel(true)
+            .setGroup(GROUP_KEY)
+            .addAction(R.drawable.ic_notification_approval, "Approve", approvePendingIntent)
+            .addAction(0, "Deny", denyPendingIntent)
             .build()
 
-        NotificationManagerCompat.from(context).notify(approval.id, notification)
+        val manager = NotificationManagerCompat.from(context)
+        manager.notify(approval.id, notification)
+
+        val summaryNotification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification_approval)
+            .setContentTitle("Workflow Approvals")
+            .setContentText("Pending workflow approvals")
+            .setGroup(GROUP_KEY)
+            .setGroupSummary(true)
+            .setAutoCancel(true)
+            .build()
+        manager.notify(SUMMARY_ID, summaryNotification)
+
         return true
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
@@ -22,7 +22,7 @@ class ApprovalNotificationManager {
         const val CHANNEL_ID = "workflow_approvals"
         const val CHANNEL_NAME = "Workflow Approvals"
         private const val GROUP_KEY = "io.github.leogallego.ansiblejane.APPROVAL_GROUP"
-        private const val SUMMARY_ID = 0
+        private const val SUMMARY_ID = 0x4A414E45 // "JANE" — avoids collision with default ID 0
 
         fun createChannel(context: Context) {
             val channel = NotificationChannel(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
@@ -63,9 +63,10 @@ class ApprovalNotificationManager {
             action = ApprovalActionReceiver.ACTION_APPROVE
             putExtra(ApprovalActionReceiver.EXTRA_APPROVAL_ID, approval.id)
         }
+        val approveRequestCode = (approval.id.hashCode() and 0x3FFFFFFF) shl 1
         val approvePendingIntent = PendingIntent.getBroadcast(
             context,
-            approval.id * 2,
+            approveRequestCode,
             approveIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
@@ -76,7 +77,7 @@ class ApprovalNotificationManager {
         }
         val denyPendingIntent = PendingIntent.getBroadcast(
             context,
-            approval.id * 2 + 1,
+            approveRequestCode or 1,
             denyIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.firstOrNull
@@ -29,6 +30,13 @@ class ApprovalPollingWorker(
                 tokenManager.activeInstance.firstOrNull { it != null }
             }
             if (instance == null) {
+                return Result.success()
+            }
+            val userPreferences: IUserPreferencesRepository = get()
+            val pollingEnabled = withTimeoutOrNull(2_000L) {
+                userPreferences.approvalPollingEnabled(instance.id).firstOrNull()
+            } ?: true
+            if (!pollingEnabled) {
                 return Result.success()
             }
             val apiProvider: IAapApiProvider = get()

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
@@ -33,7 +33,7 @@ class ApprovalPollingWorker(
                 return Result.success()
             }
             val userPreferences: IUserPreferencesRepository = get()
-            val pollingEnabled = withTimeoutOrNull(2_000L) {
+            val pollingEnabled = withTimeoutOrNull(5_000L) {
                 userPreferences.approvalPollingEnabled(instance.id).firstOrNull()
             } ?: true
             if (!pollingEnabled) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.presentation.settings
 
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.assistant.presentation.ModelFetchState
+import io.github.leogallego.ansiblejane.data.PollInterval
 import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.model.McpServerConfig
 import io.github.leogallego.ansiblejane.network.mcp.McpConnectionState
@@ -31,6 +32,8 @@ sealed interface SettingsUiState {
         val timezoneId: String? = null,
         val timeFormat: TimeFormat = TimeFormat.SYSTEM,
         val themeMode: ThemeMode = ThemeMode.SYSTEM,
+        val pollInterval: PollInterval = PollInterval.MINUTES_15,
+        val approvalPollingEnabled: Boolean = true,
         // Agent (LLM config)
         val savedConfigs: Map<String, LlmProviderConfig> = emptyMap(),
         val activeConfig: LlmProviderConfig? = null,

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
@@ -2,7 +2,7 @@ package io.github.leogallego.ansiblejane.presentation.settings
 
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.assistant.presentation.ModelFetchState
-import io.github.leogallego.ansiblejane.data.PollInterval
+import io.github.leogallego.ansiblejane.model.PollInterval
 import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.model.McpServerConfig
 import io.github.leogallego.ansiblejane.network.mcp.McpConnectionState

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -142,43 +142,33 @@ class SettingsViewModel(
         }
 
         viewModelScope.launch {
-            userPreferences.themeMode.collect { mode ->
-                updateReady { copy(themeMode = mode) }
-            }
-        }
-
-        viewModelScope.launch {
-            userPreferences.approvalPollInterval.collect { interval ->
-                updateReady { copy(pollInterval = interval) }
-            }
-        }
-
-        viewModelScope.launch {
-            tokenManager.activeInstance
-                .flatMapLatest { instance ->
+            combine(
+                userPreferences.themeMode,
+                userPreferences.approvalPollInterval,
+                tokenManager.activeInstance.flatMapLatest { instance ->
                     if (instance != null) userPreferences.approvalPollingEnabled(instance.id)
                     else flowOf(true)
                 }
-                .collect { enabled ->
-                    updateReady { copy(approvalPollingEnabled = enabled) }
+            ) { mode, interval, pollingEnabled ->
+                Triple(mode, interval, pollingEnabled)
+            }.collect { (mode, interval, pollingEnabled) ->
+                updateReady {
+                    copy(themeMode = mode, pollInterval = interval, approvalPollingEnabled = pollingEnabled)
                 }
-        }
-
-        viewModelScope.launch {
-            assistantRepository.activeProviderKeyFlow.collect { key ->
-                updateReady { copy(activeProviderKey = key) }
             }
         }
 
         viewModelScope.launch {
-            assistantRepository.savedConfigsFlow.collect { configs ->
-                updateReady { copy(savedConfigs = configs) }
-            }
-        }
-
-        viewModelScope.launch {
-            assistantRepository.activeConfigFlow.collect { config ->
-                updateReady { copy(activeConfig = config) }
+            combine(
+                assistantRepository.activeProviderKeyFlow,
+                assistantRepository.savedConfigsFlow,
+                assistantRepository.activeConfigFlow
+            ) { key, configs, config ->
+                Triple(key, configs, config)
+            }.collect { (key, configs, config) ->
+                updateReady {
+                    copy(activeProviderKey = key, savedConfigs = configs, activeConfig = config)
+                }
             }
         }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -9,7 +9,7 @@ import io.github.leogallego.ansiblejane.assistant.presentation.ModelFetchState
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.data.IToolManifestRepository
 import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
-import io.github.leogallego.ansiblejane.data.PollInterval
+import io.github.leogallego.ansiblejane.model.PollInterval
 import io.github.leogallego.ansiblejane.model.McpServerConfig
 import io.github.leogallego.ansiblejane.network.ApiVersion
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
@@ -37,6 +37,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import java.time.ZoneId
 
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class SettingsViewModel(
     private val tokenManager: ITokenManager,
     private val apiProvider: IAapApiProvider,
@@ -152,7 +153,6 @@ class SettingsViewModel(
             }
         }
 
-        @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
         viewModelScope.launch {
             tokenManager.activeInstance
                 .flatMapLatest { instance ->

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -9,6 +9,7 @@ import io.github.leogallego.ansiblejane.assistant.presentation.ModelFetchState
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.data.IToolManifestRepository
 import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
+import io.github.leogallego.ansiblejane.data.PollInterval
 import io.github.leogallego.ansiblejane.model.McpServerConfig
 import io.github.leogallego.ansiblejane.network.ApiVersion
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
@@ -29,6 +30,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -141,6 +144,24 @@ class SettingsViewModel(
             userPreferences.themeMode.collect { mode ->
                 updateReady { copy(themeMode = mode) }
             }
+        }
+
+        viewModelScope.launch {
+            userPreferences.approvalPollInterval.collect { interval ->
+                updateReady { copy(pollInterval = interval) }
+            }
+        }
+
+        @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+        viewModelScope.launch {
+            tokenManager.activeInstance
+                .flatMapLatest { instance ->
+                    if (instance != null) userPreferences.approvalPollingEnabled(instance.id)
+                    else flowOf(true)
+                }
+                .collect { enabled ->
+                    updateReady { copy(approvalPollingEnabled = enabled) }
+                }
         }
 
         viewModelScope.launch {
@@ -292,6 +313,19 @@ class SettingsViewModel(
     fun setThemeMode(mode: io.github.leogallego.ansiblejane.ui.components.ThemeMode) {
         viewModelScope.launch {
             userPreferences.setThemeMode(mode)
+        }
+    }
+
+    fun setPollInterval(interval: PollInterval) {
+        viewModelScope.launch {
+            userPreferences.setApprovalPollInterval(interval)
+        }
+    }
+
+    fun setApprovalPollingEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            val instanceId = tokenManager.activeInstance.value?.id ?: return@launch
+            userPreferences.setApprovalPollingEnabled(instanceId, enabled)
         }
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
@@ -56,6 +56,8 @@ fun SettingsScreen(
                     onTimezoneSelected = { viewModel.setTimezone(it) },
                     onTimeFormatSelected = { viewModel.setTimeFormat(it) },
                     onThemeModeSelected = { viewModel.setThemeMode(it) },
+                    onPollIntervalSelected = { viewModel.setPollInterval(it) },
+                    onApprovalPollingToggled = { viewModel.setApprovalPollingEnabled(it) },
                     onClearHistory = { viewModel.clearHistory() },
                     onLogout = onLogout,
                     onSaveProviderConfig = { key, config -> viewModel.saveProviderConfig(key, config) },
@@ -98,6 +100,8 @@ private fun SettingsContent(
     onTimezoneSelected: (String?) -> Unit,
     onTimeFormatSelected: (io.github.leogallego.ansiblejane.ui.components.TimeFormat) -> Unit,
     onThemeModeSelected: (io.github.leogallego.ansiblejane.ui.components.ThemeMode) -> Unit,
+    onPollIntervalSelected: (io.github.leogallego.ansiblejane.data.PollInterval) -> Unit,
+    onApprovalPollingToggled: (Boolean) -> Unit,
     onClearHistory: () -> Unit,
     onLogout: () -> Unit,
     onSaveProviderConfig: (String, io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig) -> Unit,
@@ -128,9 +132,13 @@ private fun SettingsContent(
                 timezoneId = state.timezoneId,
                 timeFormat = state.timeFormat,
                 themeMode = state.themeMode,
+                pollInterval = state.pollInterval,
+                approvalPollingEnabled = state.approvalPollingEnabled,
                 onTimezoneSelected = onTimezoneSelected,
                 onTimeFormatSelected = onTimeFormatSelected,
                 onThemeModeSelected = onThemeModeSelected,
+                onPollIntervalSelected = onPollIntervalSelected,
+                onApprovalPollingToggled = onApprovalPollingToggled,
                 modifier = Modifier.weight(1f)
             )
             SettingsTab.Instances -> InstancesTab(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
@@ -100,7 +100,7 @@ private fun SettingsContent(
     onTimezoneSelected: (String?) -> Unit,
     onTimeFormatSelected: (io.github.leogallego.ansiblejane.ui.components.TimeFormat) -> Unit,
     onThemeModeSelected: (io.github.leogallego.ansiblejane.ui.components.ThemeMode) -> Unit,
-    onPollIntervalSelected: (io.github.leogallego.ansiblejane.data.PollInterval) -> Unit,
+    onPollIntervalSelected: (io.github.leogallego.ansiblejane.model.PollInterval) -> Unit,
     onApprovalPollingToggled: (Boolean) -> Unit,
     onClearHistory: () -> Unit,
     onLogout: () -> Unit,

--- a/app/src/main/res/drawable/ic_notification_approval.xml
+++ b/app/src/main/res/drawable/ic_notification_approval.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_notification_approval.xml
+++ b/app/src/main/res/drawable/ic_notification_approval.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="#FFFFFF">
+    android:viewportHeight="24">
     <path
         android:fillColor="@android:color/white"
         android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/ParseDeepLinkTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/ParseDeepLinkTest.kt
@@ -75,4 +75,9 @@ class ParseDeepLinkTest {
     fun `empty URI returns null`() {
         assertNull(MainActivity.parseDeepLink(""))
     }
+
+    @Test
+    fun `ID exceeding Int max returns null`() {
+        assertNull(MainActivity.parseDeepLink("ansiblejane://approval/2147483648"))
+    }
 }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/ParseDeepLinkTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/ParseDeepLinkTest.kt
@@ -1,0 +1,78 @@
+package io.github.leogallego.ansiblejane
+
+import io.github.leogallego.ansiblejane.navigation.ApprovalDetailRoute
+import io.github.leogallego.ansiblejane.navigation.JobStatusRoute
+import io.github.leogallego.ansiblejane.navigation.WorkflowJobStatusRoute
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ParseDeepLinkTest {
+
+    @Test
+    fun `valid approval deep link returns ApprovalDetailRoute`() {
+        val result = MainActivity.parseDeepLink("ansiblejane://approval/42")
+        assertEquals(ApprovalDetailRoute(42), result)
+    }
+
+    @Test
+    fun `valid job deep link returns JobStatusRoute`() {
+        val result = MainActivity.parseDeepLink("ansiblejane://job/100")
+        assertEquals(JobStatusRoute(100), result)
+    }
+
+    @Test
+    fun `valid workflow deep link returns WorkflowJobStatusRoute`() {
+        val result = MainActivity.parseDeepLink("ansiblejane://workflow/7")
+        assertEquals(WorkflowJobStatusRoute(7), result)
+    }
+
+    @Test
+    fun `wrong scheme returns null`() {
+        assertNull(MainActivity.parseDeepLink("https://approval/42"))
+        assertNull(MainActivity.parseDeepLink("myapp://approval/42"))
+    }
+
+    @Test
+    fun `missing ID returns null`() {
+        assertNull(MainActivity.parseDeepLink("ansiblejane://approval"))
+        assertNull(MainActivity.parseDeepLink("ansiblejane://approval/"))
+    }
+
+    @Test
+    fun `non-numeric ID returns null`() {
+        assertNull(MainActivity.parseDeepLink("ansiblejane://approval/abc"))
+    }
+
+    @Test
+    fun `negative ID returns null`() {
+        assertNull(MainActivity.parseDeepLink("ansiblejane://approval/-1"))
+    }
+
+    @Test
+    fun `zero ID returns null`() {
+        assertNull(MainActivity.parseDeepLink("ansiblejane://approval/0"))
+    }
+
+    @Test
+    fun `path traversal returns null`() {
+        assertNull(MainActivity.parseDeepLink("ansiblejane://approval/../etc/passwd"))
+        assertNull(MainActivity.parseDeepLink("ansiblejane://../approval/42"))
+    }
+
+    @Test
+    fun `double slash returns null`() {
+        assertNull(MainActivity.parseDeepLink("ansiblejane://approval//42"))
+    }
+
+    @Test
+    fun `unknown type returns null`() {
+        assertNull(MainActivity.parseDeepLink("ansiblejane://settings/1"))
+        assertNull(MainActivity.parseDeepLink("ansiblejane://unknown/42"))
+    }
+
+    @Test
+    fun `empty URI returns null`() {
+        assertNull(MainActivity.parseDeepLink(""))
+    }
+}

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeUserPreferencesRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeUserPreferencesRepository.kt
@@ -1,7 +1,7 @@
 package io.github.leogallego.ansiblejane.fakes
 
 import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
-import io.github.leogallego.ansiblejane.data.PollInterval
+import io.github.leogallego.ansiblejane.model.PollInterval
 import io.github.leogallego.ansiblejane.ui.components.ThemeMode
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
 import kotlinx.coroutines.flow.Flow

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeUserPreferencesRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeUserPreferencesRepository.kt
@@ -1,6 +1,7 @@
 package io.github.leogallego.ansiblejane.fakes
 
 import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
+import io.github.leogallego.ansiblejane.data.PollInterval
 import io.github.leogallego.ansiblejane.ui.components.ThemeMode
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
 import kotlinx.coroutines.flow.Flow
@@ -26,6 +27,22 @@ class FakeUserPreferencesRepository : IUserPreferencesRepository {
 
     override suspend fun setThemeMode(mode: ThemeMode) {
         _themeMode.value = mode
+    }
+
+    private val _pollInterval = MutableStateFlow(PollInterval.MINUTES_15)
+    override val approvalPollInterval: Flow<PollInterval> = _pollInterval
+
+    override suspend fun setApprovalPollInterval(interval: PollInterval) {
+        _pollInterval.value = interval
+    }
+
+    private val _pollingEnabled = mutableMapOf<String, MutableStateFlow<Boolean>>()
+
+    override fun approvalPollingEnabled(instanceId: String): Flow<Boolean> =
+        _pollingEnabled.getOrPut(instanceId) { MutableStateFlow(true) }
+
+    override suspend fun setApprovalPollingEnabled(instanceId: String, enabled: Boolean) {
+        _pollingEnabled.getOrPut(instanceId) { MutableStateFlow(true) }.value = enabled
     }
 
     private val _favorites = mutableMapOf<String, MutableStateFlow<Set<Int>>>()

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/approval/ApprovalDetailViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/approval/ApprovalDetailViewModelTest.kt
@@ -1,0 +1,203 @@
+package io.github.leogallego.ansiblejane.presentation.approval
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import io.github.leogallego.ansiblejane.MainDispatcherRule
+import io.github.leogallego.ansiblejane.fakes.FakeWorkflowRepository
+import io.github.leogallego.ansiblejane.model.AppError
+import io.github.leogallego.ansiblejane.model.WorkflowApproval
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class ApprovalDetailViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeRepo: FakeWorkflowRepository
+
+    private val testApproval = WorkflowApproval(
+        id = 42,
+        name = "Deploy to production",
+        status = "pending",
+        created = "2024-01-15T10:00:00Z"
+    )
+
+    @Before
+    fun setup() {
+        fakeRepo = FakeWorkflowRepository()
+    }
+
+    private fun createViewModel(approvalId: Int = 42): ApprovalDetailViewModel {
+        val savedStateHandle = SavedStateHandle(mapOf("approvalId" to approvalId))
+        return ApprovalDetailViewModel(savedStateHandle, fakeRepo)
+    }
+
+    @Test
+    fun `invalid approval ID emits Error state`() = runTest {
+        val viewModel = createViewModel(approvalId = -1)
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is ApprovalDetailUiState.Error)
+            val error = (state as ApprovalDetailUiState.Error).error
+            assertTrue(error is AppError.Unknown)
+        }
+    }
+
+    @Test
+    fun `zero approval ID emits Error state`() = runTest {
+        val viewModel = createViewModel(approvalId = 0)
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is ApprovalDetailUiState.Error)
+        }
+    }
+
+    @Test
+    fun `loadApproval success emits Ready state`() = runTest {
+        fakeRepo.approvals = listOf(testApproval)
+        val viewModel = createViewModel(approvalId = 42)
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is ApprovalDetailUiState.Ready)
+            assertEquals(testApproval, (state as ApprovalDetailUiState.Ready).approval)
+        }
+    }
+
+    @Test
+    fun `loadApproval failure emits Error state`() = runTest {
+        fakeRepo.shouldFail = true
+        fakeRepo.failureException = RuntimeException("Network error")
+        val viewModel = createViewModel(approvalId = 42)
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is ApprovalDetailUiState.Error)
+        }
+    }
+
+    @Test
+    fun `loadApproval with nonexistent ID emits Error state`() = runTest {
+        fakeRepo.approvals = listOf(testApproval)
+        val viewModel = createViewModel(approvalId = 999)
+
+        viewModel.uiState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state is ApprovalDetailUiState.Error)
+        }
+    }
+
+    @Test
+    fun `approve transitions to Completed with approved action`() = runTest {
+        fakeRepo.approvals = listOf(testApproval)
+        val viewModel = createViewModel(approvalId = 42)
+
+        viewModel.uiState.test {
+            skipItems(1)
+            viewModel.approve()
+            val state = expectMostRecentItem()
+            assertTrue(state is ApprovalDetailUiState.Completed)
+            val completed = state as ApprovalDetailUiState.Completed
+            assertEquals("approved", completed.action)
+            assertEquals(testApproval, completed.approval)
+        }
+    }
+
+    @Test
+    fun `deny transitions to Completed with denied action`() = runTest {
+        fakeRepo.approvals = listOf(testApproval)
+        val viewModel = createViewModel(approvalId = 42)
+
+        viewModel.uiState.test {
+            skipItems(1)
+            viewModel.deny()
+            val state = expectMostRecentItem()
+            assertTrue(state is ApprovalDetailUiState.Completed)
+            val completed = state as ApprovalDetailUiState.Completed
+            assertEquals("denied", completed.action)
+            assertEquals(testApproval, completed.approval)
+        }
+    }
+
+    @Test
+    fun `approve from non-Ready state is no-op`() = runTest {
+        fakeRepo.shouldFail = true
+        val viewModel = createViewModel(approvalId = 42)
+
+        viewModel.uiState.test {
+            val errorState = expectMostRecentItem()
+            assertTrue(errorState is ApprovalDetailUiState.Error)
+            viewModel.approve()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `deny from non-Ready state is no-op`() = runTest {
+        fakeRepo.shouldFail = true
+        val viewModel = createViewModel(approvalId = 42)
+
+        viewModel.uiState.test {
+            val errorState = expectMostRecentItem()
+            assertTrue(errorState is ApprovalDetailUiState.Error)
+            viewModel.deny()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `approve failure emits Error state`() = runTest {
+        fakeRepo.approvals = listOf(testApproval)
+        val viewModel = createViewModel(approvalId = 42)
+
+        viewModel.uiState.test {
+            skipItems(1)
+            fakeRepo.shouldFail = true
+            fakeRepo.failureException = RuntimeException("Server error")
+            viewModel.approve()
+            val state = expectMostRecentItem()
+            assertTrue(state is ApprovalDetailUiState.Error)
+        }
+    }
+
+    @Test
+    fun `deny failure emits Error state`() = runTest {
+        fakeRepo.approvals = listOf(testApproval)
+        val viewModel = createViewModel(approvalId = 42)
+
+        viewModel.uiState.test {
+            skipItems(1)
+            fakeRepo.shouldFail = true
+            fakeRepo.failureException = RuntimeException("Server error")
+            viewModel.deny()
+            val state = expectMostRecentItem()
+            assertTrue(state is ApprovalDetailUiState.Error)
+        }
+    }
+
+    @Test
+    fun `reload after error transitions back to Ready`() = runTest {
+        fakeRepo.shouldFail = true
+        val viewModel = createViewModel(approvalId = 42)
+
+        viewModel.uiState.test {
+            val errorState = expectMostRecentItem()
+            assertTrue(errorState is ApprovalDetailUiState.Error)
+
+            fakeRepo.shouldFail = false
+            fakeRepo.approvals = listOf(testApproval)
+            viewModel.loadApproval()
+
+            val state = expectMostRecentItem()
+            assertTrue(state is ApprovalDetailUiState.Ready)
+            assertEquals(testApproval, (state as ApprovalDetailUiState.Ready).approval)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/App.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
 import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
 import io.github.leogallego.ansiblejane.navigation.AppNavigation
 import io.github.leogallego.ansiblejane.ui.components.ThemeMode
@@ -14,7 +15,8 @@ import org.koin.compose.koinInject
 fun App(
     modifier: Modifier = Modifier,
     assistantContent: @Composable () -> Unit = {},
-    settingsContent: @Composable (onLogout: () -> Unit, onNavigateBack: () -> Unit, onAddInstance: () -> Unit) -> Unit = { _, _, _ -> }
+    settingsContent: @Composable (onLogout: () -> Unit, onNavigateBack: () -> Unit, onAddInstance: () -> Unit) -> Unit = { _, _, _ -> },
+    onHandleDeepLink: ((NavHostController) -> Unit)? = null
 ) {
     val userPreferences: IUserPreferencesRepository = koinInject()
     val themeMode by userPreferences.themeMode.collectAsState(ThemeMode.SYSTEM)
@@ -29,7 +31,8 @@ fun App(
         AppNavigation(
             modifier = modifier,
             assistantContent = assistantContent,
-            settingsContent = settingsContent
+            settingsContent = settingsContent,
+            onHandleDeepLink = onHandleDeepLink
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
@@ -177,7 +177,7 @@ private fun ApprovalDetailContent(
                 if (approval.created.isNotBlank()) {
                     DetailRowHorizontal("Created", DateFormatter.formatDateTime(approval.created))
                     if (approval.status == "pending") {
-                        DetailRowHorizontal("Pending for", DateFormatter.formatRelative(approval.created).removeSuffix(" ago"))
+                        DetailRowHorizontal("Pending for", DateFormatter.formatDuration(approval.created))
                     }
                 }
 

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.collectAsState
 import io.github.leogallego.ansiblejane.model.WorkflowApproval
@@ -212,21 +214,25 @@ private fun ApprovalDetailContent(
         Spacer(modifier = Modifier.height(24.dp))
 
         if (!showActions) {
-            val (cardColor, contentColor, statusIcon) = when (approval.status) {
-                "approved" -> Triple(
+            val displayStatus = approval.status.ifBlank { "unknown" }
+            val (cardColor, contentColor, statusIcon, statusDescription) = when (displayStatus) {
+                "approved" -> StatusCardStyle(
                     MaterialTheme.colorScheme.primaryContainer,
                     MaterialTheme.colorScheme.onPrimaryContainer,
-                    Icons.Default.CheckCircle
+                    Icons.Default.CheckCircle,
+                    "Approved"
                 )
-                "denied" -> Triple(
+                "denied" -> StatusCardStyle(
                     MaterialTheme.colorScheme.errorContainer,
                     MaterialTheme.colorScheme.onErrorContainer,
-                    Icons.Default.Cancel
+                    Icons.Default.Cancel,
+                    "Denied"
                 )
-                else -> Triple(
+                else -> StatusCardStyle(
                     MaterialTheme.colorScheme.surfaceVariant,
                     MaterialTheme.colorScheme.onSurfaceVariant,
-                    Icons.Default.Info
+                    Icons.Default.Info,
+                    displayStatus.replaceFirstChar { it.uppercase() }
                 )
             }
             Card(
@@ -240,11 +246,11 @@ private fun ApprovalDetailContent(
                 ) {
                     Icon(
                         imageVector = statusIcon,
-                        contentDescription = null,
+                        contentDescription = statusDescription,
                         tint = contentColor
                     )
                     Text(
-                        text = "This approval has been ${approval.status}.",
+                        text = "This approval has been $displayStatus.",
                         style = MaterialTheme.typography.bodyMedium,
                         color = contentColor
                     )
@@ -348,3 +354,10 @@ private fun ApprovalCompletedContent(
         }
     }
 }
+
+private data class StatusCardStyle(
+    val cardColor: Color,
+    val contentColor: Color,
+    val icon: ImageVector,
+    val description: String
+)

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -211,13 +212,26 @@ private fun ApprovalDetailContent(
         Spacer(modifier = Modifier.height(24.dp))
 
         if (!showActions) {
+            val (cardColor, contentColor, statusIcon) = when (approval.status) {
+                "approved" -> Triple(
+                    MaterialTheme.colorScheme.primaryContainer,
+                    MaterialTheme.colorScheme.onPrimaryContainer,
+                    Icons.Default.CheckCircle
+                )
+                "denied" -> Triple(
+                    MaterialTheme.colorScheme.errorContainer,
+                    MaterialTheme.colorScheme.onErrorContainer,
+                    Icons.Default.Cancel
+                )
+                else -> Triple(
+                    MaterialTheme.colorScheme.surfaceVariant,
+                    MaterialTheme.colorScheme.onSurfaceVariant,
+                    Icons.Default.Info
+                )
+            }
             Card(
                 modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = if (approval.status == "approved")
-                        MaterialTheme.colorScheme.primaryContainer
-                    else MaterialTheme.colorScheme.errorContainer
-                )
+                colors = CardDefaults.cardColors(containerColor = cardColor)
             ) {
                 Column(
                     modifier = Modifier.padding(16.dp).fillMaxWidth(),
@@ -225,19 +239,14 @@ private fun ApprovalDetailContent(
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     Icon(
-                        imageVector = if (approval.status == "approved")
-                            Icons.Default.CheckCircle else Icons.Default.Cancel,
+                        imageVector = statusIcon,
                         contentDescription = null,
-                        tint = if (approval.status == "approved")
-                            MaterialTheme.colorScheme.onPrimaryContainer
-                        else MaterialTheme.colorScheme.onErrorContainer
+                        tint = contentColor
                     )
                     Text(
                         text = "This approval has been ${approval.status}.",
                         style = MaterialTheme.typography.bodyMedium,
-                        color = if (approval.status == "approved")
-                            MaterialTheme.colorScheme.onPrimaryContainer
-                        else MaterialTheme.colorScheme.onErrorContainer
+                        color = contentColor
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/approval/ApprovalDetailScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -42,6 +43,7 @@ import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import io.github.leogallego.ansiblejane.ui.components.DetailRowHorizontal
 import io.github.leogallego.ansiblejane.ui.components.DetailScaffold
 import io.github.leogallego.ansiblejane.ui.components.ErrorMessage
+import io.github.leogallego.ansiblejane.ui.components.SkeletonCard
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -57,7 +59,11 @@ fun ApprovalDetailScreen(
     DetailScaffold(title = "Workflow Approval", onNavigateBack = onNavigateBack) {
             when (val state = uiState) {
                 is ApprovalDetailUiState.Loading -> {
-                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                    Column(
+                        modifier = Modifier.fillMaxSize().padding(16.dp)
+                    ) {
+                        SkeletonCard()
+                    }
                 }
 
                 is ApprovalDetailUiState.Error -> {
@@ -165,10 +171,19 @@ private fun ApprovalDetailContent(
 
                 Spacer(modifier = Modifier.height(12.dp))
 
-                DetailRowHorizontal("Status", approval.status)
+                DetailRowHorizontal("Status", approval.status.replaceFirstChar { it.uppercase() })
 
                 if (approval.created.isNotBlank()) {
                     DetailRowHorizontal("Created", DateFormatter.formatDateTime(approval.created))
+                    if (approval.status == "pending") {
+                        DetailRowHorizontal("Pending for", DateFormatter.formatRelative(approval.created).removeSuffix(" ago"))
+                    }
+                }
+
+                approval.summaryFields.workflowJob?.let { job ->
+                    job.launchedBy?.let { user ->
+                        DetailRowHorizontal("Launched by", user.username)
+                    }
                 }
 
                 approval.summaryFields.workflowJobTemplate?.let { template ->
@@ -180,6 +195,13 @@ private fun ApprovalDetailContent(
                     DetailRowHorizontal("Job Status", job.status)
                 }
 
+                approval.summaryFields.approvedOrDeniedBy?.let { user ->
+                    DetailRowHorizontal(
+                        if (approval.status == "approved") "Approved by" else "Denied by",
+                        user.username
+                    )
+                }
+
                 if (approval.timedOut) {
                     DetailRowHorizontal("Timed Out", "Yes")
                 }
@@ -189,11 +211,36 @@ private fun ApprovalDetailContent(
         Spacer(modifier = Modifier.height(24.dp))
 
         if (!showActions) {
-            Text(
-                text = "This approval has already been ${approval.status}.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = if (approval.status == "approved")
+                        MaterialTheme.colorScheme.primaryContainer
+                    else MaterialTheme.colorScheme.errorContainer
+                )
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp).fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Icon(
+                        imageVector = if (approval.status == "approved")
+                            Icons.Default.CheckCircle else Icons.Default.Cancel,
+                        contentDescription = null,
+                        tint = if (approval.status == "approved")
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        else MaterialTheme.colorScheme.onErrorContainer
+                    )
+                    Text(
+                        text = "This approval has been ${approval.status}.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (approval.status == "approved")
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        else MaterialTheme.colorScheme.onErrorContainer
+                    )
+                }
+            }
         } else if (isActionInProgress) {
             Box(
                 modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/DateFormatter.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/DateFormatter.kt
@@ -69,6 +69,23 @@ object DateFormatter {
         }
     }
 
+    fun formatDuration(isoTimestamp: String): String {
+        return try {
+            val instant = Instant.parse(isoTimestamp)
+            val now = Instant.now()
+            val minutesAgo = ChronoUnit.MINUTES.between(instant, now).coerceAtLeast(0)
+            when {
+                minutesAgo < 1 -> "just now"
+                minutesAgo < 60 -> "${minutesAgo}m"
+                minutesAgo < 1440 -> "${minutesAgo / 60}h"
+                minutesAgo < 10080 -> "${minutesAgo / 1440}d"
+                else -> formatDateTime(isoTimestamp)
+            }
+        } catch (_: Exception) {
+            isoTimestamp
+        }
+    }
+
     fun formatDate(isoTimestamp: String): String {
         return try {
             val instant = Instant.parse(isoTimestamp)

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/GeneralTab.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/GeneralTab.kt
@@ -2,6 +2,10 @@ package io.github.leogallego.ansiblejane.ui.settings
 
 import io.github.leogallego.ansiblejane.platform.PlatformUtils
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -324,7 +328,11 @@ private fun NotificationSection(
                 )
             }
 
-            AnimatedVisibility(visible = approvalPollingEnabled) {
+            AnimatedVisibility(
+                visible = approvalPollingEnabled,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
+            ) {
                 Column {
                     Spacer(modifier = Modifier.height(12.dp))
                     Text("Poll interval", style = MaterialTheme.typography.bodyMedium)

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/GeneralTab.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/GeneralTab.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Switch
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -40,6 +41,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.github.leogallego.ansiblejane.AppVersion
+import io.github.leogallego.ansiblejane.data.PollInterval
 import io.github.leogallego.ansiblejane.ui.components.ThemeMode
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
 import java.time.ZoneId
@@ -49,9 +51,13 @@ fun GeneralTab(
     timezoneId: String?,
     timeFormat: TimeFormat,
     themeMode: ThemeMode,
+    pollInterval: PollInterval,
+    approvalPollingEnabled: Boolean,
     onTimezoneSelected: (String?) -> Unit,
     onTimeFormatSelected: (TimeFormat) -> Unit,
     onThemeModeSelected: (ThemeMode) -> Unit,
+    onPollIntervalSelected: (PollInterval) -> Unit,
+    onApprovalPollingToggled: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -67,6 +73,15 @@ fun GeneralTab(
             onTimezoneSelected = onTimezoneSelected,
             onTimeFormatSelected = onTimeFormatSelected,
             onThemeModeSelected = onThemeModeSelected
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        NotificationSection(
+            currentPollInterval = pollInterval,
+            approvalPollingEnabled = approvalPollingEnabled,
+            onPollIntervalSelected = onPollIntervalSelected,
+            onApprovalPollingToggled = onApprovalPollingToggled
         )
 
         Spacer(modifier = Modifier.height(24.dp))
@@ -267,6 +282,76 @@ private fun TimezonePickerSheet(
             }
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun NotificationSection(
+    currentPollInterval: PollInterval,
+    approvalPollingEnabled: Boolean,
+    onPollIntervalSelected: (PollInterval) -> Unit,
+    onApprovalPollingToggled: (Boolean) -> Unit
+) {
+    Text(
+        text = "Notifications",
+        style = MaterialTheme.typography.titleMedium
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Approval notifications", style = MaterialTheme.typography.bodyLarge)
+                    Text(
+                        text = "Poll for pending workflow approvals",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = approvalPollingEnabled,
+                    onCheckedChange = onApprovalPollingToggled,
+                    modifier = Modifier.testTag("switch_approval_polling")
+                )
+            }
+
+            if (approvalPollingEnabled) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Text("Poll interval", style = MaterialTheme.typography.bodyMedium)
+                Spacer(modifier = Modifier.height(8.dp))
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    PollInterval.entries.forEachIndexed { index, interval ->
+                        SegmentedButton(
+                            selected = currentPollInterval == interval,
+                            onClick = { onPollIntervalSelected(interval) },
+                            shape = SegmentedButtonDefaults.itemShape(
+                                index = index,
+                                count = PollInterval.entries.size
+                            ),
+                            modifier = Modifier.testTag("button_poll_${interval.minutes}")
+                        ) {
+                            Text(interval.displayName, style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Spacer(modifier = Modifier.height(8.dp))
+    Text(
+        text = "Sound and vibration are configured in system notification settings.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(horizontal = 4.dp)
+    )
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/GeneralTab.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/GeneralTab.kt
@@ -1,6 +1,7 @@
 package io.github.leogallego.ansiblejane.ui.settings
 
 import io.github.leogallego.ansiblejane.platform.PlatformUtils
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -41,7 +42,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.github.leogallego.ansiblejane.AppVersion
-import io.github.leogallego.ansiblejane.data.PollInterval
+import io.github.leogallego.ansiblejane.model.PollInterval
 import io.github.leogallego.ansiblejane.ui.components.ThemeMode
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
 import java.time.ZoneId
@@ -323,22 +324,24 @@ private fun NotificationSection(
                 )
             }
 
-            if (approvalPollingEnabled) {
-                Spacer(modifier = Modifier.height(12.dp))
-                Text("Poll interval", style = MaterialTheme.typography.bodyMedium)
-                Spacer(modifier = Modifier.height(8.dp))
-                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                    PollInterval.entries.forEachIndexed { index, interval ->
-                        SegmentedButton(
-                            selected = currentPollInterval == interval,
-                            onClick = { onPollIntervalSelected(interval) },
-                            shape = SegmentedButtonDefaults.itemShape(
-                                index = index,
-                                count = PollInterval.entries.size
-                            ),
-                            modifier = Modifier.testTag("button_poll_${interval.minutes}")
-                        ) {
-                            Text(interval.displayName, style = MaterialTheme.typography.labelSmall)
+            AnimatedVisibility(visible = approvalPollingEnabled) {
+                Column {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text("Poll interval", style = MaterialTheme.typography.bodyMedium)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                        PollInterval.entries.forEachIndexed { index, interval ->
+                            SegmentedButton(
+                                selected = currentPollInterval == interval,
+                                onClick = { onPollIntervalSelected(interval) },
+                                shape = SegmentedButtonDefaults.itemShape(
+                                    index = index,
+                                    count = PollInterval.entries.size
+                                ),
+                                modifier = Modifier.testTag("button_poll_${interval.minutes}")
+                            ) {
+                                Text(interval.displayName, style = MaterialTheme.typography.labelSmall)
+                            }
                         }
                     }
                 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IUserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IUserPreferencesRepository.kt
@@ -1,14 +1,9 @@
 package io.github.leogallego.ansiblejane.data
 
+import io.github.leogallego.ansiblejane.model.PollInterval
 import io.github.leogallego.ansiblejane.ui.components.ThemeMode
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
 import kotlinx.coroutines.flow.Flow
-
-enum class PollInterval(val minutes: Int, val displayName: String) {
-    MINUTES_15(15, "15 minutes"),
-    MINUTES_30(30, "30 minutes"),
-    MINUTES_60(60, "1 hour")
-}
 
 interface IUserPreferencesRepository {
     val timezoneId: Flow<String?>

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IUserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IUserPreferencesRepository.kt
@@ -4,13 +4,23 @@ import io.github.leogallego.ansiblejane.ui.components.ThemeMode
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
 import kotlinx.coroutines.flow.Flow
 
+enum class PollInterval(val minutes: Int, val displayName: String) {
+    MINUTES_15(15, "15 minutes"),
+    MINUTES_30(30, "30 minutes"),
+    MINUTES_60(60, "1 hour")
+}
+
 interface IUserPreferencesRepository {
     val timezoneId: Flow<String?>
     val timeFormat: Flow<TimeFormat>
     val themeMode: Flow<ThemeMode>
+    val approvalPollInterval: Flow<PollInterval>
     fun favoriteTemplateIds(instanceId: String): Flow<Set<Int>>
+    fun approvalPollingEnabled(instanceId: String): Flow<Boolean>
     suspend fun setTimezoneId(zoneId: String?)
     suspend fun setTimeFormat(format: TimeFormat)
     suspend fun setThemeMode(mode: ThemeMode)
+    suspend fun setApprovalPollInterval(interval: PollInterval)
+    suspend fun setApprovalPollingEnabled(instanceId: String, enabled: Boolean)
     suspend fun toggleFavoriteTemplate(instanceId: String, templateId: Int)
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/UserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/UserPreferencesRepository.kt
@@ -1,5 +1,6 @@
 package io.github.leogallego.ansiblejane.data
 
+import io.github.leogallego.ansiblejane.model.PollInterval
 import io.github.leogallego.ansiblejane.platform.DataStoreFactory
 import io.github.leogallego.ansiblejane.ui.components.ThemeMode
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
@@ -21,7 +22,7 @@ class UserPreferencesRepository(
 
     override val timeFormat: Flow<TimeFormat> = dataStore.data.map { prefs ->
         prefs[KEY_TIME_FORMAT]?.let {
-            try { TimeFormat.valueOf(it) } catch (_: Exception) { TimeFormat.SYSTEM }
+            try { TimeFormat.valueOf(it) } catch (_: IllegalArgumentException) { TimeFormat.SYSTEM }
         } ?: TimeFormat.SYSTEM
     }
 
@@ -43,7 +44,7 @@ class UserPreferencesRepository(
 
     override val themeMode: Flow<ThemeMode> = dataStore.data.map { prefs ->
         prefs[KEY_THEME_MODE]?.let {
-            try { ThemeMode.valueOf(it) } catch (_: Exception) { ThemeMode.SYSTEM }
+            try { ThemeMode.valueOf(it) } catch (_: IllegalArgumentException) { ThemeMode.SYSTEM }
         } ?: ThemeMode.SYSTEM
     }
 
@@ -55,7 +56,7 @@ class UserPreferencesRepository(
 
     override val approvalPollInterval: Flow<PollInterval> = dataStore.data.map { prefs ->
         prefs[KEY_POLL_INTERVAL]?.let {
-            try { PollInterval.valueOf(it) } catch (_: Exception) { PollInterval.MINUTES_15 }
+            try { PollInterval.valueOf(it) } catch (_: IllegalArgumentException) { PollInterval.MINUTES_15 }
         } ?: PollInterval.MINUTES_15
     }
 

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/UserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/UserPreferencesRepository.kt
@@ -52,6 +52,29 @@ class UserPreferencesRepository(
         }
     }
 
+    override val approvalPollInterval: Flow<PollInterval> = dataStore.data.map { prefs ->
+        prefs[KEY_POLL_INTERVAL]?.let {
+            try { PollInterval.valueOf(it) } catch (_: Exception) { PollInterval.MINUTES_15 }
+        } ?: PollInterval.MINUTES_15
+    }
+
+    override suspend fun setApprovalPollInterval(interval: PollInterval) {
+        dataStore.edit { prefs ->
+            prefs[KEY_POLL_INTERVAL] = interval.name
+        }
+    }
+
+    override fun approvalPollingEnabled(instanceId: String): Flow<Boolean> =
+        dataStore.data.map { prefs ->
+            prefs[pollingEnabledKey(instanceId)] != "false"
+        }
+
+    override suspend fun setApprovalPollingEnabled(instanceId: String, enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[pollingEnabledKey(instanceId)] = enabled.toString()
+        }
+    }
+
     override fun favoriteTemplateIds(instanceId: String): Flow<Set<Int>> =
         dataStore.data.map { prefs ->
             prefs[favoritesKey(instanceId)]
@@ -82,8 +105,12 @@ class UserPreferencesRepository(
         private val KEY_TIMEZONE = stringPreferencesKey("timezone_override")
         private val KEY_TIME_FORMAT = stringPreferencesKey("time_format")
         private val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
+        private val KEY_POLL_INTERVAL = stringPreferencesKey("approval_poll_interval")
 
         private fun favoritesKey(instanceId: String) =
             stringPreferencesKey("favorite_templates_$instanceId")
+
+        private fun pollingEnabledKey(instanceId: String) =
+            stringPreferencesKey("approval_polling_enabled_$instanceId")
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/UserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/UserPreferencesRepository.kt
@@ -3,6 +3,7 @@ package io.github.leogallego.ansiblejane.data
 import io.github.leogallego.ansiblejane.platform.DataStoreFactory
 import io.github.leogallego.ansiblejane.ui.components.ThemeMode
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
@@ -66,12 +67,12 @@ class UserPreferencesRepository(
 
     override fun approvalPollingEnabled(instanceId: String): Flow<Boolean> =
         dataStore.data.map { prefs ->
-            prefs[pollingEnabledKey(instanceId)] != "false"
+            prefs[pollingEnabledKey(instanceId)] ?: true
         }
 
     override suspend fun setApprovalPollingEnabled(instanceId: String, enabled: Boolean) {
         dataStore.edit { prefs ->
-            prefs[pollingEnabledKey(instanceId)] = enabled.toString()
+            prefs[pollingEnabledKey(instanceId)] = enabled
         }
     }
 
@@ -111,6 +112,6 @@ class UserPreferencesRepository(
             stringPreferencesKey("favorite_templates_$instanceId")
 
         private fun pollingEnabledKey(instanceId: String) =
-            stringPreferencesKey("approval_polling_enabled_$instanceId")
+            booleanPreferencesKey("approval_polling_enabled_$instanceId")
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/PollInterval.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/PollInterval.kt
@@ -1,0 +1,7 @@
+package io.github.leogallego.ansiblejane.model
+
+enum class PollInterval(val minutes: Int, val displayName: String) {
+    MINUTES_15(15, "15 minutes"),
+    MINUTES_30(30, "30 minutes"),
+    MINUTES_60(60, "1 hour")
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/WorkflowApproval.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/WorkflowApproval.kt
@@ -26,6 +26,7 @@ data class WorkflowApprovalJobRef(
     val id: Int,
     val name: String = "",
     val status: String = "",
+    @SerialName("launched_by") val launchedBy: WorkflowApprovalUserRef? = null,
 )
 
 @Serializable


### PR DESCRIPTION
## Summary

- **ApprovalDetailScreen polish** — shows launcher username, relative pending time, loading skeleton, colored status card for resolved approvals
- **Notification settings** — configurable poll interval (15/30/60 min), per-instance polling toggle, POST_NOTIFICATIONS permission prompt
- **Notification improvements** — dedicated icon, grouping, inline Approve/Deny action buttons via BroadcastReceiver
- **Deep-link expansion** — `ansiblejane://job/{id}` and `ansiblejane://workflow/{id}` routes, deferred deep-links for unauthenticated state

Closes #173
Closes #275
Closes #276
Closes #277
Closes #278

## Test plan

- [x] 13 unit tests for parseDeepLink (valid routes, invalid schemes, path traversal, ID bounds, overflow)
- [x] 12 unit tests for ApprovalDetailViewModel (state transitions, approve/deny, error handling, reload)
- [ ] Open ApprovalDetailScreen for a pending approval — verify launcher name, relative time, and action buttons
- [ ] Open ApprovalDetailScreen for an already-resolved approval — verify colored status card with approved/denied-by
- [ ] Settings > General > Notifications — toggle polling off/on, change interval, verify WorkManager reschedules
- [ ] Verify POST_NOTIFICATIONS permission prompt on fresh install (Android 13+)
- [ ] Trigger multiple approval notifications — verify grouping and inline Approve/Deny buttons
- [ ] Test `ansiblejane://job/123` and `ansiblejane://workflow/456` deep-links
- [ ] Test deep-link when not authenticated — should defer and navigate after login

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>