### PR TITLE
fix: harden ApprovalActionReceiver notification handling

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiver.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiver.kt
@@ -29,9 +29,6 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
         private const val TAG = "ApprovalActionReceiver"
     }
 
-    private fun safeNotificationId(approvalId: Int): Int =
-        if (approvalId == ApprovalNotificationManager.SUMMARY_ID) approvalId + 1 else approvalId
-
     private fun showErrorNotification(
         context: Context,
         approvalId: Int,
@@ -43,7 +40,7 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
             action = if (wasApprove) ACTION_APPROVE else ACTION_DENY
             putExtra(EXTRA_APPROVAL_ID, approvalId)
         }
-        val retryRequestCode = (approvalId.hashCode() and 0x1FFFFFFF) or 0x40000000
+        val retryRequestCode = (approvalId.hashCode() and 0x7FFFFFFF) or Int.MIN_VALUE
         val retryPendingIntent = PendingIntent.getBroadcast(
             context,
             retryRequestCode,
@@ -60,7 +57,7 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
             .build()
 
         try {
-            NotificationManagerCompat.from(context).notify(safeNotificationId(approvalId), notification)
+            NotificationManagerCompat.from(context).notify(ApprovalNotificationManager.safeNotificationId(approvalId), notification)
         } catch (e: SecurityException) {
             Log.w(TAG, "Cannot post error notification — channel may have been deleted", e)
         }
@@ -99,7 +96,7 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
                     apiProvider.getApiService().denyWorkflow(approvalId)
                 }
 
-                NotificationManagerCompat.from(context).cancel(safeNotificationId(approvalId))
+                NotificationManagerCompat.from(context).cancel(ApprovalNotificationManager.safeNotificationId(approvalId))
 
                 Log.i(TAG, "Approval $approvalId ${actionLabel}d")
             } catch (e: Exception) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiver.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiver.kt
@@ -29,6 +29,9 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
         private const val TAG = "ApprovalActionReceiver"
     }
 
+    private fun safeNotificationId(approvalId: Int): Int =
+        if (approvalId == ApprovalNotificationManager.SUMMARY_ID) approvalId + 1 else approvalId
+
     private fun showErrorNotification(
         context: Context,
         approvalId: Int,
@@ -40,22 +43,27 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
             action = if (wasApprove) ACTION_APPROVE else ACTION_DENY
             putExtra(EXTRA_APPROVAL_ID, approvalId)
         }
+        val retryRequestCode = (approvalId.hashCode() and 0x1FFFFFFF) or 0x40000000
         val retryPendingIntent = PendingIntent.getBroadcast(
             context,
-            approvalId,
+            retryRequestCode,
             retryIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
         val notification = NotificationCompat.Builder(context, ApprovalNotificationManager.CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification_approval)
-            .setContentTitle("Failed to $actionLabel approval")
-            .setContentText(errorMessage ?: "Please try again")
+            .setContentTitle(context.getString(R.string.notification_approval_failed_title, actionLabel))
+            .setContentText(errorMessage ?: context.getString(R.string.notification_approval_failed_message))
             .setAutoCancel(true)
-            .addAction(R.drawable.ic_notification_approval, "Retry", retryPendingIntent)
+            .addAction(R.drawable.ic_notification_approval, context.getString(R.string.action_retry), retryPendingIntent)
             .build()
 
-        NotificationManagerCompat.from(context).notify(approvalId, notification)
+        try {
+            NotificationManagerCompat.from(context).notify(safeNotificationId(approvalId), notification)
+        } catch (e: SecurityException) {
+            Log.w(TAG, "Cannot post error notification — channel may have been deleted", e)
+        }
     }
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -77,7 +85,10 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
                 }
                 if (instance == null) {
                     Log.w(TAG, "No active instance, cannot $actionLabel $approvalId")
-                    showErrorNotification(context, approvalId, isApprove, "No active instance")
+                    showErrorNotification(
+                        context, approvalId, isApprove,
+                        context.getString(R.string.notification_no_active_instance)
+                    )
                     return@launch
                 }
 
@@ -88,7 +99,7 @@ class ApprovalActionReceiver : BroadcastReceiver(), KoinComponent {
                     apiProvider.getApiService().denyWorkflow(approvalId)
                 }
 
-                NotificationManagerCompat.from(context).cancel(approvalId)
+                NotificationManagerCompat.from(context).cancel(safeNotificationId(approvalId))
 
                 Log.i(TAG, "Approval $approvalId ${actionLabel}d")
             } catch (e: Exception) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
@@ -22,7 +22,7 @@ class ApprovalNotificationManager {
         const val CHANNEL_ID = "workflow_approvals"
         const val CHANNEL_NAME = "Workflow Approvals"
         private const val GROUP_KEY = "io.github.leogallego.ansiblejane.APPROVAL_GROUP"
-        private const val SUMMARY_ID = 0x4A414E45 // "JANE" — avoids collision with default ID 0
+        internal const val SUMMARY_ID = 0x4A414E45 // "JANE" — avoids collision with default ID 0
 
         fun createChannel(context: Context) {
             val channel = NotificationChannel(

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
@@ -24,6 +24,9 @@ class ApprovalNotificationManager {
         private const val GROUP_KEY = "io.github.leogallego.ansiblejane.APPROVAL_GROUP"
         internal const val SUMMARY_ID = 0x4A414E45 // "JANE" — avoids collision with default ID 0
 
+        internal fun safeNotificationId(approvalId: Int): Int =
+            if (approvalId == SUMMARY_ID) approvalId + 1 else approvalId
+
         fun createChannel(context: Context) {
             val channel = NotificationChannel(
                 CHANNEL_ID,
@@ -102,7 +105,7 @@ class ApprovalNotificationManager {
             .build()
 
         val manager = NotificationManagerCompat.from(context)
-        manager.notify(approval.id, notification)
+        manager.notify(safeNotificationId(approval.id), notification)
 
         val summaryNotification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification_approval)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,11 @@
     <string name="action_retry">Retry</string>
     <string name="action_cancel">Cancel</string>
 
+    <!-- Notification: approval actions -->
+    <string name="notification_approval_failed_title">Failed to %1$s approval</string>
+    <string name="notification_approval_failed_message">Please try again</string>
+    <string name="notification_no_active_instance">No active instance</string>
+
 
     <!-- Shared component text -->
     <string name="show_details">Show details</string>


### PR DESCRIPTION
## Summary

- Wrap `NotificationManagerCompat.notify()` in try-catch for `SecurityException` when the notification channel has been deleted by the user
- Extract hardcoded user-facing strings (`"Failed to ... approval"`, `"Please try again"`, `"No active instance"`) to string resources for localization
- Guard error notification ID against `SUMMARY_ID` collision via `safeNotificationId()` helper
- Use hash-based PendingIntent request code (`0x40000000` namespace) for retry action, consistent with `ApprovalNotificationManager`'s approach

## Test plan

- [x] All 8 `ApprovalActionReceiverTest` tests pass (no changes needed — Robolectric resolves string resources)
- [x] All 8 `ApprovalPollingWorkerTest` tests pass (no regressions)

Closes #285

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>