### PR TITLE
test: ToolRouter disabled tools filtering (#282)

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -261,6 +261,18 @@ class ToolRouter {
         return (toolName to source) !in disabledTools
     }
 
+    fun applyPersistedDisables(keys: Set<String>) {
+        for (entry in keys) {
+            val colonIndex = entry.indexOf(':')
+            if (colonIndex > 0) {
+                val sourceStr = entry.substring(0, colonIndex)
+                val toolName = entry.substring(colonIndex + 1)
+                val source = try { ToolSource.valueOf(sourceStr) } catch (_: Exception) { continue }
+                setToolEnabled(toolName, source, false)
+            }
+        }
+    }
+
     data class QueryResult(
         val tools: List<Tool>,
         val categoryMatched: Boolean

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -199,15 +199,7 @@ class AssistantViewModel(
             toolRouter.registerLocalTools(localTools)
             toolRouter.registerMcpTools(mcpTools)
 
-            for (entry in disabledTools) {
-                val colonIndex = entry.indexOf(':')
-                if (colonIndex > 0) {
-                    val sourceStr = entry.substring(0, colonIndex)
-                    val toolName = entry.substring(colonIndex + 1)
-                    val source = try { ToolSource.valueOf(sourceStr) } catch (_: Exception) { continue }
-                    toolRouter.setToolEnabled(toolName, source, false)
-                }
-            }
+            toolRouter.applyPersistedDisables(disabledTools)
 
             Log.d(TAG, "ROUTE: query=\"$text\", ${localTools.size} local, ${mcpTools.size} mcp, ${disabledTools.size} disabled")
             val queryResult = toolRouter.getToolsForQuery(text, serverConfigs)

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -1133,6 +1133,42 @@ class ToolRouterTest {
         assertTrue("valid tool unaffected by invalid keys", router.isToolEnabled("list_hosts", ToolSource.LOCAL))
     }
 
+    @Test
+    fun `SHOULD re-include tool in query results WHEN re-enabled after disable`() {
+        val tools = listOf(
+            localTool("list_hosts"),
+            localTool("list_inventories")
+        )
+        router.registerLocalTools(tools)
+        router.setToolEnabled("list_hosts", ToolSource.LOCAL, false)
+
+        val before = router.getToolsForQuery("show my hosts").tools
+        assertFalse("list_hosts" in before.map { it.spec.name })
+
+        router.setToolEnabled("list_hosts", ToolSource.LOCAL, true)
+
+        val after = router.getToolsForQuery("show my hosts").tools
+        assertTrue("list_hosts" in after.map { it.spec.name })
+    }
+
+    @Test
+    fun `SHOULD return categoryMatched true but empty tools WHEN all category tools disabled`() {
+        val tools = listOf(
+            localTool("list_hosts"),
+            localTool("list_inventories"),
+            localTool("list_groups")
+        )
+        router.registerLocalTools(tools)
+        router.setToolEnabled("list_hosts", ToolSource.LOCAL, false)
+        router.setToolEnabled("list_inventories", ToolSource.LOCAL, false)
+        router.setToolEnabled("list_groups", ToolSource.LOCAL, false)
+
+        val result = router.getToolsForQuery("show my hosts")
+
+        assertTrue("category should match", result.categoryMatched)
+        assertTrue("tools should be empty", result.tools.isEmpty())
+    }
+
     // --- getCategoryForTool ---
 
     @Test

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -1069,7 +1069,7 @@ class ToolRouterTest {
     }
 
     @Test
-    fun `SHOULD parse persisted key format and disable tools correctly`() {
+    fun `applyPersistedDisables SHOULD parse key format and disable tools`() {
         val tools = listOf(
             localTool("list_hosts"),
             localTool("list_jobs"),
@@ -1078,16 +1078,7 @@ class ToolRouterTest {
         router.registerLocalTools(tools)
         router.registerMcpTools(listOf(mcpTool("controller.users_list")))
 
-        val persistedKeys = setOf("LOCAL:list_hosts", "MCP:controller.users_list")
-        for (entry in persistedKeys) {
-            val colonIndex = entry.indexOf(':')
-            if (colonIndex > 0) {
-                val sourceStr = entry.substring(0, colonIndex)
-                val toolName = entry.substring(colonIndex + 1)
-                val source = ToolSource.valueOf(sourceStr)
-                router.setToolEnabled(toolName, source, false)
-            }
-        }
+        router.applyPersistedDisables(setOf("LOCAL:list_hosts", "MCP:controller.users_list"))
 
         assertFalse(router.isToolEnabled("list_hosts", ToolSource.LOCAL))
         assertTrue(router.isToolEnabled("list_jobs", ToolSource.LOCAL))
@@ -1134,23 +1125,10 @@ class ToolRouterTest {
     }
 
     @Test
-    fun `SHOULD handle invalid persisted key format gracefully`() {
+    fun `applyPersistedDisables SHOULD skip invalid key formats gracefully`() {
         router.registerLocalTools(listOf(localTool("list_hosts")))
 
-        val invalidKeys = setOf("INVALID:list_hosts", "list_hosts", ":list_hosts")
-        for (entry in invalidKeys) {
-            val colonIndex = entry.indexOf(':')
-            if (colonIndex > 0) {
-                val sourceStr = entry.substring(0, colonIndex)
-                val toolName = entry.substring(colonIndex + 1)
-                try {
-                    val source = ToolSource.valueOf(sourceStr)
-                    router.setToolEnabled(toolName, source, false)
-                } catch (_: IllegalArgumentException) {
-                    // invalid source — skip, matching AssistantViewModel behavior
-                }
-            }
-        }
+        router.applyPersistedDisables(setOf("INVALID:list_hosts", "list_hosts", ":list_hosts"))
 
         assertTrue("valid tool unaffected by invalid keys", router.isToolEnabled("list_hosts", ToolSource.LOCAL))
     }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -1030,6 +1030,131 @@ class ToolRouterTest {
         assertFalse("list_hosts" in names)
     }
 
+    // --- Disabled tools filtering (issue #282) ---
+
+    @Test
+    fun `SHOULD not include disabled MCP tools in query results`() {
+        val tools = listOf(
+            mcpTool("controller.hosts_list"),
+            mcpTool("controller.groups_list"),
+            mcpTool("controller.users_list")
+        )
+        router.registerMcpTools(tools)
+        router.setToolEnabled("controller.hosts_list", ToolSource.MCP, false)
+
+        val result = router.getToolsForQuery("list my hosts", listOf(readWriteConfig)).tools
+        val names = result.map { it.spec.name }
+
+        assertFalse("controller.hosts_list" in names)
+        assertTrue("controller.groups_list" in names)
+    }
+
+    @Test
+    fun `SHOULD exclude multiple disabled tools from query results`() {
+        val tools = listOf(
+            localTool("list_hosts"),
+            localTool("list_inventories"),
+            localTool("list_groups")
+        )
+        router.registerLocalTools(tools)
+        router.setToolEnabled("list_hosts", ToolSource.LOCAL, false)
+        router.setToolEnabled("list_inventories", ToolSource.LOCAL, false)
+
+        val result = router.getToolsForQuery("show my hosts and inventories").tools
+        val names = result.map { it.spec.name }
+
+        assertFalse("list_hosts" in names)
+        assertFalse("list_inventories" in names)
+        assertTrue("list_groups" in names)
+    }
+
+    @Test
+    fun `SHOULD parse persisted key format and disable tools correctly`() {
+        val tools = listOf(
+            localTool("list_hosts"),
+            localTool("list_jobs"),
+            localTool("list_inventories")
+        )
+        router.registerLocalTools(tools)
+        router.registerMcpTools(listOf(mcpTool("controller.users_list")))
+
+        val persistedKeys = setOf("LOCAL:list_hosts", "MCP:controller.users_list")
+        for (entry in persistedKeys) {
+            val colonIndex = entry.indexOf(':')
+            if (colonIndex > 0) {
+                val sourceStr = entry.substring(0, colonIndex)
+                val toolName = entry.substring(colonIndex + 1)
+                val source = ToolSource.valueOf(sourceStr)
+                router.setToolEnabled(toolName, source, false)
+            }
+        }
+
+        assertFalse(router.isToolEnabled("list_hosts", ToolSource.LOCAL))
+        assertTrue(router.isToolEnabled("list_jobs", ToolSource.LOCAL))
+        assertFalse(router.isToolEnabled("controller.users_list", ToolSource.MCP))
+
+        val result = router.getToolsForQuery("show hosts and users").tools
+        val names = result.map { it.spec.name }
+
+        assertFalse("list_hosts" in names)
+        assertFalse("controller.users_list" in names)
+    }
+
+    @Test
+    fun `SHOULD keep manual disables after re-registering local tools`() {
+        router.registerLocalTools(listOf(localTool("list_hosts"), localTool("list_inventories")))
+        router.setToolEnabled("list_hosts", ToolSource.LOCAL, false)
+
+        router.registerLocalTools(listOf(localTool("list_hosts"), localTool("list_inventories")))
+
+        assertFalse(router.isToolEnabled("list_hosts", ToolSource.LOCAL))
+    }
+
+    @Test
+    fun `SHOULD keep manual MCP disables alongside auto-disabled overlaps`() {
+        val local = listOf(localTool("list_hosts"))
+        val mcp = listOf(
+            mcpTool("controller.hosts_list"),
+            mcpTool("controller.users_list")
+        )
+        router.registerLocalTools(local)
+        router.registerMcpTools(mcp)
+
+        router.setToolEnabled("controller.users_list", ToolSource.MCP, false)
+
+        assertFalse("auto-disabled overlap", router.isToolEnabled("controller.hosts_list", ToolSource.MCP))
+        assertFalse("manually disabled", router.isToolEnabled("controller.users_list", ToolSource.MCP))
+
+        val result = router.getToolsForQuery("show hosts and users").tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("list_hosts" in names)
+        assertFalse("controller.hosts_list" in names)
+        assertFalse("controller.users_list" in names)
+    }
+
+    @Test
+    fun `SHOULD handle invalid persisted key format gracefully`() {
+        router.registerLocalTools(listOf(localTool("list_hosts")))
+
+        val invalidKeys = setOf("INVALID:list_hosts", "list_hosts", ":list_hosts")
+        for (entry in invalidKeys) {
+            val colonIndex = entry.indexOf(':')
+            if (colonIndex > 0) {
+                val sourceStr = entry.substring(0, colonIndex)
+                val toolName = entry.substring(colonIndex + 1)
+                try {
+                    val source = ToolSource.valueOf(sourceStr)
+                    router.setToolEnabled(toolName, source, false)
+                } catch (_: IllegalArgumentException) {
+                    // invalid source — skip, matching AssistantViewModel behavior
+                }
+            }
+        }
+
+        assertTrue("valid tool unaffected by invalid keys", router.isToolEnabled("list_hosts", ToolSource.LOCAL))
+    }
+
     // --- getCategoryForTool ---
 
     @Test


### PR DESCRIPTION
## Summary

- Add 7 integration tests to ToolRouterTest verifying that disabled tools are properly excluded from `getToolsForQuery()` results
- Extract `applyPersistedDisables()` into ToolRouter so both production code and tests use the same key-parsing logic (was duplicated in AssistantViewModel)
- Tests cover: MCP tool exclusion, multiple disabled tools, persisted key format parsing, manual disables surviving re-registration, interaction between auto-disabled overlaps and manual disables, and graceful handling of invalid persisted keys

## Changes

- **ToolRouter.kt**: Add `applyPersistedDisables(keys: Set<String>)` method that parses `"SOURCE:name"` format and calls `setToolEnabled()`
- **AssistantViewModel.kt**: Replace inline parsing loop with `toolRouter.applyPersistedDisables(disabledTools)`
- **ToolRouterTest.kt**: 7 new tests in "Disabled tools filtering (issue #282)" section

## Test plan

- [x] All 77 ToolRouter tests pass (70 existing + 7 new)
- [x] All 16 SettingsViewModelTest pass (no breakage from refactor)
- [x] No changes to external behavior

## Review findings addressed

- Dimensional review found 2 tests were duplicating AssistantViewModel parsing logic — fixed by extracting `applyPersistedDisables()` into ToolRouter
- Production bug found (auto-disable overwrites user re-enables) — filed as #288

Closes #282

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>