### PR TITLE
fix: pre-release bug fixes #288, #279, #283

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -134,6 +134,7 @@ dependencies {
     implementation(libs.tink.android)
     implementation(libs.kotlinx.collections.immutable)
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.datetime)
 
     implementation(libs.markdown.renderer)
     implementation(libs.markdown.renderer.m3)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
@@ -28,7 +28,7 @@ import org.koin.android.ext.android.inject
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
-import java.time.ZoneId
+import kotlinx.datetime.TimeZone
 import java.util.concurrent.TimeUnit
 
 class AnsibleJaneApp : Application() {
@@ -84,7 +84,7 @@ class AnsibleJaneApp : Application() {
         appScope.launch {
             val savedZone = userPreferences.timezoneId.first()
             DateFormatter.zoneOverride = savedZone?.let {
-                try { ZoneId.of(it) } catch (_: Exception) { null }
+                try { TimeZone.of(it) } catch (_: Exception) { null }
             }
             DateFormatter.timeFormat = userPreferences.timeFormat.first()
         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -11,7 +11,9 @@ class ToolRouter {
 
     private val localTools = mutableListOf<LocalTool>()
     private val mcpTools = mutableListOf<Tool>()
-    private val disabledTools = mutableSetOf<Pair<String, ToolSource>>()
+    private val autoDisabled = mutableSetOf<Pair<String, ToolSource>>()
+    private val userDisabled = mutableSetOf<Pair<String, ToolSource>>()
+    private val userEnabled = mutableSetOf<Pair<String, ToolSource>>()
 
     private enum class Category(
         val keywords: Set<String>,
@@ -254,23 +256,48 @@ class ToolRouter {
 
     fun setToolEnabled(toolName: String, source: ToolSource, enabled: Boolean) {
         val key = toolName to source
-        if (enabled) disabledTools.remove(key) else disabledTools.add(key)
+        if (enabled) {
+            userDisabled.remove(key)
+            userEnabled.add(key)
+        } else {
+            userDisabled.add(key)
+            userEnabled.remove(key)
+        }
     }
 
     fun isToolEnabled(toolName: String, source: ToolSource): Boolean {
-        return (toolName to source) !in disabledTools
+        val key = toolName to source
+        return key !in userDisabled && (key !in autoDisabled || key in userEnabled)
     }
 
-    fun applyPersistedDisables(keys: Set<String>) {
-        for (entry in keys) {
+    fun isAutoDisabled(toolName: String, source: ToolSource): Boolean {
+        return (toolName to source) in autoDisabled
+    }
+
+    fun applyPersistedState(disabled: Set<String>, enabledOverrides: Set<String>) {
+        for (entry in disabled) {
             val colonIndex = entry.indexOf(':')
             if (colonIndex > 0) {
                 val sourceStr = entry.substring(0, colonIndex)
                 val toolName = entry.substring(colonIndex + 1)
                 val source = try { ToolSource.valueOf(sourceStr) } catch (_: Exception) { continue }
-                setToolEnabled(toolName, source, false)
+                userDisabled.add(toolName to source)
             }
         }
+        for (entry in enabledOverrides) {
+            val colonIndex = entry.indexOf(':')
+            if (colonIndex > 0) {
+                val sourceStr = entry.substring(0, colonIndex)
+                val toolName = entry.substring(colonIndex + 1)
+                val source = try { ToolSource.valueOf(sourceStr) } catch (_: Exception) { continue }
+                userEnabled.add(toolName to source)
+            }
+        }
+    }
+
+    @Deprecated("Use applyPersistedState instead", ReplaceWith("applyPersistedState(keys, emptySet())"))
+    fun applyPersistedDisables(keys: Set<String>) {
+        applyPersistedState(keys, emptySet())
     }
 
     data class QueryResult(
@@ -381,7 +408,7 @@ class ToolRouter {
         for (localName in activeLocalNames) {
             val overlappingMcpNames = OVERLAP_MAPPING[localName] ?: continue
             for (mcpName in overlappingMcpNames) {
-                disabledTools.add(mcpName to ToolSource.MCP)
+                autoDisabled.add(mcpName to ToolSource.MCP)
                 disabledCount++
             }
         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -191,6 +191,7 @@ class AssistantViewModel(
         generateJob?.cancel()
         generateJob = viewModelScope.launch {
             val disabledTools = repository.getDisabledTools()
+            val enabledOverrides = repository.getEnabledOverrides()
 
             mcpServerManager.refreshConnections()
             val mcpTools = mcpServerManager.getAllTools()
@@ -199,7 +200,7 @@ class AssistantViewModel(
             toolRouter.registerLocalTools(localTools)
             toolRouter.registerMcpTools(mcpTools)
 
-            toolRouter.applyPersistedDisables(disabledTools)
+            toolRouter.applyPersistedState(disabledTools, enabledOverrides)
 
             Log.d(TAG, "ROUTE: query=\"$text\", ${localTools.size} local, ${mcpTools.size} mcp, ${disabledTools.size} disabled")
             val queryResult = toolRouter.getToolsForQuery(text, serverConfigs)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/AppDataModule.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/data/AppDataModule.kt
@@ -1,6 +1,8 @@
 package io.github.leogallego.ansiblejane.data
 
 import io.github.leogallego.ansiblejane.di.sharedNetworkModule
+import io.github.leogallego.ansiblejane.notification.ApprovalNotificationManager
+import io.github.leogallego.ansiblejane.notification.IApprovalNotificationManager
 import io.github.leogallego.ansiblejane.platform.BackgroundWorker
 import io.github.leogallego.ansiblejane.platform.ConnectivityObserver
 import io.github.leogallego.ansiblejane.platform.DataStoreFactory
@@ -17,6 +19,7 @@ val platformModule = module {
     single { BackgroundWorker(androidContext()) }
     single { NotificationManager(androidContext()) }
     single { PlatformUtils(androidContext()) }
+    single<IApprovalNotificationManager> { ApprovalNotificationManager() }
 }
 
 val dataModule = module {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalNotificationManager.kt
@@ -16,7 +16,7 @@ import io.github.leogallego.ansiblejane.MainActivity
 import io.github.leogallego.ansiblejane.R
 import io.github.leogallego.ansiblejane.model.WorkflowApproval
 
-class ApprovalNotificationManager {
+class ApprovalNotificationManager : IApprovalNotificationManager {
 
     companion object {
         const val CHANNEL_ID = "workflow_approvals"
@@ -40,7 +40,7 @@ class ApprovalNotificationManager {
         }
     }
 
-    fun showNotification(context: Context, approval: WorkflowApproval): Boolean {
+    override fun showNotification(context: Context, approval: WorkflowApproval): Boolean {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (ContextCompat.checkSelfPermission(
                     context,

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorker.kt
@@ -41,7 +41,7 @@ class ApprovalPollingWorker(
             }
             val apiProvider: IAapApiProvider = get()
             val approvalTracker: ApprovalTracker = get()
-            val notificationManager: ApprovalNotificationManager = get()
+            val notificationManager: IApprovalNotificationManager = get()
 
             val response = apiProvider.getApiService().getWorkflowApprovals(status = "pending")
             val pendingApprovals = response.results

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/IApprovalNotificationManager.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/IApprovalNotificationManager.kt
@@ -1,0 +1,8 @@
+package io.github.leogallego.ansiblejane.notification
+
+import android.content.Context
+import io.github.leogallego.ansiblejane.model.WorkflowApproval
+
+interface IApprovalNotificationManager {
+    fun showNotification(context: Context, approval: WorkflowApproval): Boolean
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
@@ -50,6 +50,7 @@ sealed interface SettingsUiState {
         val expandedMcpServers: Set<String> = emptySet(),
         val expandedCategories: Set<String> = emptySet(),
         val disabledTools: Set<String> = emptySet(),
+        val enabledOverrides: Set<String> = emptySet(),
         val isRefreshingTools: Boolean = false
     ) : SettingsUiState
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
-import java.time.ZoneId
+import kotlinx.datetime.TimeZone
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class SettingsViewModel(
@@ -61,6 +61,7 @@ class SettingsViewModel(
             val initialActiveKey = assistantRepository.activeProviderKeyFlow.first()
 
             val initialDisabledTools = assistantRepository.getDisabledTools()
+            val initialEnabledOverrides = assistantRepository.getEnabledOverrides()
             val initialLocalTools = localTools.map { tool ->
                 LocalToolUiState(
                     name = tool.spec.name,
@@ -78,7 +79,7 @@ class SettingsViewModel(
                 mcpServerManager.connections
             ) { instances, active, timezone, timeFormat, connections ->
                 DateFormatter.zoneOverride = timezone?.let {
-                    try { ZoneId.of(it) } catch (_: Exception) { null }
+                    try { TimeZone.of(it) } catch (_: Exception) { null }
                 }
                 DateFormatter.timeFormat = timeFormat
 
@@ -96,6 +97,7 @@ class SettingsViewModel(
                 val preservedExpandedCats = (current as? SettingsUiState.Ready)?.expandedCategories ?: emptySet()
                 val preservedLocalTools = (current as? SettingsUiState.Ready)?.localTools ?: initialLocalTools
                 val preservedDisabledTools = (current as? SettingsUiState.Ready)?.disabledTools ?: initialDisabledTools
+                val preservedEnabledOverrides = (current as? SettingsUiState.Ready)?.enabledOverrides ?: initialEnabledOverrides
 
                 val allMcpTools = mcpServerManager.getAllTools()
                 val mcpServerTools = allMcpTools
@@ -134,7 +136,8 @@ class SettingsViewModel(
                     mcpServerTools = mcpServerTools,
                     expandedMcpServers = preservedExpandedMcp,
                     expandedCategories = preservedExpandedCats,
-                    disabledTools = preservedDisabledTools
+                    disabledTools = preservedDisabledTools,
+                    enabledOverrides = preservedEnabledOverrides
                 )
             }.collect { state ->
                 _uiState.update { state }
@@ -475,12 +478,23 @@ class SettingsViewModel(
     fun toggleToolEnabled(toolName: String, source: ToolSource, enabled: Boolean) {
         val key = "${source.name}:$toolName"
         viewModelScope.launch {
-            val current = (uiState.value as? SettingsUiState.Ready)?.disabledTools ?: emptySet()
-            val updated = if (enabled) current - key else current + key
-            assistantRepository.saveDisabledTools(updated)
+            val currentDisabled = (uiState.value as? SettingsUiState.Ready)?.disabledTools ?: emptySet()
+            val currentOverrides = (uiState.value as? SettingsUiState.Ready)?.enabledOverrides ?: emptySet()
+            val updatedDisabled: Set<String>
+            val updatedOverrides: Set<String>
+            if (enabled) {
+                updatedDisabled = currentDisabled - key
+                updatedOverrides = currentOverrides + key
+            } else {
+                updatedDisabled = currentDisabled + key
+                updatedOverrides = currentOverrides - key
+            }
+            assistantRepository.saveDisabledTools(updatedDisabled)
+            assistantRepository.saveEnabledOverrides(updatedOverrides)
             updateReady {
                 copy(
-                    disabledTools = updated,
+                    disabledTools = updatedDisabled,
+                    enabledOverrides = updatedOverrides,
                     localTools = localTools.map {
                         if (it.name == toolName && source == ToolSource.LOCAL) {
                             it.copy(isEnabled = enabled)

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -1069,7 +1069,7 @@ class ToolRouterTest {
     }
 
     @Test
-    fun `applyPersistedDisables SHOULD parse key format and disable tools`() {
+    fun `applyPersistedState SHOULD parse key format and disable tools`() {
         val tools = listOf(
             localTool("list_hosts"),
             localTool("list_jobs"),
@@ -1078,7 +1078,7 @@ class ToolRouterTest {
         router.registerLocalTools(tools)
         router.registerMcpTools(listOf(mcpTool("controller.users_list")))
 
-        router.applyPersistedDisables(setOf("LOCAL:list_hosts", "MCP:controller.users_list"))
+        router.applyPersistedState(setOf("LOCAL:list_hosts", "MCP:controller.users_list"), emptySet())
 
         assertFalse(router.isToolEnabled("list_hosts", ToolSource.LOCAL))
         assertTrue(router.isToolEnabled("list_jobs", ToolSource.LOCAL))
@@ -1125,10 +1125,10 @@ class ToolRouterTest {
     }
 
     @Test
-    fun `applyPersistedDisables SHOULD skip invalid key formats gracefully`() {
+    fun `applyPersistedState SHOULD skip invalid key formats gracefully`() {
         router.registerLocalTools(listOf(localTool("list_hosts")))
 
-        router.applyPersistedDisables(setOf("INVALID:list_hosts", "list_hosts", ":list_hosts"))
+        router.applyPersistedState(setOf("INVALID:list_hosts", "list_hosts", ":list_hosts"), emptySet())
 
         assertTrue("valid tool unaffected by invalid keys", router.isToolEnabled("list_hosts", ToolSource.LOCAL))
     }
@@ -1194,6 +1194,59 @@ class ToolRouterTest {
     @Test
     fun `getCategoryForTool SHOULD return null for unknown tool`() {
         assertNull(ToolRouter.getCategoryForTool("nonexistent_tool"))
+    }
+
+    // --- Issue #288: user re-enable survives re-registration ---
+
+    @Test
+    fun `SHOULD preserve user re-enable of auto-disabled MCP tool after re-registration`() {
+        router.registerLocalTools(listOf(localTool("list_hosts")))
+        assertFalse("auto-disabled", router.isToolEnabled("controller.hosts_list", ToolSource.MCP))
+
+        router.setToolEnabled("controller.hosts_list", ToolSource.MCP, true)
+        assertTrue("user re-enabled", router.isToolEnabled("controller.hosts_list", ToolSource.MCP))
+
+        router.registerLocalTools(listOf(localTool("list_hosts")))
+        assertTrue("survives re-registration", router.isToolEnabled("controller.hosts_list", ToolSource.MCP))
+    }
+
+    @Test
+    fun `userEnabled SHOULD override autoDisabled but not userDisabled`() {
+        router.registerLocalTools(listOf(localTool("list_hosts")))
+        router.registerMcpTools(listOf(mcpTool("controller.hosts_list"), mcpTool("controller.users_list")))
+
+        assertTrue(router.isAutoDisabled("controller.hosts_list", ToolSource.MCP))
+        assertFalse(router.isAutoDisabled("controller.users_list", ToolSource.MCP))
+
+        router.setToolEnabled("controller.hosts_list", ToolSource.MCP, true)
+        assertTrue("userEnabled overrides autoDisabled", router.isToolEnabled("controller.hosts_list", ToolSource.MCP))
+
+        router.setToolEnabled("controller.users_list", ToolSource.MCP, false)
+        assertFalse("userDisabled takes effect", router.isToolEnabled("controller.users_list", ToolSource.MCP))
+    }
+
+    @Test
+    fun `applyPersistedState SHOULD populate both sets correctly`() {
+        router.registerLocalTools(listOf(localTool("list_hosts")))
+        router.registerMcpTools(listOf(mcpTool("controller.hosts_list"), mcpTool("controller.users_list")))
+
+        router.applyPersistedState(
+            disabled = setOf("MCP:controller.users_list"),
+            enabledOverrides = setOf("MCP:controller.hosts_list")
+        )
+
+        assertTrue("enabledOverride overrides autoDisabled", router.isToolEnabled("controller.hosts_list", ToolSource.MCP))
+        assertFalse("userDisabled applied", router.isToolEnabled("controller.users_list", ToolSource.MCP))
+    }
+
+    @Test
+    fun `isAutoDisabled SHOULD return correct status`() {
+        router.registerLocalTools(listOf(localTool("list_hosts")))
+        router.registerMcpTools(listOf(mcpTool("controller.hosts_list"), mcpTool("controller.users_list")))
+
+        assertTrue(router.isAutoDisabled("controller.hosts_list", ToolSource.MCP))
+        assertFalse(router.isAutoDisabled("controller.users_list", ToolSource.MCP))
+        assertFalse(router.isAutoDisabled("list_hosts", ToolSource.LOCAL))
     }
 
     @Test

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeApprovalNotificationManager.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeApprovalNotificationManager.kt
@@ -1,0 +1,15 @@
+package io.github.leogallego.ansiblejane.fakes
+
+import android.content.Context
+import io.github.leogallego.ansiblejane.model.WorkflowApproval
+import io.github.leogallego.ansiblejane.notification.IApprovalNotificationManager
+
+class FakeApprovalNotificationManager : IApprovalNotificationManager {
+    val shownApprovals = mutableListOf<WorkflowApproval>()
+    var returnValue = true
+
+    override fun showNotification(context: Context, approval: WorkflowApproval): Boolean {
+        shownApprovals.add(approval)
+        return returnValue
+    }
+}

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
@@ -20,6 +20,7 @@ class FakeAssistantRepository : IAssistantRepository {
     var allConfigs = mutableMapOf<String, LlmProviderConfig>()
     var activeProvider: String? = null
     var savedDisabledTools: Set<String> = emptySet()
+    var savedEnabledOverrides: Set<String> = emptySet()
 
     private val _onHistoryCleared = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     override val onHistoryCleared: SharedFlow<Unit> = _onHistoryCleared.asSharedFlow()
@@ -95,4 +96,10 @@ class FakeAssistantRepository : IAssistantRepository {
     }
 
     override suspend fun getDisabledTools(): Set<String> = savedDisabledTools
+
+    override suspend fun saveEnabledOverrides(tools: Set<String>) {
+        savedEnabledOverrides = tools
+    }
+
+    override suspend fun getEnabledOverrides(): Set<String> = savedEnabledOverrides
 }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorkerTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorkerTest.kt
@@ -6,6 +6,7 @@ import androidx.work.ListenableWorker
 import androidx.work.testing.TestListenableWorkerBuilder
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
+import io.github.leogallego.ansiblejane.fakes.FakeApprovalNotificationManager
 import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
 import io.github.leogallego.ansiblejane.fakes.FakeUserPreferencesRepository
 import io.github.leogallego.ansiblejane.model.AapInstance
@@ -15,6 +16,7 @@ import io.github.leogallego.ansiblejane.network.AapApiClient
 import io.github.leogallego.ansiblejane.network.EdaApiClient
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import io.github.leogallego.ansiblejane.network.PlatformApiClient
+import io.github.leogallego.ansiblejane.notification.IApprovalNotificationManager
 import io.github.leogallego.ansiblejane.platform.DataStoreFactory
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -45,7 +47,7 @@ class ApprovalPollingWorkerTest {
     private lateinit var fakeTokenManager: FakeTokenManager
     private lateinit var fakeUserPreferences: FakeUserPreferencesRepository
     private lateinit var approvalTracker: ApprovalTracker
-    private lateinit var notificationManager: ApprovalNotificationManager
+    private lateinit var fakeNotificationManager: FakeApprovalNotificationManager
     private val json = Json { ignoreUnknownKeys = true }
 
     private val testInstance = AapInstance(
@@ -63,7 +65,7 @@ class ApprovalPollingWorkerTest {
         fakeUserPreferences = FakeUserPreferencesRepository()
         val context: Context = ApplicationProvider.getApplicationContext()
         approvalTracker = ApprovalTracker(DataStoreFactory(context))
-        notificationManager = ApprovalNotificationManager()
+        fakeNotificationManager = FakeApprovalNotificationManager()
         ApprovalNotificationManager.createChannel(context)
     }
 
@@ -113,7 +115,7 @@ class ApprovalPollingWorkerTest {
                 single<IAapApiProvider> { apiProvider }
                 single<IUserPreferencesRepository> { fakeUserPreferences }
                 single { approvalTracker }
-                single { notificationManager }
+                single<IApprovalNotificationManager> { fakeNotificationManager }
             })
         }
     }
@@ -216,5 +218,32 @@ class ApprovalPollingWorkerTest {
 
         assertEquals(ListenableWorker.Result.success(), result)
         assertTrue("Should poll when enabled by default", 10 in approvalTracker.getSeenIds())
+    }
+
+    @Test
+    fun `new approvals trigger showNotification calls`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        startKoinWith(apiProvider = buildMockApiProvider(listOf(approval1, approval2)))
+        val worker = buildWorker()
+
+        worker.doWork()
+
+        val shownIds = fakeNotificationManager.shownApprovals.map { it.id }
+        assertTrue("Approval 10 should be shown", 10 in shownIds)
+        assertTrue("Approval 20 should be shown", 20 in shownIds)
+        assertEquals("Should show exactly 2 notifications", 2, fakeNotificationManager.shownApprovals.size)
+    }
+
+    @Test
+    fun `IDs marked as seen even when notification permission denied`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        fakeNotificationManager.returnValue = false
+        startKoinWith(apiProvider = buildMockApiProvider(listOf(approval1)))
+        val worker = buildWorker()
+
+        worker.doWork()
+
+        assertTrue("Should still mark as seen", 10 in approvalTracker.getSeenIds())
+        assertEquals("Should attempt notification", 1, fakeNotificationManager.shownApprovals.size)
     }
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -93,6 +93,7 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.kotlinx.collections.immutable)
+            implementation(libs.kotlinx.datetime)
 
             implementation(libs.koin.core)
             implementation(libs.koin.compose)

--- a/composeApp/src/androidMain/kotlin/io/github/leogallego/ansiblejane/ui/components/PlatformTimeFormat.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/leogallego/ansiblejane/ui/components/PlatformTimeFormat.android.kt
@@ -1,0 +1,9 @@
+package io.github.leogallego.ansiblejane.ui.components
+
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+
+actual fun isSystem24HourFormat(): Boolean {
+    val pattern = (DateFormat.getTimeInstance(DateFormat.SHORT) as? SimpleDateFormat)?.toPattern() ?: return true
+    return 'H' in pattern
+}

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/dashboard/DashboardViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/dashboard/DashboardViewModel.kt
@@ -24,6 +24,7 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Instant
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
@@ -205,28 +206,25 @@ class DashboardViewModel(
         val tz = TimeZone.currentSystemDefault()
         val now = Clock.System.now()
 
+        fun bucketByDate(jobs: List<Job>): Map<LocalDate, Int> =
+            jobs.mapNotNull { job ->
+                job.finished?.let {
+                    try { Instant.parse(it).toLocalDateTime(tz).date } catch (_: Exception) { null }
+                }
+            }.groupingBy { it }.eachCount()
+
+        val successByDate = bucketByDate(successJobs)
+        val failedByDate = bucketByDate(failedJobs)
+
         return (6 downTo 0).map { daysAgo ->
-            val day = now - daysAgo.days
-            val dayDate = day.toLocalDateTime(tz).date
+            val dayDate = (now - daysAgo.days).toLocalDateTime(tz).date
             val label = dayDate.dayOfWeek.name.take(3).lowercase()
                 .replaceFirstChar { it.uppercase() }
-
-            val successCount = successJobs.count { job ->
-                job.finished?.let {
-                    try {
-                        Instant.parse(it).toLocalDateTime(tz).date == dayDate
-                    } catch (_: Exception) { false }
-                } ?: false
-            }
-            val failCount = failedJobs.count { job ->
-                job.finished?.let {
-                    try {
-                        Instant.parse(it).toLocalDateTime(tz).date == dayDate
-                    } catch (_: Exception) { false }
-                } ?: false
-            }
-
-            DayJobStats(label = label, successful = successCount, failed = failCount)
+            DayJobStats(
+                label = label,
+                successful = successByDate[dayDate] ?: 0,
+                failed = failedByDate[dayDate] ?: 0
+            )
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/dashboard/DashboardViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/dashboard/DashboardViewModel.kt
@@ -20,10 +20,12 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 
 class DashboardViewModel(
     private val jobRepository: IJobRepository,
@@ -77,8 +79,9 @@ class DashboardViewModel(
         _uiState.update { DashboardUiState.Loading }
         dashboardJob = viewModelScope.launch {
             val instance = tokenManager.activeInstance.value ?: return@launch
-            val since24h = Instant.now().minus(24, ChronoUnit.HOURS).toString()
-            val since7d = Instant.now().minus(7, ChronoUnit.DAYS).toString()
+            val now = Clock.System.now()
+            val since24h = (now - 24.hours).toString()
+            val since7d = (now - 7.days).toString()
 
             val activeDeferred = async {
                 jobRepository.getRecentJobs(
@@ -199,26 +202,26 @@ class DashboardViewModel(
         val successJobs = successResult.getOrNull()?.jobs ?: emptyList()
         val failedJobs = failedResult.getOrNull()?.jobs ?: emptyList()
 
-        val dayFormat = DateTimeFormatter.ofPattern("EEE")
-        val zone = ZoneId.systemDefault()
-        val now = Instant.now()
+        val tz = TimeZone.currentSystemDefault()
+        val now = Clock.System.now()
 
         return (6 downTo 0).map { daysAgo ->
-            val day = now.minus(daysAgo.toLong(), ChronoUnit.DAYS)
-            val dayStart = day.atZone(zone).toLocalDate()
-            val label = dayFormat.format(dayStart)
+            val day = now - daysAgo.days
+            val dayDate = day.toLocalDateTime(tz).date
+            val label = dayDate.dayOfWeek.name.take(3).lowercase()
+                .replaceFirstChar { it.uppercase() }
 
             val successCount = successJobs.count { job ->
                 job.finished?.let {
                     try {
-                        Instant.parse(it).atZone(zone).toLocalDate() == dayStart
+                        Instant.parse(it).toLocalDateTime(tz).date == dayDate
                     } catch (_: Exception) { false }
                 } ?: false
             }
             val failCount = failedJobs.count { job ->
                 job.finished?.let {
                     try {
-                        Instant.parse(it).atZone(zone).toLocalDate() == dayStart
+                        Instant.parse(it).toLocalDateTime(tz).date == dayDate
                     } catch (_: Exception) { false }
                 } ?: false
             }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/DateFormatter.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/DateFormatter.kt
@@ -21,13 +21,16 @@ object DateFormatter {
             val instant = Instant.parse(isoTimestamp)
             val local = instant.toLocalDateTime(zone)
             val month = MONTH_ABBREVS[local.month.ordinal]
-            when (timeFormat) {
-                TimeFormat.SYSTEM, TimeFormat.HOURS_24 ->
-                    "$month ${local.day}, ${local.year} ${local.hour.pad()}:${local.minute.pad()}"
-                TimeFormat.HOURS_12 -> {
-                    val (hour12, amPm) = to12Hour(local.hour)
-                    "$month ${local.day}, ${local.year} $hour12:${local.minute.pad()} $amPm"
-                }
+            val use24h = when (timeFormat) {
+                TimeFormat.SYSTEM -> isSystem24HourFormat()
+                TimeFormat.HOURS_24 -> true
+                TimeFormat.HOURS_12 -> false
+            }
+            if (use24h) {
+                "$month ${local.day}, ${local.year} ${local.hour.pad()}:${local.minute.pad()}"
+            } else {
+                val (hour12, amPm) = to12Hour(local.hour)
+                "$month ${local.day}, ${local.year} $hour12:${local.minute.pad()} $amPm"
             }
         } catch (_: Exception) {
             isoTimestamp

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/DateFormatter.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/DateFormatter.kt
@@ -1,41 +1,34 @@
 package io.github.leogallego.ansiblejane.ui.components
 
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
-import java.time.temporal.ChronoUnit
-import java.util.Locale
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 
 object DateFormatter {
 
     @Volatile
-    var zoneOverride: ZoneId? = null
+    var zoneOverride: TimeZone? = null
 
     @Volatile
     var timeFormat: TimeFormat = TimeFormat.SYSTEM
 
-    private val dateOnlyFormatter: DateTimeFormatter =
-        DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
-
-    private val zone: ZoneId
-        get() = zoneOverride ?: ZoneId.systemDefault()
-
-    private val dateTimeFormatter: DateTimeFormatter
-        get() = when (timeFormat) {
-            TimeFormat.SYSTEM ->
-                DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT)
-            TimeFormat.HOURS_24 ->
-                DateTimeFormatter.ofPattern("MMM d, yyyy HH:mm", Locale.getDefault())
-            TimeFormat.HOURS_12 ->
-                DateTimeFormatter.ofPattern("MMM d, yyyy h:mm a", Locale.getDefault())
-        }
+    private val zone: TimeZone
+        get() = zoneOverride ?: TimeZone.currentSystemDefault()
 
     fun formatDateTime(isoTimestamp: String): String {
         return try {
             val instant = Instant.parse(isoTimestamp)
-            val local = instant.atZone(zone)
-            dateTimeFormatter.format(local)
+            val local = instant.toLocalDateTime(zone)
+            val month = MONTH_ABBREVS[local.month.ordinal]
+            when (timeFormat) {
+                TimeFormat.SYSTEM, TimeFormat.HOURS_24 ->
+                    "$month ${local.day}, ${local.year} ${local.hour.pad()}:${local.minute.pad()}"
+                TimeFormat.HOURS_12 -> {
+                    val (hour12, amPm) = to12Hour(local.hour)
+                    "$month ${local.day}, ${local.year} $hour12:${local.minute.pad()} $amPm"
+                }
+            }
         } catch (_: Exception) {
             isoTimestamp
         }
@@ -44,8 +37,9 @@ object DateFormatter {
     fun formatRelative(isoTimestamp: String): String {
         return try {
             val instant = Instant.parse(isoTimestamp)
-            val now = Instant.now()
-            val minutesAgo = ChronoUnit.MINUTES.between(instant, now)
+            val now = Clock.System.now()
+            val diff = now - instant
+            val minutesAgo = diff.inWholeMinutes
             if (minutesAgo < 0) {
                 val minutesUntil = -minutesAgo
                 when {
@@ -72,8 +66,8 @@ object DateFormatter {
     fun formatDuration(isoTimestamp: String): String {
         return try {
             val instant = Instant.parse(isoTimestamp)
-            val now = Instant.now()
-            val minutesAgo = ChronoUnit.MINUTES.between(instant, now).coerceAtLeast(0)
+            val now = Clock.System.now()
+            val minutesAgo = (now - instant).inWholeMinutes.coerceAtLeast(0)
             when {
                 minutesAgo < 1 -> "just now"
                 minutesAgo < 60 -> "${minutesAgo}m"
@@ -89,10 +83,28 @@ object DateFormatter {
     fun formatDate(isoTimestamp: String): String {
         return try {
             val instant = Instant.parse(isoTimestamp)
-            val local = instant.atZone(zone)
-            dateOnlyFormatter.format(local)
+            val local = instant.toLocalDateTime(zone)
+            val month = MONTH_ABBREVS[local.month.ordinal]
+            "$month ${local.day}, ${local.year}"
         } catch (_: Exception) {
             isoTimestamp
         }
     }
+
+    private fun Int.pad(): String = toString().padStart(2, '0')
+
+    private fun to12Hour(hour24: Int): Pair<Int, String> {
+        val amPm = if (hour24 < 12) "AM" else "PM"
+        val hour12 = when {
+            hour24 == 0 -> 12
+            hour24 > 12 -> hour24 - 12
+            else -> hour24
+        }
+        return hour12 to amPm
+    }
+
+    private val MONTH_ABBREVS = arrayOf(
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    )
 }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/PlatformTimeFormat.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/PlatformTimeFormat.kt
@@ -1,0 +1,3 @@
+package io.github.leogallego.ansiblejane.ui.components
+
+expect fun isSystem24HourFormat(): Boolean

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/GeneralTab.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/GeneralTab.kt
@@ -49,7 +49,7 @@ import io.github.leogallego.ansiblejane.AppVersion
 import io.github.leogallego.ansiblejane.model.PollInterval
 import io.github.leogallego.ansiblejane.ui.components.ThemeMode
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
-import java.time.ZoneId
+import kotlinx.datetime.TimeZone
 
 @Composable
 fun GeneralTab(
@@ -109,7 +109,7 @@ private fun DisplaySection(
     onThemeModeSelected: (ThemeMode) -> Unit
 ) {
     var showTimezonePicker by remember { mutableStateOf(false) }
-    val timezoneDisplay = currentTimezone ?: "System (${ZoneId.systemDefault().id})"
+    val timezoneDisplay = currentTimezone ?: "System (${TimeZone.currentSystemDefault().id})"
 
     Text(
         text = "Display",
@@ -212,10 +212,10 @@ private fun TimezonePickerSheet(
     onDismiss: () -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState()
-    val systemZone = ZoneId.systemDefault().id
+    val systemZone = TimeZone.currentSystemDefault().id
 
     val timezones = remember {
-        listOf(null to "System ($systemZone)") + ZoneId.getAvailableZoneIds()
+        listOf(null to "System ($systemZone)") + TimeZone.availableZoneIds
             .filter { it.contains("/") && !it.startsWith("SystemV") }
             .sorted()
             .map { it to it }

--- a/composeApp/src/desktopMain/kotlin/io/github/leogallego/ansiblejane/ui/components/PlatformTimeFormat.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/io/github/leogallego/ansiblejane/ui/components/PlatformTimeFormat.desktop.kt
@@ -1,0 +1,9 @@
+package io.github.leogallego.ansiblejane.ui.components
+
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+
+actual fun isSystem24HourFormat(): Boolean {
+    val pattern = (DateFormat.getTimeInstance(DateFormat.SHORT) as? SimpleDateFormat)?.toPattern() ?: return true
+    return 'H' in pattern
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
@@ -40,6 +40,7 @@ class AssistantRepository(
         val KEY_LLM_CONFIGS = stringPreferencesKey("llm_configs")
         val KEY_ACTIVE_PROVIDER = stringPreferencesKey("active_provider")
         val KEY_DISABLED_TOOLS = stringPreferencesKey("disabled_tools")
+        val KEY_ENABLED_OVERRIDES = stringPreferencesKey("enabled_overrides")
         const val MAX_MESSAGES = 100
     }
 
@@ -234,6 +235,30 @@ class AssistantRepository(
             )
         } catch (e: Exception) {
             DebugLog.w(TAG, "Failed to deserialize disabled tools: ${e.message}")
+            emptySet()
+        }
+    }
+
+    override suspend fun saveEnabledOverrides(tools: Set<String>) {
+        val encoded = json.encodeToString(
+            kotlinx.serialization.builtins.SetSerializer(String.serializer()),
+            tools
+        )
+        assistantDataStore.edit { prefs ->
+            prefs[KEY_ENABLED_OVERRIDES] = encoded
+        }
+    }
+
+    override suspend fun getEnabledOverrides(): Set<String> {
+        val prefs = assistantDataStore.data.first()
+        val encoded = prefs[KEY_ENABLED_OVERRIDES] ?: return emptySet()
+        return try {
+            json.decodeFromString(
+                kotlinx.serialization.builtins.SetSerializer(String.serializer()),
+                encoded
+            )
+        } catch (e: Exception) {
+            DebugLog.w(TAG, "Failed to deserialize enabled overrides: ${e.message}")
             emptySet()
         }
     }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt
@@ -23,4 +23,6 @@ interface IAssistantRepository {
     suspend fun switchActiveProvider(providerKey: String)
     suspend fun saveDisabledTools(tools: Set<String>)
     suspend fun getDisabledTools(): Set<String>
+    suspend fun saveEnabledOverrides(tools: Set<String>)
+    suspend fun getEnabledOverrides(): Set<String>
 }


### PR DESCRIPTION
## Summary

Three pre-release bug fixes in separate commits:

### fix: separate auto-disabled from user-disabled tools in ToolRouter (#288)
- Replace single `disabledTools` set with three independent sets (`autoDisabled`, `userDisabled`, `userEnabled`)
- User re-enables of auto-disabled MCP tools now survive ToolRouter re-registration
- Add `enabledOverrides` persistence via `IAssistantRepository`/`AssistantRepository`
- SettingsViewModel writes symmetrically to both sets on every toggle
- Resolution: `key \!in userDisabled && (key \!in autoDisabled || key in userEnabled)`
- 4 new regression tests + updated existing tests for renamed API

### fix: migrate java.time to kotlinx-datetime in commonMain (#279)
- Replace `java.time.*` with `kotlin.time.Clock`/`Instant` and `kotlinx.datetime.TimeZone`/`toLocalDateTime`
- Files: `DateFormatter.kt`, `GeneralTab.kt`, `DashboardViewModel.kt`, `AnsibleJaneApp.kt`, `SettingsViewModel.kt`
- Add `kotlinx-datetime` dependency to `composeApp` and `app` modules (already in shared)
- Enables desktop target compilation (java.time is JVM-only)
- Known trade-off: English-only date formatting (loses locale-aware formatting)

### fix: extract IApprovalNotificationManager interface for testability (#283)
- New `IApprovalNotificationManager` interface with `showNotification()` method
- `ApprovalNotificationManager` implements the interface
- **Add missing Koin registration** (`single<IApprovalNotificationManager>` in `AppDataModule`)
- `ApprovalPollingWorker` now injects via interface
- New `FakeApprovalNotificationManager` for tests
- 2 new tests: notification delivery verification + permission denied behavior

## Test plan
- [x] ToolRouter tests pass (531 total, all green)
- [x] Desktop compilation succeeds (no java.time references in commonMain)
- [x] ApprovalPollingWorker tests verify notification calls via fake
- [x] Full test suite: `./gradlew :app:testDebugUnitTest :composeApp:desktopTest`

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>