### PR TITLE
fix: tool toggle auto-disabled state + correct 24h format API (#290, #291)

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
@@ -87,6 +87,7 @@ class AnsibleJaneApp : Application() {
                 try { TimeZone.of(it) } catch (_: Exception) { null }
             }
             DateFormatter.timeFormat = userPreferences.timeFormat.first()
+            DateFormatter.systemIs24Hour = android.text.format.DateFormat.is24HourFormat(this@AnsibleJaneApp)
         }
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
@@ -81,13 +81,14 @@ class AnsibleJaneApp : Application() {
                 }
         }
 
+        DateFormatter.systemIs24Hour = android.text.format.DateFormat.is24HourFormat(this)
+
         appScope.launch {
             val savedZone = userPreferences.timezoneId.first()
             DateFormatter.zoneOverride = savedZone?.let {
                 try { TimeZone.of(it) } catch (_: Exception) { null }
             }
             DateFormatter.timeFormat = userPreferences.timeFormat.first()
-            DateFormatter.systemIs24Hour = android.text.format.DateFormat.is24HourFormat(this@AnsibleJaneApp)
         }
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.core.content.ContextCompat
+import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import io.github.leogallego.ansiblejane.assistant.ui.AssistantScreen
 import io.github.leogallego.ansiblejane.navigation.ApprovalDetailRoute
 import io.github.leogallego.ansiblejane.navigation.JobStatusRoute
@@ -80,6 +81,11 @@ class MainActivity : ComponentActivity() {
                 }
             )
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        DateFormatter.systemIs24Hour = android.text.format.DateFormat.is24HourFormat(this)
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalToolUiState.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalToolUiState.kt
@@ -11,5 +11,6 @@ data class McpToolUiState(
     val name: String,
     val description: String,
     val isEnabled: Boolean,
+    val isAutoDisabled: Boolean = false,
     val inputSchema: String? = null
 )

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -54,6 +54,10 @@ class SettingsViewModel(
     private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
+    private val autoDisabledMcpNames: Set<String> = localTools
+        .flatMap { ToolRouter.OVERLAP_MAPPING[it.spec.name] ?: emptySet() }
+        .toSet()
+
     init {
         viewModelScope.launch {
             val configs = assistantRepository.loadAllLlmConfigs()
@@ -78,10 +82,11 @@ class SettingsViewModel(
                 userPreferences.timeFormat,
                 mcpServerManager.connections
             ) { instances, active, timezone, timeFormat, connections ->
-                DateFormatter.zoneOverride = timezone?.let {
+                val newZone = timezone?.let {
                     try { TimeZone.of(it) } catch (_: Exception) { null }
                 }
-                DateFormatter.timeFormat = timeFormat
+                if (DateFormatter.zoneOverride != newZone) DateFormatter.zoneOverride = newZone
+                if (DateFormatter.timeFormat != timeFormat) DateFormatter.timeFormat = timeFormat
 
                 val current = _uiState.value
                 val preservedTab = (current as? SettingsUiState.Ready)?.currentTab ?: SettingsTab.General
@@ -98,11 +103,6 @@ class SettingsViewModel(
                 val preservedLocalTools = (current as? SettingsUiState.Ready)?.localTools ?: initialLocalTools
                 val preservedDisabledTools = (current as? SettingsUiState.Ready)?.disabledTools ?: initialDisabledTools
                 val preservedEnabledOverrides = (current as? SettingsUiState.Ready)?.enabledOverrides ?: initialEnabledOverrides
-
-                val activeLocalNames = localTools.map { it.spec.name }.toSet()
-                val autoDisabledMcpNames = activeLocalNames
-                    .flatMap { ToolRouter.OVERLAP_MAPPING[it] ?: emptySet() }
-                    .toSet()
 
                 val allMcpTools = mcpServerManager.getAllTools()
                 val mcpServerTools = allMcpTools
@@ -490,17 +490,16 @@ class SettingsViewModel(
             val currentDisabled = (uiState.value as? SettingsUiState.Ready)?.disabledTools ?: emptySet()
             val currentOverrides = (uiState.value as? SettingsUiState.Ready)?.enabledOverrides ?: emptySet()
 
-            val isAutoDisabled = source == ToolSource.MCP &&
-                toolName in localTools.flatMap { ToolRouter.OVERLAP_MAPPING[it.spec.name] ?: emptySet() }
+            val isAutoDisabled = source == ToolSource.MCP && toolName in autoDisabledMcpNames
 
             val updatedDisabled: Set<String>
             val updatedOverrides: Set<String>
             if (isAutoDisabled) {
-                updatedDisabled = currentDisabled
+                updatedDisabled = currentDisabled - key
                 updatedOverrides = if (enabled) currentOverrides + key else currentOverrides - key
             } else {
                 updatedDisabled = if (enabled) currentDisabled - key else currentDisabled + key
-                updatedOverrides = currentOverrides
+                updatedOverrides = currentOverrides - key
             }
             assistantRepository.saveToolState(updatedDisabled, updatedOverrides)
             updateReady {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -99,6 +99,11 @@ class SettingsViewModel(
                 val preservedDisabledTools = (current as? SettingsUiState.Ready)?.disabledTools ?: initialDisabledTools
                 val preservedEnabledOverrides = (current as? SettingsUiState.Ready)?.enabledOverrides ?: initialEnabledOverrides
 
+                val activeLocalNames = localTools.map { it.spec.name }.toSet()
+                val autoDisabledMcpNames = activeLocalNames
+                    .flatMap { ToolRouter.OVERLAP_MAPPING[it] ?: emptySet() }
+                    .toSet()
+
                 val allMcpTools = mcpServerManager.getAllTools()
                 val mcpServerTools = allMcpTools
                     .groupBy { it.serverLabel }
@@ -107,10 +112,14 @@ class SettingsViewModel(
                     .mapValues { (_, tools) ->
                         tools.map { tool ->
                             val schema = tool.spec.parametersSchema.takeIf { it.isNotEmpty() }
+                            val isAutoDisabled = tool.spec.name in autoDisabledMcpNames
+                            val key = "MCP:${tool.spec.name}"
                             McpToolUiState(
                                 name = tool.spec.name,
                                 description = tool.spec.description,
-                                isEnabled = "MCP:${tool.spec.name}" !in preservedDisabledTools,
+                                isEnabled = if (isAutoDisabled) key in preservedEnabledOverrides
+                                    else key !in preservedDisabledTools,
+                                isAutoDisabled = isAutoDisabled,
                                 inputSchema = schema?.toString()
                             )
                         }
@@ -480,17 +489,20 @@ class SettingsViewModel(
         viewModelScope.launch {
             val currentDisabled = (uiState.value as? SettingsUiState.Ready)?.disabledTools ?: emptySet()
             val currentOverrides = (uiState.value as? SettingsUiState.Ready)?.enabledOverrides ?: emptySet()
+
+            val isAutoDisabled = source == ToolSource.MCP &&
+                toolName in localTools.flatMap { ToolRouter.OVERLAP_MAPPING[it.spec.name] ?: emptySet() }
+
             val updatedDisabled: Set<String>
             val updatedOverrides: Set<String>
-            if (enabled) {
-                updatedDisabled = currentDisabled - key
-                updatedOverrides = currentOverrides + key
+            if (isAutoDisabled) {
+                updatedDisabled = currentDisabled
+                updatedOverrides = if (enabled) currentOverrides + key else currentOverrides - key
             } else {
-                updatedDisabled = currentDisabled + key
-                updatedOverrides = currentOverrides - key
+                updatedDisabled = if (enabled) currentDisabled - key else currentDisabled + key
+                updatedOverrides = currentOverrides
             }
-            assistantRepository.saveDisabledTools(updatedDisabled)
-            assistantRepository.saveEnabledOverrides(updatedOverrides)
+            assistantRepository.saveToolState(updatedDisabled, updatedOverrides)
             updateReady {
                 copy(
                     disabledTools = updatedDisabled,

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/McpServerCard.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/McpServerCard.kt
@@ -241,6 +241,7 @@ fun McpServerCard(
                                     name = tool.name,
                                     description = tool.description,
                                     isEnabled = tool.isEnabled,
+                                    isAutoDisabled = tool.isAutoDisabled,
                                     testTagPrefix = "switch_mcp_tool",
                                     onToggle = { onToggleTool(tool.name, it) }
                                 )

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolItemRow.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolItemRow.kt
@@ -22,6 +22,7 @@ fun ToolItemRow(
     isEnabled: Boolean,
     testTagPrefix: String,
     modifier: Modifier = Modifier,
+    isAutoDisabled: Boolean = false,
     onToggle: (Boolean) -> Unit
 ) {
     Row(
@@ -45,6 +46,13 @@ fun ToolItemRow(
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
+            if (isAutoDisabled) {
+                Text(
+                    text = "Auto-disabled (overlaps local tool)",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.tertiary
+                )
+            }
         }
         Switch(
             checked = isEnabled,

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
@@ -91,15 +91,7 @@ class FakeAssistantRepository : IAssistantRepository {
         _activeConfigFlow.value = allConfigs[providerKey]
     }
 
-    override suspend fun saveDisabledTools(tools: Set<String>) {
-        savedDisabledTools = tools
-    }
-
     override suspend fun getDisabledTools(): Set<String> = savedDisabledTools
-
-    override suspend fun saveEnabledOverrides(tools: Set<String>) {
-        savedEnabledOverrides = tools
-    }
 
     override suspend fun getEnabledOverrides(): Set<String> = savedEnabledOverrides
 

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
@@ -102,4 +102,9 @@ class FakeAssistantRepository : IAssistantRepository {
     }
 
     override suspend fun getEnabledOverrides(): Set<String> = savedEnabledOverrides
+
+    override suspend fun saveToolState(disabled: Set<String>, enabledOverrides: Set<String>) {
+        savedDisabledTools = disabled
+        savedEnabledOverrides = enabledOverrides
+    }
 }

--- a/composeApp/src/androidMain/kotlin/io/github/leogallego/ansiblejane/ui/components/PlatformTimeFormat.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/leogallego/ansiblejane/ui/components/PlatformTimeFormat.android.kt
@@ -3,7 +3,9 @@ package io.github.leogallego.ansiblejane.ui.components
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 
-actual fun isSystem24HourFormat(): Boolean {
-    val pattern = (DateFormat.getTimeInstance(DateFormat.SHORT) as? SimpleDateFormat)?.toPattern() ?: return true
-    return 'H' in pattern
+private val cached: Boolean by lazy {
+    val pattern = (DateFormat.getTimeInstance(DateFormat.SHORT) as? SimpleDateFormat)?.toPattern() ?: return@lazy true
+    'H' in pattern
 }
+
+actual fun isSystem24HourFormat(): Boolean = cached

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/DateFormatter.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/DateFormatter.kt
@@ -13,6 +13,9 @@ object DateFormatter {
     @Volatile
     var timeFormat: TimeFormat = TimeFormat.SYSTEM
 
+    @Volatile
+    var systemIs24Hour: Boolean? = null
+
     private val zone: TimeZone
         get() = zoneOverride ?: TimeZone.currentSystemDefault()
 
@@ -22,7 +25,7 @@ object DateFormatter {
             val local = instant.toLocalDateTime(zone)
             val month = MONTH_ABBREVS[local.month.ordinal]
             val use24h = when (timeFormat) {
-                TimeFormat.SYSTEM -> isSystem24HourFormat()
+                TimeFormat.SYSTEM -> systemIs24Hour ?: isSystem24HourFormat()
                 TimeFormat.HOURS_24 -> true
                 TimeFormat.HOURS_12 -> false
             }

--- a/composeApp/src/desktopMain/kotlin/io/github/leogallego/ansiblejane/ui/components/PlatformTimeFormat.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/io/github/leogallego/ansiblejane/ui/components/PlatformTimeFormat.desktop.kt
@@ -3,7 +3,9 @@ package io.github.leogallego.ansiblejane.ui.components
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 
-actual fun isSystem24HourFormat(): Boolean {
-    val pattern = (DateFormat.getTimeInstance(DateFormat.SHORT) as? SimpleDateFormat)?.toPattern() ?: return true
-    return 'H' in pattern
+private val cached: Boolean by lazy {
+    val pattern = (DateFormat.getTimeInstance(DateFormat.SHORT) as? SimpleDateFormat)?.toPattern() ?: return@lazy true
+    'H' in pattern
 }
+
+actual fun isSystem24HourFormat(): Boolean = cached

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
@@ -215,16 +215,6 @@ class AssistantRepository(
         }
     }
 
-    override suspend fun saveDisabledTools(tools: Set<String>) {
-        val encoded = json.encodeToString(
-            kotlinx.serialization.builtins.SetSerializer(String.serializer()),
-            tools
-        )
-        assistantDataStore.edit { prefs ->
-            prefs[KEY_DISABLED_TOOLS] = encoded
-        }
-    }
-
     override suspend fun getDisabledTools(): Set<String> {
         val prefs = assistantDataStore.data.first()
         val encoded = prefs[KEY_DISABLED_TOOLS] ?: return emptySet()
@@ -236,16 +226,6 @@ class AssistantRepository(
         } catch (e: Exception) {
             DebugLog.w(TAG, "Failed to deserialize disabled tools: ${e.message}")
             emptySet()
-        }
-    }
-
-    override suspend fun saveEnabledOverrides(tools: Set<String>) {
-        val encoded = json.encodeToString(
-            kotlinx.serialization.builtins.SetSerializer(String.serializer()),
-            tools
-        )
-        assistantDataStore.edit { prefs ->
-            prefs[KEY_ENABLED_OVERRIDES] = encoded
         }
     }
 

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
@@ -262,4 +262,12 @@ class AssistantRepository(
             emptySet()
         }
     }
+
+    override suspend fun saveToolState(disabled: Set<String>, enabledOverrides: Set<String>) {
+        val setSerializer = kotlinx.serialization.builtins.SetSerializer(String.serializer())
+        assistantDataStore.edit { prefs ->
+            prefs[KEY_DISABLED_TOOLS] = json.encodeToString(setSerializer, disabled)
+            prefs[KEY_ENABLED_OVERRIDES] = json.encodeToString(setSerializer, enabledOverrides)
+        }
+    }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt
@@ -25,4 +25,5 @@ interface IAssistantRepository {
     suspend fun getDisabledTools(): Set<String>
     suspend fun saveEnabledOverrides(tools: Set<String>)
     suspend fun getEnabledOverrides(): Set<String>
+    suspend fun saveToolState(disabled: Set<String>, enabledOverrides: Set<String>)
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt
@@ -21,9 +21,7 @@ interface IAssistantRepository {
     val savedConfigsFlow: Flow<Map<String, LlmProviderConfig>>
     val activeProviderKeyFlow: Flow<String?>
     suspend fun switchActiveProvider(providerKey: String)
-    suspend fun saveDisabledTools(tools: Set<String>)
     suspend fun getDisabledTools(): Set<String>
-    suspend fun saveEnabledOverrides(tools: Set<String>)
     suspend fun getEnabledOverrides(): Set<String>
     suspend fun saveToolState(disabled: Set<String>, enabledOverrides: Set<String>)
 }


### PR DESCRIPTION
## Summary

- **#290**: Settings UI tool toggle now correctly reflects auto-disabled state for MCP tools that overlap with local tools.
  - Computes auto-disabled set from `ToolRouter.OVERLAP_MAPPING` (once at init, not per-emission)
  - Shows "Auto-disabled (overlaps local tool)" indicator in ToolItemRow
  - Guards `enabledOverrides` to only apply to auto-disabled tools; cleans stale entries from both sets on toggle
  - Atomic DataStore write via `saveToolState()` — removed old non-atomic `saveDisabledTools`/`saveEnabledOverrides`
- **#291**: `isSystem24HourFormat()` now uses correct Android API (`android.text.format.DateFormat.is24HourFormat(context)`) set synchronously in `Application.onCreate` (no startup race), refreshed on `Activity.onResume`
  - Both Android and desktop actuals cached via `lazy{}`
  - DateFormatter combine side effects guarded with change checks

### Review fixes (commit 2)
- Clean stale `disabledTools` entries when toggling auto-disabled tools (prevents UI/runtime divergence)
- Clean stale `enabledOverrides` entries when toggling non-auto-disabled tools (prevents latent re-enablement)
- Move `systemIs24Hour` init before coroutine (eliminates startup race window)
- Extract `autoDisabledMcpNames` to computed-once field (eliminates duplication + missing `.toSet()`)
- Guard DateFormatter side effects in combine with equality checks

### Cleanup (commit 3)
- Remove dead `saveDisabledTools`/`saveEnabledOverrides` from interface, implementation, and test fake

### Pre-existing issues filed
- ToolRouter state management (TOCTOU race, key collision, per-message instantiation) → commented on #171

Closes #290
Closes #291

## Test plan

- [x] `./gradlew :composeApp:compileKotlinDesktop :app:assembleDebug` passes
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] `./gradlew :shared:jvmTest` passes
- [x] 3 rounds of code review (7-angle initial + regression check + skill-informed final)
- [ ] Deploy to emulator → Settings → Tools → verify auto-disabled MCP tools show indicator
- [ ] Verify time format respects Android 24h toggle in Settings

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>