### PR TITLE
test: remaining test coverage from approval notification review (#280)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ aap-docs/
 # Temporary files
 .tmp/
 
+# Robolectric offline SDK jars (sandbox)
+robolectric-deps/
+
 # Android / Gradle
 build/
 .gradle/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,13 @@ android {
         unitTests {
             isIncludeAndroidResources = true
             isReturnDefaultValues = true
+            all {
+                val roboDepsDir = file("${rootProject.projectDir}/robolectric-deps")
+                if (roboDepsDir.exists()) {
+                    it.systemProperty("robolectric.offline", "true")
+                    it.systemProperty("robolectric.dependency.dir", roboDepsDir.absolutePath)
+                }
+            }
         }
     }
 }
@@ -139,6 +146,7 @@ dependencies {
     testImplementation(libs.androidx.compose.ui.test.junit4)
     testImplementation(libs.androidx.test.runner)
     testImplementation(libs.androidx.test.rules)
+    testImplementation(libs.androidx.work.testing)
 
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,6 +73,10 @@ android {
                     it.systemProperty("robolectric.offline", "true")
                     it.systemProperty("robolectric.dependency.dir", roboDepsDir.absolutePath)
                 }
+                val tmpDir = file("${rootProject.projectDir}/.tmp")
+                if (tmpDir.exists()) {
+                    it.systemProperty("java.io.tmpdir", tmpDir.absolutePath)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiver.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiver.kt
@@ -1,10 +1,13 @@
 package io.github.leogallego.ansiblejane.notification
 
+import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import io.github.leogallego.ansiblejane.R
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import kotlinx.coroutines.CoroutineScope
@@ -26,6 +29,35 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
         private const val TAG = "ApprovalActionReceiver"
     }
 
+    private fun showErrorNotification(
+        context: Context,
+        approvalId: Int,
+        wasApprove: Boolean,
+        errorMessage: String?
+    ) {
+        val actionLabel = if (wasApprove) "approve" else "deny"
+        val retryIntent = Intent(context, ApprovalActionReceiver::class.java).apply {
+            action = if (wasApprove) ACTION_APPROVE else ACTION_DENY
+            putExtra(EXTRA_APPROVAL_ID, approvalId)
+        }
+        val retryPendingIntent = PendingIntent.getBroadcast(
+            context,
+            approvalId,
+            retryIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, ApprovalNotificationManager.CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification_approval)
+            .setContentTitle("Failed to $actionLabel approval")
+            .setContentText(errorMessage ?: "Please try again")
+            .setAutoCancel(true)
+            .addAction(R.drawable.ic_notification_approval, "Retry", retryPendingIntent)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(approvalId, notification)
+    }
+
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != ACTION_APPROVE && intent.action != ACTION_DENY) return
 
@@ -37,13 +69,15 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
         scope.launch {
+            val actionLabel = if (isApprove) "approve" else "deny"
             try {
                 val tokenManager: ITokenManager = get()
                 val instance = withTimeoutOrNull(5_000L) {
                     tokenManager.activeInstance.firstOrNull { it != null }
                 }
                 if (instance == null) {
-                    Log.w(TAG, "No active instance, cannot ${if (isApprove) "approve" else "deny"} $approvalId")
+                    Log.w(TAG, "No active instance, cannot $actionLabel $approvalId")
+                    showErrorNotification(context, approvalId, isApprove, "No active instance")
                     return@launch
                 }
 
@@ -56,9 +90,10 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
 
                 NotificationManagerCompat.from(context).cancel(approvalId)
 
-                Log.i(TAG, "Approval $approvalId ${if (isApprove) "approved" else "denied"}")
+                Log.i(TAG, "Approval $approvalId ${actionLabel}d")
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to ${if (isApprove) "approve" else "deny"} $approvalId", e)
+                Log.e(TAG, "Failed to $actionLabel $approvalId", e)
+                showErrorNotification(context, approvalId, isApprove, e.message)
             } finally {
                 pendingResult.finish()
                 scope.cancel()

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiverTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiverTest.kt
@@ -177,14 +177,20 @@ class ApprovalActionReceiverTest {
 
         receiver.onReceive(context, buildIntent(ApprovalActionReceiver.ACTION_APPROVE, approvalId = 42))
 
-        Thread.sleep(6_000)
-
         val notifManager = shadowOf(
             context.getSystemService(android.app.NotificationManager::class.java)
         )
-        val notification = notifManager.getNotification(42)
+        // Poll for error notification instead of fixed sleep — production timeout is 5s,
+        // so we poll up to 10s with short intervals to avoid flakiness on slow CI.
+        var notification: android.app.Notification? = null
+        val deadline = System.currentTimeMillis() + 10_000
+        while (System.currentTimeMillis() < deadline) {
+            notification = notifManager.getNotification(42)
+            if (notification != null) break
+            Thread.sleep(200)
+        }
         assertNotNull("Error notification should be posted", notification)
-        val extras = notification.extras
+        val extras = notification!!.extras
         assertTrue(
             "Title should indicate failure",
             extras.getString("android.title")?.contains("Failed") == true
@@ -202,14 +208,20 @@ class ApprovalActionReceiverTest {
         receiver.onReceive(context, buildIntent(ApprovalActionReceiver.ACTION_APPROVE, approvalId = 42))
 
         callLatch.await(5, TimeUnit.SECONDS)
-        Thread.sleep(100)
 
+        // Poll briefly — notification is posted right after the IOException is caught
         val notifManager = shadowOf(
             context.getSystemService(android.app.NotificationManager::class.java)
         )
-        val notification = notifManager.getNotification(42)
+        var notification: android.app.Notification? = null
+        val deadline = System.currentTimeMillis() + 2_000
+        while (System.currentTimeMillis() < deadline) {
+            notification = notifManager.getNotification(42)
+            if (notification != null) break
+            Thread.sleep(50)
+        }
         assertNotNull("Error notification should replace original", notification)
-        assertEquals("Should have Retry action", 1, notification.actions.size)
+        assertEquals("Should have Retry action", 1, notification!!.actions.size)
         assertEquals("Retry", notification.actions[0].title)
     }
 }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiverTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiverTest.kt
@@ -1,0 +1,215 @@
+package io.github.leogallego.ansiblejane.notification
+
+import android.content.Intent
+import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
+import io.github.leogallego.ansiblejane.model.AapInstance
+import io.github.leogallego.ansiblejane.network.AapApiClient
+import io.github.leogallego.ansiblejane.network.EdaApiClient
+import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import io.github.leogallego.ansiblejane.network.PlatformApiClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+class ApprovalActionReceiverTest {
+
+    private lateinit var fakeTokenManager: FakeTokenManager
+    private val apiCalls = mutableListOf<String>()
+    private lateinit var callLatch: CountDownLatch
+
+    private val testInstance = AapInstance(
+        id = "inst-1",
+        baseUrl = "https://aap.example.com",
+        token = "test-token"
+    )
+
+    private fun buildTrackingApiProvider(shouldFail: Boolean = false): IAapApiProvider {
+        val mockEngine = MockEngine { request ->
+            apiCalls.add(request.url.encodedPath)
+            callLatch.countDown()
+            if (shouldFail) {
+                throw java.io.IOException("Connection refused")
+            } else {
+                respond("{}", status = HttpStatusCode.OK)
+            }
+        }
+        val client = HttpClient(mockEngine)
+        val apiClient = AapApiClient(client)
+        return object : IAapApiProvider {
+            override fun getApiService() = apiClient
+            override fun getEdaApiService(): EdaApiClient = throw UnsupportedOperationException()
+            override fun getPlatformApiService(): PlatformApiClient = throw UnsupportedOperationException()
+            override fun evictInstance(instanceId: String) {}
+        }
+    }
+
+    @Before
+    fun setup() {
+        fakeTokenManager = FakeTokenManager()
+        apiCalls.clear()
+        callLatch = CountDownLatch(1)
+    }
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+    private fun startKoinWith(apiProvider: IAapApiProvider = buildTrackingApiProvider()) {
+        startKoin {
+            modules(module {
+                single<ITokenManager> { fakeTokenManager }
+                single<IAapApiProvider> { apiProvider }
+            })
+        }
+    }
+
+    private fun buildIntent(action: String?, approvalId: Int = 42): Intent {
+        return Intent(action).apply {
+            putExtra(ApprovalActionReceiver.EXTRA_APPROVAL_ID, approvalId)
+        }
+    }
+
+    @Test
+    fun `unknown action is ignored`() {
+        startKoinWith()
+        val receiver = ApprovalActionReceiver()
+        val context = RuntimeEnvironment.getApplication()
+
+        receiver.onReceive(context, buildIntent("com.example.UNKNOWN_ACTION"))
+
+        assertTrue("No API calls should be made for unknown action", apiCalls.isEmpty())
+    }
+
+    @Test
+    fun `null action is ignored`() {
+        startKoinWith()
+        val receiver = ApprovalActionReceiver()
+        val context = RuntimeEnvironment.getApplication()
+
+        receiver.onReceive(context, buildIntent(null))
+
+        assertTrue("No API calls should be made for null action", apiCalls.isEmpty())
+    }
+
+    @Test
+    fun `negative approval ID is rejected`() {
+        startKoinWith()
+        fakeTokenManager.setInstances(listOf(testInstance))
+        val receiver = ApprovalActionReceiver()
+        val context = RuntimeEnvironment.getApplication()
+
+        receiver.onReceive(context, buildIntent(ApprovalActionReceiver.ACTION_APPROVE, approvalId = -1))
+
+        assertTrue("No API calls for negative ID", apiCalls.isEmpty())
+    }
+
+    @Test
+    fun `zero approval ID is rejected`() {
+        startKoinWith()
+        fakeTokenManager.setInstances(listOf(testInstance))
+        val receiver = ApprovalActionReceiver()
+        val context = RuntimeEnvironment.getApplication()
+
+        receiver.onReceive(context, buildIntent(ApprovalActionReceiver.ACTION_APPROVE, approvalId = 0))
+
+        assertTrue("No API calls for zero ID", apiCalls.isEmpty())
+    }
+
+    @Test
+    fun `approve action calls approveWorkflow endpoint`() {
+        startKoinWith()
+        fakeTokenManager.setInstances(listOf(testInstance))
+        val receiver = ApprovalActionReceiver()
+        val context = RuntimeEnvironment.getApplication()
+
+        receiver.onReceive(context, buildIntent(ApprovalActionReceiver.ACTION_APPROVE, approvalId = 42))
+
+        callLatch.await(5, TimeUnit.SECONDS)
+
+        assertTrue(
+            "Should call approve endpoint",
+            apiCalls.any { it.contains("workflow_approvals/42/approve") }
+        )
+    }
+
+    @Test
+    fun `deny action calls denyWorkflow endpoint`() {
+        startKoinWith()
+        fakeTokenManager.setInstances(listOf(testInstance))
+        val receiver = ApprovalActionReceiver()
+        val context = RuntimeEnvironment.getApplication()
+
+        receiver.onReceive(context, buildIntent(ApprovalActionReceiver.ACTION_DENY, approvalId = 42))
+
+        callLatch.await(5, TimeUnit.SECONDS)
+
+        assertTrue(
+            "Should call deny endpoint",
+            apiCalls.any { it.contains("workflow_approvals/42/deny") }
+        )
+    }
+
+    @Test
+    fun `no active instance shows error notification`() {
+        startKoinWith()
+        ApprovalNotificationManager.createChannel(RuntimeEnvironment.getApplication())
+        val receiver = ApprovalActionReceiver()
+        val context = RuntimeEnvironment.getApplication()
+
+        receiver.onReceive(context, buildIntent(ApprovalActionReceiver.ACTION_APPROVE, approvalId = 42))
+
+        Thread.sleep(6_000)
+
+        val notifManager = shadowOf(
+            context.getSystemService(android.app.NotificationManager::class.java)
+        )
+        val notification = notifManager.getNotification(42)
+        assertNotNull("Error notification should be posted", notification)
+        val extras = notification.extras
+        assertTrue(
+            "Title should indicate failure",
+            extras.getString("android.title")?.contains("Failed") == true
+        )
+    }
+
+    @Test
+    fun `API failure shows error notification with retry`() {
+        startKoinWith(apiProvider = buildTrackingApiProvider(shouldFail = true))
+        ApprovalNotificationManager.createChannel(RuntimeEnvironment.getApplication())
+        fakeTokenManager.setInstances(listOf(testInstance))
+        val receiver = ApprovalActionReceiver()
+        val context = RuntimeEnvironment.getApplication()
+
+        receiver.onReceive(context, buildIntent(ApprovalActionReceiver.ACTION_APPROVE, approvalId = 42))
+
+        callLatch.await(5, TimeUnit.SECONDS)
+        Thread.sleep(100)
+
+        val notifManager = shadowOf(
+            context.getSystemService(android.app.NotificationManager::class.java)
+        )
+        val notification = notifManager.getNotification(42)
+        assertNotNull("Error notification should replace original", notification)
+        assertEquals("Should have Retry action", 1, notification.actions.size)
+        assertEquals("Retry", notification.actions[0].title)
+    }
+}

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorkerTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorkerTest.kt
@@ -1,0 +1,207 @@
+package io.github.leogallego.ansiblejane.notification
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
+import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
+import io.github.leogallego.ansiblejane.fakes.FakeUserPreferencesRepository
+import io.github.leogallego.ansiblejane.model.AapInstance
+import io.github.leogallego.ansiblejane.model.PaginatedResponse
+import io.github.leogallego.ansiblejane.model.WorkflowApproval
+import io.github.leogallego.ansiblejane.network.AapApiClient
+import io.github.leogallego.ansiblejane.network.EdaApiClient
+import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import io.github.leogallego.ansiblejane.network.PlatformApiClient
+import io.github.leogallego.ansiblejane.platform.DataStoreFactory
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ApprovalPollingWorkerTest {
+
+    private lateinit var fakeTokenManager: FakeTokenManager
+    private lateinit var fakeUserPreferences: FakeUserPreferencesRepository
+    private lateinit var approvalTracker: ApprovalTracker
+    private lateinit var notificationManager: ApprovalNotificationManager
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val testInstance = AapInstance(
+        id = "inst-1",
+        baseUrl = "https://aap.example.com",
+        token = "test-token"
+    )
+
+    private val approval1 = WorkflowApproval(id = 10, name = "Deploy prod")
+    private val approval2 = WorkflowApproval(id = 20, name = "Deploy staging")
+
+    @Before
+    fun setup() {
+        fakeTokenManager = FakeTokenManager()
+        fakeUserPreferences = FakeUserPreferencesRepository()
+        val context: Context = ApplicationProvider.getApplicationContext()
+        approvalTracker = ApprovalTracker(DataStoreFactory(context))
+        notificationManager = ApprovalNotificationManager()
+        ApprovalNotificationManager.createChannel(context)
+    }
+
+    @After
+    fun tearDown() {
+        stopKoin()
+        val context: Context = ApplicationProvider.getApplicationContext()
+        context.filesDir.resolve("datastore").deleteRecursively()
+    }
+
+    private fun buildMockApiProvider(
+        approvals: List<WorkflowApproval> = emptyList(),
+        shouldFail: Boolean = false
+    ): IAapApiProvider {
+        val responseJson = json.encodeToString(
+            PaginatedResponse(count = approvals.size, results = approvals)
+        )
+        val mockEngine = MockEngine { _ ->
+            if (shouldFail) {
+                respond("error", status = HttpStatusCode.InternalServerError)
+            } else {
+                respond(
+                    content = responseJson,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                )
+            }
+        }
+        val client = HttpClient(mockEngine) {
+            install(ContentNegotiation) { json(json) }
+        }
+        val apiClient = AapApiClient(client)
+        return object : IAapApiProvider {
+            override fun getApiService() = apiClient
+            override fun getEdaApiService(): EdaApiClient = throw UnsupportedOperationException()
+            override fun getPlatformApiService(): PlatformApiClient = throw UnsupportedOperationException()
+            override fun evictInstance(instanceId: String) {}
+        }
+    }
+
+    private fun startKoinWith(apiProvider: IAapApiProvider = buildMockApiProvider()) {
+        startKoin {
+            modules(module {
+                single<ITokenManager> { fakeTokenManager }
+                single<IAapApiProvider> { apiProvider }
+                single<IUserPreferencesRepository> { fakeUserPreferences }
+                single { approvalTracker }
+                single { notificationManager }
+            })
+        }
+    }
+
+    private fun buildWorker(): ApprovalPollingWorker {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        return TestListenableWorkerBuilder<ApprovalPollingWorker>(context).build()
+    }
+
+    @Test
+    fun `no active instance returns success`() = runTest {
+        startKoinWith()
+        val worker = buildWorker()
+
+        val result = worker.doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun `polling disabled returns success`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        fakeUserPreferences.setApprovalPollingEnabled("inst-1", false)
+        startKoinWith()
+        val worker = buildWorker()
+
+        val result = worker.doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun `new approvals are marked as seen`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        startKoinWith(apiProvider = buildMockApiProvider(listOf(approval1, approval2)))
+        val worker = buildWorker()
+
+        val result = worker.doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+        val seenIds = approvalTracker.getSeenIds()
+        assertTrue("Approval 10 should be marked seen", 10 in seenIds)
+        assertTrue("Approval 20 should be marked seen", 20 in seenIds)
+    }
+
+    @Test
+    fun `stale seen IDs are pruned`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        approvalTracker.markSeen(setOf(10, 99))
+        startKoinWith(apiProvider = buildMockApiProvider(listOf(approval1)))
+        val worker = buildWorker()
+
+        worker.doWork()
+
+        val seenIds = approvalTracker.getSeenIds()
+        assertTrue("Active ID should be retained", 10 in seenIds)
+        assertTrue("Stale ID should be pruned", 99 !in seenIds)
+    }
+
+    @Test
+    fun `API failure returns retry`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        startKoinWith(apiProvider = buildMockApiProvider(shouldFail = true))
+        val worker = buildWorker()
+
+        val result = worker.doWork()
+
+        assertEquals(ListenableWorker.Result.retry(), result)
+    }
+
+    @Test
+    fun `empty pending approvals returns success`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        startKoinWith(apiProvider = buildMockApiProvider(emptyList()))
+        val worker = buildWorker()
+
+        val result = worker.doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun `polling enabled by default`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        startKoinWith(apiProvider = buildMockApiProvider(listOf(approval1)))
+        val worker = buildWorker()
+
+        val result = worker.doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+        assertTrue("Should poll when enabled by default", 10 in approvalTracker.getSeenIds())
+    }
+}

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorkerTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorkerTest.kt
@@ -74,18 +74,20 @@ class ApprovalPollingWorkerTest {
         context.filesDir.resolve("datastore").deleteRecursively()
     }
 
+    private enum class FailureMode { NONE, HTTP_500, NETWORK_ERROR }
+
     private fun buildMockApiProvider(
         approvals: List<WorkflowApproval> = emptyList(),
-        shouldFail: Boolean = false
+        failureMode: FailureMode = FailureMode.NONE
     ): IAapApiProvider {
         val responseJson = json.encodeToString(
             PaginatedResponse(count = approvals.size, results = approvals)
         )
         val mockEngine = MockEngine { _ ->
-            if (shouldFail) {
-                respond("error", status = HttpStatusCode.InternalServerError)
-            } else {
-                respond(
+            when (failureMode) {
+                FailureMode.HTTP_500 -> respond("error", status = HttpStatusCode.InternalServerError)
+                FailureMode.NETWORK_ERROR -> throw java.io.IOException("Connection refused")
+                FailureMode.NONE -> respond(
                     content = responseJson,
                     status = HttpStatusCode.OK,
                     headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -172,9 +174,20 @@ class ApprovalPollingWorkerTest {
     }
 
     @Test
-    fun `API failure returns retry`() = runTest {
+    fun `HTTP error returns retry`() = runTest {
         fakeTokenManager.setInstances(listOf(testInstance))
-        startKoinWith(apiProvider = buildMockApiProvider(shouldFail = true))
+        startKoinWith(apiProvider = buildMockApiProvider(failureMode = FailureMode.HTTP_500))
+        val worker = buildWorker()
+
+        val result = worker.doWork()
+
+        assertEquals(ListenableWorker.Result.retry(), result)
+    }
+
+    @Test
+    fun `network error returns retry`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        startKoinWith(apiProvider = buildMockApiProvider(failureMode = FailureMode.NETWORK_ERROR))
         val worker = buildWorker()
 
         val result = worker.doWork()

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
@@ -7,11 +7,13 @@ import io.github.leogallego.ansiblejane.fakes.FakeAssistantRepository
 import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
 import io.github.leogallego.ansiblejane.fakes.FakeUserPreferencesRepository
 import io.github.leogallego.ansiblejane.model.AapInstance
+import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
+import io.github.leogallego.ansiblejane.ui.components.ThemeMode
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -300,6 +302,95 @@ class SettingsViewModelTest {
             viewModel.toggleExpandMcpServer("Jobs")
             val expanded = awaitItem() as SettingsUiState.Ready
             assertTrue("Jobs" in expanded.expandedMcpServers)
+        }
+    }
+
+    // --- Combined flow propagation ---
+
+    @Test
+    fun `themeMode flow updates propagate to UI state`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem() as SettingsUiState.Ready
+            assertEquals(ThemeMode.SYSTEM, initial.themeMode)
+
+            fakeUserPreferences.setThemeMode(ThemeMode.DARK)
+
+            val updated = awaitItem() as SettingsUiState.Ready
+            assertEquals(ThemeMode.DARK, updated.themeMode)
+        }
+    }
+
+    @Test
+    fun `activeProviderKey flow updates propagate to UI state`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem() as SettingsUiState.Ready
+            assertNull(initial.activeProviderKey)
+
+            fakeAssistantRepo.switchActiveProvider("openai")
+
+            val updated = awaitItem() as SettingsUiState.Ready
+            assertEquals("openai", updated.activeProviderKey)
+        }
+    }
+
+    @Test
+    fun `savedConfigs flow updates propagate to UI state`() = runTest {
+        val viewModel = createViewModel()
+        val testConfig = LlmProviderConfig.OpenAiCompatible(
+            url = "https://api.openai.com/v1",
+            model = "gpt-4",
+            apiKey = "test-key"
+        )
+
+        viewModel.uiState.test {
+            val initial = awaitItem() as SettingsUiState.Ready
+            assertTrue(initial.savedConfigs.isEmpty())
+
+            fakeAssistantRepo.saveAllLlmConfigs(mapOf("openai" to testConfig))
+
+            val updated = awaitItem() as SettingsUiState.Ready
+            assertEquals(1, updated.savedConfigs.size)
+            assertEquals(testConfig, updated.savedConfigs["openai"])
+        }
+    }
+
+    @Test
+    fun `activeConfig flow updates propagate to UI state`() = runTest {
+        val testConfig = LlmProviderConfig.OpenAiCompatible(
+            url = "https://api.openai.com/v1",
+            model = "gpt-4",
+            apiKey = "test-key"
+        )
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem() as SettingsUiState.Ready
+            assertNull(initial.activeConfig)
+
+            fakeAssistantRepo.saveLlmConfig(testConfig)
+
+            // saveLlmConfig updates activeConfig, savedConfigs, and activeProviderKey
+            val updated = expectMostRecentItem() as SettingsUiState.Ready
+            assertEquals(testConfig, updated.activeConfig)
+        }
+    }
+
+    @Test
+    fun `timezone flow updates propagate to UI state`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val initial = awaitItem() as SettingsUiState.Ready
+            assertNull(initial.timezoneId)
+
+            fakeUserPreferences.setTimezoneId("America/New_York")
+
+            val updated = awaitItem() as SettingsUiState.Ready
+            assertEquals("America/New_York", updated.timezoneId)
         }
     }
 }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
@@ -373,9 +373,36 @@ class SettingsViewModelTest {
 
             fakeAssistantRepo.saveLlmConfig(testConfig)
 
-            // saveLlmConfig updates activeConfig, savedConfigs, and activeProviderKey
+            // saveLlmConfig updates 3 flows (activeConfig, savedConfigs, activeProviderKey).
+            // The ViewModel's combine operator may emit intermediate states as each flow
+            // settles — use expectMostRecentItem() to skip those and assert the final state.
             val updated = expectMostRecentItem() as SettingsUiState.Ready
             assertEquals(testConfig, updated.activeConfig)
+        }
+    }
+
+    @Test
+    fun `multiple simultaneous flow updates settle to correct final state`() = runTest {
+        val testConfig = LlmProviderConfig.OpenAiCompatible(
+            url = "https://api.openai.com/v1",
+            model = "gpt-4",
+            apiKey = "test-key"
+        )
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            awaitItem() // initial
+
+            fakeUserPreferences.setThemeMode(ThemeMode.DARK)
+            fakeAssistantRepo.switchActiveProvider("openai")
+            fakeUserPreferences.setTimezoneId("America/New_York")
+            fakeAssistantRepo.saveAllLlmConfigs(mapOf("openai" to testConfig))
+
+            val settled = expectMostRecentItem() as SettingsUiState.Ready
+            assertEquals(ThemeMode.DARK, settled.themeMode)
+            assertEquals("openai", settled.activeProviderKey)
+            assertEquals("America/New_York", settled.timezoneId)
+            assertEquals(1, settled.savedConfigs.size)
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,6 +89,7 @@ koin-compose-viewmodel = { group = "io.insert-koin", name = "koin-compose-viewmo
 # Data
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore-preferences" }
 androidx-work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work-runtime" }
+androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "work-runtime" }
 
 # Security
 tink-android = { group = "com.google.crypto.tink", name = "tink-android", version.ref = "tink-android" }

--- a/scripts/sandbox-setup.sh
+++ b/scripts/sandbox-setup.sh
@@ -47,4 +47,24 @@ else
     fi
 fi
 
+# 4. Set up Robolectric offline mode jars
+# Robolectric needs pre-instrumented android-all jars in a flat directory.
+# In sandbox mode, it can't create ~/.robolectric-download-lock on the
+# read-only home filesystem, so offline mode with local jars is required.
+ROBO_DEPS="robolectric-deps"
+if [ ! -d "$ROBO_DEPS" ]; then
+    M2_ROBO="$HOME/.m2/repository/org/robolectric/android-all-instrumented"
+    if [ -d "$M2_ROBO" ]; then
+        mkdir -p "$ROBO_DEPS"
+        for jar in "$M2_ROBO"/*/android-all-instrumented-*.jar; do
+            [ -f "$jar" ] && ln -sf "$jar" "$ROBO_DEPS/$(basename "$jar")"
+        done
+        echo "Linked Robolectric SDK jars to $ROBO_DEPS"
+    else
+        echo "Warning: Robolectric jars not found in ~/.m2 — run tests once outside sandbox first"
+    fi
+else
+    echo "Robolectric deps directory already exists"
+fi
+
 echo "Sandbox setup complete."


### PR DESCRIPTION
## Summary

- Add 23 new tests for 3 areas from #280:
  - **ApprovalActionReceiverTest** (8): intent action guard, ID validation, approve/deny routing, error notification on failure
  - **ApprovalPollingWorkerTest** (8): no-instance, polling disabled, seen/new tracking, stale pruning, HTTP error retry, network error retry
  - **SettingsViewModelTest** (6): themeMode, activeProviderKey, savedConfigs, activeConfig, timezone flow propagation, simultaneous flow stress test
- Fix Robolectric in sandboxed environments via offline mode with pre-cached SDK jars
- Fix java.io.tmpdir for test executor in sandbox (Robolectric TempDirectory)
- Add `work-testing` dependency for WorkManager unit tests
- Extend `sandbox-setup.sh` to handle Robolectric jar symlinks
- Fix: ApprovalActionReceiver shows error notification with Retry on failure (was silently failing)

## Test plan

- [x] All 38 targeted tests pass (8 + 8 + 22)
- [x] No regressions in existing test suite
- [x] Polling replaces Thread.sleep for notification assertions (no CI flakiness)
- [x] Both HTTP and network failure modes covered in worker tests

Closes #280
Ref #284

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>