### PR TITLE
fix: ToolRouter singleton + TOCTOU race + MCP key collision (#171)

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
@@ -15,7 +15,6 @@ import io.github.leogallego.ansiblejane.notification.ApprovalPollingWorker
 import io.github.leogallego.ansiblejane.platform.DataStoreFactory
 import io.github.leogallego.ansiblejane.platform.SecureKeyStorage
 import io.github.leogallego.ansiblejane.platform.TinkMigration
-import io.github.leogallego.ansiblejane.presentation.appPresentationModule
 import io.github.leogallego.ansiblejane.presentation.presentationModule
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import kotlinx.coroutines.CoroutineScope
@@ -39,7 +38,7 @@ class AnsibleJaneApp : Application() {
         startKoin {
             androidLogger()
             androidContext(this@AnsibleJaneApp)
-            modules(dataModule, presentationModule, appPresentationModule, localToolsModule, assistantModule)
+            modules(dataModule, presentationModule, localToolsModule, assistantModule)
         }
 
         appScope.launch(Dispatchers.IO) {

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/AssistantModule.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/AssistantModule.kt
@@ -1,24 +1,18 @@
 package io.github.leogallego.ansiblejane.assistant
 
-import io.github.leogallego.ansiblejane.assistant.data.IAssistantRepository
+import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
 import io.github.leogallego.ansiblejane.assistant.presentation.AssistantViewModel
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.network.createPlatformHttpClient
 import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
 import io.github.leogallego.ansiblejane.network.networkJson
 import io.github.leogallego.ansiblejane.presentation.settings.SettingsViewModel
-import io.ktor.client.HttpClient
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.logging.LogLevel
-import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.sse.SSE
 import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders
-import io.ktor.serialization.kotlinx.json.json
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
-import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val assistantModule = module {
@@ -51,12 +45,20 @@ val assistantModule = module {
         }
     }
 
+    single {
+        ToolRouter(
+            initialLocalTools = getAll<LocalTool>(),
+            repository = get()
+        )
+    }
+
     viewModel {
         AssistantViewModel(
             mcpServerManager = get(),
             repository = get(),
             tokenManager = get(),
             manifestRepository = get(),
+            toolRouter = get(),
             localTools = getAll<LocalTool>()
         )
     }
@@ -70,9 +72,9 @@ val assistantModule = module {
             mcpServerManager = get(),
             manifestRepository = get(),
             instanceDiscovery = get(),
+            toolRouter = get(),
             httpClient = get(named("llm")),
-            json = networkJson,
-            localTools = getAll<LocalTool>()
+            json = networkJson
         )
     }
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -1,19 +1,71 @@
 package io.github.leogallego.ansiblejane.assistant.engine
 
+import io.github.leogallego.ansiblejane.assistant.data.IAssistantRepository
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.McpTool
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.model.McpServerConfig
+import java.util.concurrent.atomic.AtomicBoolean
 
-class ToolRouter {
+class ToolRouter(
+    initialLocalTools: List<LocalTool> = emptyList(),
+    private val repository: IAssistantRepository? = null
+) {
+
+    data class ToolKey(val name: String, val source: ToolSource, val serverLabel: String? = null) {
+        fun toPersistedKey(): String = when (source) {
+            ToolSource.LOCAL -> "LOCAL:$name"
+            ToolSource.MCP -> "MCP:${serverLabel ?: ""}:$name"
+        }
+
+        companion object {
+            fun fromPersistedKey(key: String): ToolKey? {
+                val firstColon = key.indexOf(':')
+                if (firstColon <= 0) return null
+                val sourceStr = key.substring(0, firstColon)
+                val source = try { ToolSource.valueOf(sourceStr) } catch (_: Exception) { return null }
+                val rest = key.substring(firstColon + 1)
+                return when (source) {
+                    ToolSource.LOCAL -> ToolKey(rest, source)
+                    ToolSource.MCP -> {
+                        val secondColon = rest.indexOf(':')
+                        if (secondColon >= 0) {
+                            val serverLabel = rest.substring(0, secondColon).takeIf { it.isNotEmpty() }
+                            val name = rest.substring(secondColon + 1)
+                            ToolKey(name, source, serverLabel)
+                        } else {
+                            null
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     private val localTools = mutableListOf<LocalTool>()
     private val mcpTools = mutableListOf<Tool>()
-    private val autoDisabled = mutableSetOf<Pair<String, ToolSource>>()
-    private val userDisabled = mutableSetOf<Pair<String, ToolSource>>()
-    private val userEnabled = mutableSetOf<Pair<String, ToolSource>>()
+    private val autoDisabled = mutableSetOf<ToolKey>()
+    private val userDisabled = mutableSetOf<ToolKey>()
+    private val userEnabled = mutableSetOf<ToolKey>()
+
+    private val initialized = AtomicBoolean(false)
+
+    init {
+        if (initialLocalTools.isNotEmpty()) {
+            localTools.addAll(initialLocalTools)
+            autoDisableOverlappingMcpTools()
+        }
+    }
+
+    suspend fun initialize() {
+        if (!initialized.compareAndSet(false, true)) return
+        val repo = repository ?: return
+        val disabled = repo.getDisabledTools()
+        val overrides = repo.getEnabledOverrides()
+        applyPersistedState(disabled, overrides)
+    }
 
     private enum class Category(
         val keywords: Set<String>,
@@ -254,8 +306,8 @@ class ToolRouter {
         autoDisableOverlappingMcpTools()
     }
 
-    fun setToolEnabled(toolName: String, source: ToolSource, enabled: Boolean) {
-        val key = toolName to source
+    fun setToolEnabled(toolName: String, source: ToolSource, serverLabel: String? = null, enabled: Boolean) {
+        val key = ToolKey(toolName, source, serverLabel)
         if (enabled) {
             userDisabled.remove(key)
             userEnabled.add(key)
@@ -265,39 +317,48 @@ class ToolRouter {
         }
     }
 
-    fun isToolEnabled(toolName: String, source: ToolSource): Boolean {
-        val key = toolName to source
-        return key !in userDisabled && (key !in autoDisabled || key in userEnabled)
+    fun isToolEnabled(toolName: String, source: ToolSource, serverLabel: String? = null): Boolean {
+        val key = ToolKey(toolName, source, serverLabel)
+        val isAuto = isAutoDisabledByName(toolName, source)
+        return key !in userDisabled && (!isAuto || key in userEnabled)
     }
 
-    fun isAutoDisabled(toolName: String, source: ToolSource): Boolean {
-        return (toolName to source) in autoDisabled
+    fun isAutoDisabled(toolName: String, source: ToolSource, serverLabel: String? = null): Boolean {
+        return isAutoDisabledByName(toolName, source)
     }
+
+    private fun isAutoDisabledByName(toolName: String, source: ToolSource): Boolean {
+        return autoDisabled.any { it.name == toolName && it.source == source }
+    }
+
+    suspend fun toggleToolEnabled(toolName: String, source: ToolSource, serverLabel: String? = null, enabled: Boolean) {
+        val key = ToolKey(toolName, source, serverLabel)
+        val isAuto = isAutoDisabledByName(toolName, source)
+        if (isAuto) {
+            userDisabled.remove(key)
+            if (enabled) userEnabled.add(key) else userEnabled.remove(key)
+        } else {
+            if (enabled) userDisabled.remove(key) else userDisabled.add(key)
+            userEnabled.remove(key)
+        }
+        persistState()
+    }
+
+    fun getPersistedDisabled(): Set<String> =
+        userDisabled.map { it.toPersistedKey() }.toSet()
+
+    fun getPersistedOverrides(): Set<String> =
+        userEnabled.map { it.toPersistedKey() }.toSet()
 
     fun applyPersistedState(disabled: Set<String>, enabledOverrides: Set<String>) {
         for (entry in disabled) {
-            val colonIndex = entry.indexOf(':')
-            if (colonIndex > 0) {
-                val sourceStr = entry.substring(0, colonIndex)
-                val toolName = entry.substring(colonIndex + 1)
-                val source = try { ToolSource.valueOf(sourceStr) } catch (_: Exception) { continue }
-                userDisabled.add(toolName to source)
-            }
+            val key = ToolKey.fromPersistedKey(entry) ?: continue
+            userDisabled.add(key)
         }
         for (entry in enabledOverrides) {
-            val colonIndex = entry.indexOf(':')
-            if (colonIndex > 0) {
-                val sourceStr = entry.substring(0, colonIndex)
-                val toolName = entry.substring(colonIndex + 1)
-                val source = try { ToolSource.valueOf(sourceStr) } catch (_: Exception) { continue }
-                userEnabled.add(toolName to source)
-            }
+            val key = ToolKey.fromPersistedKey(entry) ?: continue
+            userEnabled.add(key)
         }
-    }
-
-    @Deprecated("Use applyPersistedState instead", ReplaceWith("applyPersistedState(keys, emptySet())"))
-    fun applyPersistedDisables(keys: Set<String>) {
-        applyPersistedState(keys, emptySet())
     }
 
     data class QueryResult(
@@ -337,7 +398,7 @@ class ToolRouter {
         }
 
         val filteredMcp = mcpTools.filter { tool ->
-            val isEnabled = isToolEnabled(tool.spec.name, ToolSource.MCP)
+            val isEnabled = isToolEnabled(tool.spec.name, ToolSource.MCP, tool.serverLabel)
 
             val toolToolset = (tool as? McpTool)?.toolset
             val toolsetCategories = toolToolset?.let { TOOLSET_CATEGORY_MAP[it] }
@@ -402,13 +463,18 @@ class ToolRouter {
         return result
     }
 
+    private suspend fun persistState() {
+        repository?.saveToolState(getPersistedDisabled(), getPersistedOverrides())
+    }
+
     private fun autoDisableOverlappingMcpTools() {
+        autoDisabled.clear()
         val activeLocalNames = localTools.map { it.spec.name }.toSet()
         var disabledCount = 0
         for (localName in activeLocalNames) {
             val overlappingMcpNames = OVERLAP_MAPPING[localName] ?: continue
             for (mcpName in overlappingMcpNames) {
-                autoDisabled.add(mcpName to ToolSource.MCP)
+                autoDisabled.add(ToolKey(mcpName, ToolSource.MCP))
                 disabledCount++
             }
         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -339,7 +339,7 @@ class ToolRouter(
     }
 
     suspend fun toggleToolEnabled(toolName: String, source: ToolSource, serverLabel: String? = null, enabled: Boolean) {
-        synchronized(this) {
+        val snapshot = synchronized(this) {
             val key = ToolKey(toolName, source, serverLabel)
             val isAuto = isAutoDisabledByName(toolName, source)
             if (isAuto) {
@@ -349,8 +349,12 @@ class ToolRouter(
                 if (enabled) userDisabled.remove(key) else userDisabled.add(key)
                 userEnabled.remove(key)
             }
+            Pair(
+                userDisabled.map { it.toPersistedKey() }.toSet(),
+                userEnabled.map { it.toPersistedKey() }.toSet()
+            )
         }
-        persistState()
+        repository?.saveToolState(snapshot.first, snapshot.second)
     }
 
     @Synchronized

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -1,5 +1,6 @@
 package io.github.leogallego.ansiblejane.assistant.engine
 
+import androidx.annotation.VisibleForTesting
 import io.github.leogallego.ansiblejane.assistant.data.IAssistantRepository
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
@@ -294,18 +295,22 @@ class ToolRouter(
         }
     }
 
+    @Synchronized
     fun registerLocalTools(tools: List<LocalTool>) {
         localTools.clear()
         localTools.addAll(tools)
         autoDisableOverlappingMcpTools()
     }
 
+    @Synchronized
     fun registerMcpTools(tools: List<Tool>) {
         mcpTools.clear()
         mcpTools.addAll(tools)
         autoDisableOverlappingMcpTools()
     }
 
+    @VisibleForTesting
+    @Synchronized
     fun setToolEnabled(toolName: String, source: ToolSource, serverLabel: String? = null, enabled: Boolean) {
         val key = ToolKey(toolName, source, serverLabel)
         if (enabled) {
@@ -317,12 +322,14 @@ class ToolRouter(
         }
     }
 
+    @Synchronized
     fun isToolEnabled(toolName: String, source: ToolSource, serverLabel: String? = null): Boolean {
         val key = ToolKey(toolName, source, serverLabel)
         val isAuto = isAutoDisabledByName(toolName, source)
         return key !in userDisabled && (!isAuto || key in userEnabled)
     }
 
+    @Synchronized
     fun isAutoDisabled(toolName: String, source: ToolSource, serverLabel: String? = null): Boolean {
         return isAutoDisabledByName(toolName, source)
     }
@@ -332,24 +339,29 @@ class ToolRouter(
     }
 
     suspend fun toggleToolEnabled(toolName: String, source: ToolSource, serverLabel: String? = null, enabled: Boolean) {
-        val key = ToolKey(toolName, source, serverLabel)
-        val isAuto = isAutoDisabledByName(toolName, source)
-        if (isAuto) {
-            userDisabled.remove(key)
-            if (enabled) userEnabled.add(key) else userEnabled.remove(key)
-        } else {
-            if (enabled) userDisabled.remove(key) else userDisabled.add(key)
-            userEnabled.remove(key)
+        synchronized(this) {
+            val key = ToolKey(toolName, source, serverLabel)
+            val isAuto = isAutoDisabledByName(toolName, source)
+            if (isAuto) {
+                userDisabled.remove(key)
+                if (enabled) userEnabled.add(key) else userEnabled.remove(key)
+            } else {
+                if (enabled) userDisabled.remove(key) else userDisabled.add(key)
+                userEnabled.remove(key)
+            }
         }
         persistState()
     }
 
+    @Synchronized
     fun getPersistedDisabled(): Set<String> =
         userDisabled.map { it.toPersistedKey() }.toSet()
 
+    @Synchronized
     fun getPersistedOverrides(): Set<String> =
         userEnabled.map { it.toPersistedKey() }.toSet()
 
+    @Synchronized
     fun applyPersistedState(disabled: Set<String>, enabledOverrides: Set<String>) {
         for (entry in disabled) {
             val key = ToolKey.fromPersistedKey(entry) ?: continue
@@ -366,6 +378,7 @@ class ToolRouter(
         val categoryMatched: Boolean
     )
 
+    @Synchronized
     fun getToolsForQuery(
         query: String,
         serverConfigs: List<McpServerConfig> = emptyList()
@@ -412,10 +425,7 @@ class ToolRouter(
             }
 
             val passesReadOnly = if (readOnlyLabels.isNotEmpty()) {
-                val serverLabel = tool.spec.description
-                    .substringAfter("[", "")
-                    .substringBefore("]", "")
-                if (serverLabel in readOnlyLabels) {
+                if (tool.serverLabel in readOnlyLabels) {
                     WRITE_ACTIONS.none { action -> tool.spec.name.endsWith(action) }
                 } else {
                     true
@@ -456,6 +466,7 @@ class ToolRouter(
             .map { it.first }
     }
 
+    @Synchronized
     fun getAllRegisteredTools(): List<Pair<Tool, ToolSource>> {
         val result = mutableListOf<Pair<Tool, ToolSource>>()
         localTools.forEach { result.add(it to ToolSource.LOCAL) }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -18,7 +18,6 @@ import io.github.leogallego.ansiblejane.assistant.llm.KoogLlmProvider
 import io.github.leogallego.ansiblejane.assistant.llm.LlmProvider
 import io.github.leogallego.ansiblejane.assistant.tools.CachedMcpTool
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.assistant.tools.local.ListToolsLocalTool
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.data.IToolManifestRepository
@@ -43,6 +42,7 @@ class AssistantViewModel(
     private val repository: IAssistantRepository,
     private val tokenManager: ITokenManager,
     private val manifestRepository: IToolManifestRepository,
+    private val toolRouter: ToolRouter,
     private val localTools: List<LocalTool> = emptyList()
 ) : ViewModel() {
 
@@ -190,19 +190,14 @@ class AssistantViewModel(
 
         generateJob?.cancel()
         generateJob = viewModelScope.launch {
-            val disabledTools = repository.getDisabledTools()
-            val enabledOverrides = repository.getEnabledOverrides()
+            toolRouter.initialize()
 
             mcpServerManager.refreshConnections()
             val mcpTools = mcpServerManager.getAllTools()
             val serverConfigs = tokenManager.activeInstance.value?.mcpServerUrls ?: emptyList()
-            val toolRouter = ToolRouter()
-            toolRouter.registerLocalTools(localTools)
             toolRouter.registerMcpTools(mcpTools)
 
-            toolRouter.applyPersistedState(disabledTools, enabledOverrides)
-
-            Log.d(TAG, "ROUTE: query=\"$text\", ${localTools.size} local, ${mcpTools.size} mcp, ${disabledTools.size} disabled")
+            Log.d(TAG, "ROUTE: query=\"$text\", ${localTools.size} local, ${mcpTools.size} mcp")
             val queryResult = toolRouter.getToolsForQuery(text, serverConfigs)
             val mode = config.tokenSavingMode
             Log.d(TAG, "ROUTE: categoryMatched=${queryResult.categoryMatched}, " +

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/AppPresentationModule.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/AppPresentationModule.kt
@@ -1,9 +1,6 @@
 package io.github.leogallego.ansiblejane.presentation
 
-import io.github.leogallego.ansiblejane.presentation.settings.SettingsViewModel
-import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val appPresentationModule = module {
-    viewModelOf(::SettingsViewModel)
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/AppPresentationModule.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/AppPresentationModule.kt
@@ -1,6 +1,0 @@
-package io.github.leogallego.ansiblejane.presentation
-
-import org.koin.dsl.module
-
-val appPresentationModule = module {
-}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
@@ -49,8 +49,6 @@ sealed interface SettingsUiState {
         val mcpServerTools: Map<String, List<McpToolUiState>> = emptyMap(),
         val expandedMcpServers: Set<String> = emptySet(),
         val expandedCategories: Set<String> = emptySet(),
-        val disabledTools: Set<String> = emptySet(),
-        val enabledOverrides: Set<String> = emptySet(),
         val isRefreshingTools: Boolean = false
     ) : SettingsUiState
 }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -493,9 +493,9 @@ class SettingsViewModel(
                             it.copy(isEnabled = enabled)
                         } else it
                     },
-                    mcpServerTools = mcpServerTools.mapValues { (_, tools) ->
+                    mcpServerTools = mcpServerTools.mapValues { (server, tools) ->
                         tools.map {
-                            if (it.name == toolName && source == ToolSource.MCP) {
+                            if (it.name == toolName && source == ToolSource.MCP && server == serverLabel) {
                                 it.copy(isEnabled = enabled)
                             } else it
                         }

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -97,10 +97,6 @@ class SettingsViewModel(
                 val preservedExpandedMcp = (current as? SettingsUiState.Ready)?.expandedMcpServers ?: emptySet()
                 val preservedExpandedCats = (current as? SettingsUiState.Ready)?.expandedCategories ?: emptySet()
                 val preservedLocalTools = (current as? SettingsUiState.Ready)?.localTools ?: initialLocalTools
-                val preservedDisabledTools = (current as? SettingsUiState.Ready)?.disabledTools
-                    ?: toolRouter.getPersistedDisabled()
-                val preservedEnabledOverrides = (current as? SettingsUiState.Ready)?.enabledOverrides
-                    ?: toolRouter.getPersistedOverrides()
 
                 val allMcpTools = mcpServerManager.getAllTools()
                 val mcpServerTools = allMcpTools
@@ -139,9 +135,7 @@ class SettingsViewModel(
                     localTools = preservedLocalTools,
                     mcpServerTools = mcpServerTools,
                     expandedMcpServers = preservedExpandedMcp,
-                    expandedCategories = preservedExpandedCats,
-                    disabledTools = preservedDisabledTools,
-                    enabledOverrides = preservedEnabledOverrides
+                    expandedCategories = preservedExpandedCats
                 )
             }.collect { state ->
                 _uiState.update { state }
@@ -482,12 +476,8 @@ class SettingsViewModel(
     fun toggleToolEnabled(toolName: String, source: ToolSource, serverLabel: String? = null, enabled: Boolean) {
         viewModelScope.launch {
             toolRouter.toggleToolEnabled(toolName, source, serverLabel, enabled)
-            val updatedDisabled = toolRouter.getPersistedDisabled()
-            val updatedOverrides = toolRouter.getPersistedOverrides()
             updateReady {
                 copy(
-                    disabledTools = updatedDisabled,
-                    enabledOverrides = updatedOverrides,
                     localTools = localTools.map {
                         if (it.name == toolName && source == ToolSource.LOCAL) {
                             it.copy(isEnabled = enabled)

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -15,10 +15,8 @@ import io.github.leogallego.ansiblejane.network.ApiVersion
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import io.github.leogallego.ansiblejane.network.InstanceDiscovery
 import io.github.leogallego.ansiblejane.network.createPlatformHttpClient
-import io.github.leogallego.ansiblejane.network.mcp.McpConnectionState
 import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
 import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
-import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
@@ -46,34 +44,32 @@ class SettingsViewModel(
     private val mcpServerManager: McpServerManager,
     private val manifestRepository: IToolManifestRepository,
     private val instanceDiscovery: InstanceDiscovery,
+    private val toolRouter: ToolRouter,
     private val httpClient: HttpClient,
-    private val json: Json,
-    private val localTools: List<LocalTool> = emptyList()
+    private val json: Json
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
-    private val autoDisabledMcpNames: Set<String> = localTools
-        .flatMap { ToolRouter.OVERLAP_MAPPING[it.spec.name] ?: emptySet() }
-        .toSet()
-
     init {
         viewModelScope.launch {
+            toolRouter.initialize()
+
             val configs = assistantRepository.loadAllLlmConfigs()
             val activeConfig = assistantRepository.loadLlmConfig()
             val initialActiveKey = assistantRepository.activeProviderKeyFlow.first()
 
-            val initialDisabledTools = assistantRepository.getDisabledTools()
-            val initialEnabledOverrides = assistantRepository.getEnabledOverrides()
-            val initialLocalTools = localTools.map { tool ->
-                LocalToolUiState(
-                    name = tool.spec.name,
-                    description = tool.spec.description,
-                    category = ToolRouter.getCategoryForTool(tool.spec.name) ?: "OTHER",
-                    isEnabled = "LOCAL:${tool.spec.name}" !in initialDisabledTools
-                )
-            }
+            val initialLocalTools = toolRouter.getAllRegisteredTools()
+                .filter { (_, source) -> source == ToolSource.LOCAL }
+                .map { (tool, _) ->
+                    LocalToolUiState(
+                        name = tool.spec.name,
+                        description = tool.spec.description,
+                        category = ToolRouter.getCategoryForTool(tool.spec.name) ?: "OTHER",
+                        isEnabled = toolRouter.isToolEnabled(tool.spec.name, ToolSource.LOCAL)
+                    )
+                }
 
             combine(
                 tokenManager.instances,
@@ -101,8 +97,10 @@ class SettingsViewModel(
                 val preservedExpandedMcp = (current as? SettingsUiState.Ready)?.expandedMcpServers ?: emptySet()
                 val preservedExpandedCats = (current as? SettingsUiState.Ready)?.expandedCategories ?: emptySet()
                 val preservedLocalTools = (current as? SettingsUiState.Ready)?.localTools ?: initialLocalTools
-                val preservedDisabledTools = (current as? SettingsUiState.Ready)?.disabledTools ?: initialDisabledTools
-                val preservedEnabledOverrides = (current as? SettingsUiState.Ready)?.enabledOverrides ?: initialEnabledOverrides
+                val preservedDisabledTools = (current as? SettingsUiState.Ready)?.disabledTools
+                    ?: toolRouter.getPersistedDisabled()
+                val preservedEnabledOverrides = (current as? SettingsUiState.Ready)?.enabledOverrides
+                    ?: toolRouter.getPersistedOverrides()
 
                 val allMcpTools = mcpServerManager.getAllTools()
                 val mcpServerTools = allMcpTools
@@ -112,14 +110,11 @@ class SettingsViewModel(
                     .mapValues { (_, tools) ->
                         tools.map { tool ->
                             val schema = tool.spec.parametersSchema.takeIf { it.isNotEmpty() }
-                            val isAutoDisabled = tool.spec.name in autoDisabledMcpNames
-                            val key = "MCP:${tool.spec.name}"
                             McpToolUiState(
                                 name = tool.spec.name,
                                 description = tool.spec.description,
-                                isEnabled = if (isAutoDisabled) key in preservedEnabledOverrides
-                                    else key !in preservedDisabledTools,
-                                isAutoDisabled = isAutoDisabled,
+                                isEnabled = toolRouter.isToolEnabled(tool.spec.name, ToolSource.MCP, tool.serverLabel),
+                                isAutoDisabled = toolRouter.isAutoDisabled(tool.spec.name, ToolSource.MCP, tool.serverLabel),
                                 inputSchema = schema?.toString()
                             )
                         }
@@ -484,24 +479,11 @@ class SettingsViewModel(
         }
     }
 
-    fun toggleToolEnabled(toolName: String, source: ToolSource, enabled: Boolean) {
-        val key = "${source.name}:$toolName"
+    fun toggleToolEnabled(toolName: String, source: ToolSource, serverLabel: String? = null, enabled: Boolean) {
         viewModelScope.launch {
-            val currentDisabled = (uiState.value as? SettingsUiState.Ready)?.disabledTools ?: emptySet()
-            val currentOverrides = (uiState.value as? SettingsUiState.Ready)?.enabledOverrides ?: emptySet()
-
-            val isAutoDisabled = source == ToolSource.MCP && toolName in autoDisabledMcpNames
-
-            val updatedDisabled: Set<String>
-            val updatedOverrides: Set<String>
-            if (isAutoDisabled) {
-                updatedDisabled = currentDisabled - key
-                updatedOverrides = if (enabled) currentOverrides + key else currentOverrides - key
-            } else {
-                updatedDisabled = if (enabled) currentDisabled - key else currentDisabled + key
-                updatedOverrides = currentOverrides - key
-            }
-            assistantRepository.saveToolState(updatedDisabled, updatedOverrides)
+            toolRouter.toggleToolEnabled(toolName, source, serverLabel, enabled)
+            val updatedDisabled = toolRouter.getPersistedDisabled()
+            val updatedOverrides = toolRouter.getPersistedOverrides()
             updateReady {
                 copy(
                     disabledTools = updatedDisabled,

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
@@ -74,7 +74,7 @@ fun SettingsScreen(
                         viewModel.toggleUseInstanceAuth(url, useInstanceAuth)
                     },
                     onToggleServerEnabled = { url, enabled -> viewModel.toggleServerEnabled(url, enabled) },
-                    onToggleToolEnabled = { name, source, enabled -> viewModel.toggleToolEnabled(name, source, enabled) },
+                    onToggleToolEnabled = { name, source, serverLabel, enabled -> viewModel.toggleToolEnabled(name, source, serverLabel, enabled) },
                     onToggleExpandMcpServer = { viewModel.toggleExpandMcpServer(it) },
                     onToggleExpandCategory = { viewModel.toggleExpandCategory(it) },
                     onRefreshMcpServer = { viewModel.refreshMcpServer(it) },
@@ -114,7 +114,7 @@ private fun SettingsContent(
     onToggleReadOnly: (String, Boolean) -> Unit,
     onToggleUseInstanceAuth: (String, Boolean) -> Unit,
     onToggleServerEnabled: (String, Boolean) -> Unit,
-    onToggleToolEnabled: (String, ToolSource, Boolean) -> Unit,
+    onToggleToolEnabled: (String, ToolSource, String?, Boolean) -> Unit,
     onToggleExpandMcpServer: (String) -> Unit,
     onToggleExpandCategory: (String) -> Unit,
     onRefreshMcpServer: (String) -> Unit,

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolsTab.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolsTab.kt
@@ -52,7 +52,7 @@ fun ToolsTab(
     onToggleReadOnly: (url: String, readOnly: Boolean) -> Unit,
     onToggleUseInstanceAuth: (url: String, useInstanceAuth: Boolean) -> Unit,
     onToggleServerEnabled: (url: String, enabled: Boolean) -> Unit,
-    onToggleToolEnabled: (name: String, source: ToolSource, enabled: Boolean) -> Unit,
+    onToggleToolEnabled: (name: String, source: ToolSource, serverLabel: String?, enabled: Boolean) -> Unit,
     onToggleExpandMcpServer: (label: String) -> Unit,
     onToggleExpandCategory: (category: String) -> Unit,
     onRefreshMcpServer: (label: String) -> Unit,
@@ -107,7 +107,7 @@ fun ToolsTab(
                     onToggleReadOnly = { onToggleReadOnly(server.url, it) },
                     onToggleUseInstanceAuth = { onToggleUseInstanceAuth(server.url, it) },
                     onToggleTool = { name, enabled ->
-                        onToggleToolEnabled(name, ToolSource.MCP, enabled)
+                        onToggleToolEnabled(name, ToolSource.MCP, server.label, enabled)
                     },
                     onRefresh = { onRefreshMcpServer(server.label) },
                     onRemove = { onRemoveMcpServer(server.url) }
@@ -161,7 +161,7 @@ fun ToolsTab(
             expandedCategories = expandedCategories,
             onToggleCategory = onToggleExpandCategory,
             onToggleTool = { name, enabled ->
-                onToggleToolEnabled(name, ToolSource.LOCAL, enabled)
+                onToggleToolEnabled(name, ToolSource.LOCAL, null, enabled)
             }
         )
     }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -20,6 +20,7 @@ class ToolRouterTest {
     private lateinit var router: ToolRouter
 
     private fun mcpTool(name: String, serverLabel: String = "aap") = object : Tool {
+        override val serverLabel: String = serverLabel
         override val spec = ToolSpec(name, "[$serverLabel] description of $name", JsonObject(emptyMap()))
         override suspend fun execute(args: JsonObject) = ToolResult(success = true)
     }
@@ -151,8 +152,8 @@ class ToolRouterTest {
         router.registerLocalTools(listOf(localTool("list_job_templates")))
         assertFalse(router.isToolEnabled("controller.job_templates_list", ToolSource.MCP))
 
-        router.setToolEnabled("controller.job_templates_list", ToolSource.MCP, true)
-        assertTrue(router.isToolEnabled("controller.job_templates_list", ToolSource.MCP))
+        router.setToolEnabled("controller.job_templates_list", ToolSource.MCP, "aap", true)
+        assertTrue(router.isToolEnabled("controller.job_templates_list", ToolSource.MCP, "aap"))
     }
 
     @Test
@@ -160,7 +161,7 @@ class ToolRouterTest {
         router.registerLocalTools(listOf(localTool("list_hosts")))
         assertTrue(router.isToolEnabled("list_hosts", ToolSource.LOCAL))
 
-        router.setToolEnabled("list_hosts", ToolSource.LOCAL, false)
+        router.setToolEnabled("list_hosts", ToolSource.LOCAL, enabled = false)
         assertFalse(router.isToolEnabled("list_hosts", ToolSource.LOCAL))
     }
 
@@ -171,7 +172,7 @@ class ToolRouterTest {
             localTool("list_inventories")
         )
         router.registerLocalTools(tools)
-        router.setToolEnabled("list_hosts", ToolSource.LOCAL, false)
+        router.setToolEnabled("list_hosts", ToolSource.LOCAL, enabled = false)
 
         val result = router.getToolsForQuery("show my hosts and inventories").tools
         val names = result.map { it.spec.name }
@@ -1040,7 +1041,7 @@ class ToolRouterTest {
             mcpTool("controller.users_list")
         )
         router.registerMcpTools(tools)
-        router.setToolEnabled("controller.hosts_list", ToolSource.MCP, false)
+        router.setToolEnabled("controller.hosts_list", ToolSource.MCP, "aap", false)
 
         val result = router.getToolsForQuery("list my hosts", listOf(readWriteConfig)).tools
         val names = result.map { it.spec.name }
@@ -1057,8 +1058,8 @@ class ToolRouterTest {
             localTool("list_groups")
         )
         router.registerLocalTools(tools)
-        router.setToolEnabled("list_hosts", ToolSource.LOCAL, false)
-        router.setToolEnabled("list_inventories", ToolSource.LOCAL, false)
+        router.setToolEnabled("list_hosts", ToolSource.LOCAL, enabled = false)
+        router.setToolEnabled("list_inventories", ToolSource.LOCAL, enabled = false)
 
         val result = router.getToolsForQuery("show my hosts and inventories").tools
         val names = result.map { it.spec.name }
@@ -1078,11 +1079,11 @@ class ToolRouterTest {
         router.registerLocalTools(tools)
         router.registerMcpTools(listOf(mcpTool("controller.users_list")))
 
-        router.applyPersistedState(setOf("LOCAL:list_hosts", "MCP:controller.users_list"), emptySet())
+        router.applyPersistedState(setOf("LOCAL:list_hosts", "MCP:aap:controller.users_list"), emptySet())
 
         assertFalse(router.isToolEnabled("list_hosts", ToolSource.LOCAL))
         assertTrue(router.isToolEnabled("list_jobs", ToolSource.LOCAL))
-        assertFalse(router.isToolEnabled("controller.users_list", ToolSource.MCP))
+        assertFalse(router.isToolEnabled("controller.users_list", ToolSource.MCP, "aap"))
 
         val result = router.getToolsForQuery("show hosts and users").tools
         val names = result.map { it.spec.name }
@@ -1094,7 +1095,7 @@ class ToolRouterTest {
     @Test
     fun `SHOULD keep manual disables after re-registering local tools`() {
         router.registerLocalTools(listOf(localTool("list_hosts"), localTool("list_inventories")))
-        router.setToolEnabled("list_hosts", ToolSource.LOCAL, false)
+        router.setToolEnabled("list_hosts", ToolSource.LOCAL, enabled = false)
 
         router.registerLocalTools(listOf(localTool("list_hosts"), localTool("list_inventories")))
 
@@ -1111,10 +1112,10 @@ class ToolRouterTest {
         router.registerLocalTools(local)
         router.registerMcpTools(mcp)
 
-        router.setToolEnabled("controller.users_list", ToolSource.MCP, false)
+        router.setToolEnabled("controller.users_list", ToolSource.MCP, "aap", false)
 
-        assertFalse("auto-disabled overlap", router.isToolEnabled("controller.hosts_list", ToolSource.MCP))
-        assertFalse("manually disabled", router.isToolEnabled("controller.users_list", ToolSource.MCP))
+        assertFalse("auto-disabled overlap", router.isToolEnabled("controller.hosts_list", ToolSource.MCP, "aap"))
+        assertFalse("manually disabled", router.isToolEnabled("controller.users_list", ToolSource.MCP, "aap"))
 
         val result = router.getToolsForQuery("show hosts and users").tools
         val names = result.map { it.spec.name }
@@ -1140,12 +1141,12 @@ class ToolRouterTest {
             localTool("list_inventories")
         )
         router.registerLocalTools(tools)
-        router.setToolEnabled("list_hosts", ToolSource.LOCAL, false)
+        router.setToolEnabled("list_hosts", ToolSource.LOCAL, enabled = false)
 
         val before = router.getToolsForQuery("show my hosts").tools
         assertFalse("list_hosts" in before.map { it.spec.name })
 
-        router.setToolEnabled("list_hosts", ToolSource.LOCAL, true)
+        router.setToolEnabled("list_hosts", ToolSource.LOCAL, enabled = true)
 
         val after = router.getToolsForQuery("show my hosts").tools
         assertTrue("list_hosts" in after.map { it.spec.name })
@@ -1159,9 +1160,9 @@ class ToolRouterTest {
             localTool("list_groups")
         )
         router.registerLocalTools(tools)
-        router.setToolEnabled("list_hosts", ToolSource.LOCAL, false)
-        router.setToolEnabled("list_inventories", ToolSource.LOCAL, false)
-        router.setToolEnabled("list_groups", ToolSource.LOCAL, false)
+        router.setToolEnabled("list_hosts", ToolSource.LOCAL, enabled = false)
+        router.setToolEnabled("list_inventories", ToolSource.LOCAL, enabled = false)
+        router.setToolEnabled("list_groups", ToolSource.LOCAL, enabled = false)
 
         val result = router.getToolsForQuery("show my hosts")
 
@@ -1203,11 +1204,11 @@ class ToolRouterTest {
         router.registerLocalTools(listOf(localTool("list_hosts")))
         assertFalse("auto-disabled", router.isToolEnabled("controller.hosts_list", ToolSource.MCP))
 
-        router.setToolEnabled("controller.hosts_list", ToolSource.MCP, true)
-        assertTrue("user re-enabled", router.isToolEnabled("controller.hosts_list", ToolSource.MCP))
+        router.setToolEnabled("controller.hosts_list", ToolSource.MCP, "aap", true)
+        assertTrue("user re-enabled", router.isToolEnabled("controller.hosts_list", ToolSource.MCP, "aap"))
 
         router.registerLocalTools(listOf(localTool("list_hosts")))
-        assertTrue("survives re-registration", router.isToolEnabled("controller.hosts_list", ToolSource.MCP))
+        assertTrue("survives re-registration", router.isToolEnabled("controller.hosts_list", ToolSource.MCP, "aap"))
     }
 
     @Test
@@ -1218,11 +1219,11 @@ class ToolRouterTest {
         assertTrue(router.isAutoDisabled("controller.hosts_list", ToolSource.MCP))
         assertFalse(router.isAutoDisabled("controller.users_list", ToolSource.MCP))
 
-        router.setToolEnabled("controller.hosts_list", ToolSource.MCP, true)
-        assertTrue("userEnabled overrides autoDisabled", router.isToolEnabled("controller.hosts_list", ToolSource.MCP))
+        router.setToolEnabled("controller.hosts_list", ToolSource.MCP, "aap", true)
+        assertTrue("userEnabled overrides autoDisabled", router.isToolEnabled("controller.hosts_list", ToolSource.MCP, "aap"))
 
-        router.setToolEnabled("controller.users_list", ToolSource.MCP, false)
-        assertFalse("userDisabled takes effect", router.isToolEnabled("controller.users_list", ToolSource.MCP))
+        router.setToolEnabled("controller.users_list", ToolSource.MCP, "aap", false)
+        assertFalse("userDisabled takes effect", router.isToolEnabled("controller.users_list", ToolSource.MCP, "aap"))
     }
 
     @Test
@@ -1231,12 +1232,12 @@ class ToolRouterTest {
         router.registerMcpTools(listOf(mcpTool("controller.hosts_list"), mcpTool("controller.users_list")))
 
         router.applyPersistedState(
-            disabled = setOf("MCP:controller.users_list"),
-            enabledOverrides = setOf("MCP:controller.hosts_list")
+            disabled = setOf("MCP:aap:controller.users_list"),
+            enabledOverrides = setOf("MCP:aap:controller.hosts_list")
         )
 
-        assertTrue("enabledOverride overrides autoDisabled", router.isToolEnabled("controller.hosts_list", ToolSource.MCP))
-        assertFalse("userDisabled applied", router.isToolEnabled("controller.users_list", ToolSource.MCP))
+        assertTrue("enabledOverride overrides autoDisabled", router.isToolEnabled("controller.hosts_list", ToolSource.MCP, "aap"))
+        assertFalse("userDisabled applied", router.isToolEnabled("controller.users_list", ToolSource.MCP, "aap"))
     }
 
     @Test

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
@@ -238,7 +238,6 @@ class SettingsViewModelTest {
 
         viewModel.uiState.test {
             val state = awaitItem() as SettingsUiState.Ready
-            assertEquals(setOf("LOCAL:list_hosts", "MCP:aap:controller.jobs_list"), state.disabledTools)
             val hostTool = state.localTools.find { it.name == "list_hosts" }
             assertFalse("list_hosts should be disabled", hostTool?.isEnabled ?: true)
             val invTool = state.localTools.find { it.name == "list_inventories" }
@@ -248,12 +247,13 @@ class SettingsViewModelTest {
 
     @Test
     fun `toggleToolEnabled SHOULD disable a local tool and persist`() = runTest {
-        val viewModel = createViewModel()
+        val tools = listOf(fakeLocalTool("list_hosts"))
+        val viewModel = createViewModel(localTools = tools)
         viewModel.uiState.test {
             skipItems(1)
             viewModel.toggleToolEnabled("list_hosts", ToolSource.LOCAL, enabled = false)
             val state = awaitItem() as SettingsUiState.Ready
-            assertTrue("LOCAL:list_hosts" in state.disabledTools)
+            assertFalse(state.localTools.find { it.name == "list_hosts" }?.isEnabled ?: true)
             assertTrue("LOCAL:list_hosts" in fakeAssistantRepo.savedDisabledTools)
         }
     }
@@ -261,24 +261,22 @@ class SettingsViewModelTest {
     @Test
     fun `toggleToolEnabled SHOULD re-enable a previously disabled tool`() = runTest {
         fakeAssistantRepo.savedDisabledTools = setOf("LOCAL:list_hosts")
-        val viewModel = createViewModel()
+        val tools = listOf(fakeLocalTool("list_hosts"))
+        val viewModel = createViewModel(localTools = tools)
         viewModel.uiState.test {
             skipItems(1)
             viewModel.toggleToolEnabled("list_hosts", ToolSource.LOCAL, enabled = true)
             val state = awaitItem() as SettingsUiState.Ready
-            assertFalse("LOCAL:list_hosts" in state.disabledTools)
+            assertTrue(state.localTools.find { it.name == "list_hosts" }?.isEnabled ?: false)
+            assertFalse("LOCAL:list_hosts" in fakeAssistantRepo.savedDisabledTools)
         }
     }
 
     @Test
     fun `toggleToolEnabled SHOULD use MCP prefix for MCP tools`() = runTest {
         val viewModel = createViewModel()
-        viewModel.uiState.test {
-            skipItems(1)
-            viewModel.toggleToolEnabled("controller.hosts_list", ToolSource.MCP, "aap", false)
-            val state = awaitItem() as SettingsUiState.Ready
-            assertTrue("MCP:aap:controller.hosts_list" in state.disabledTools)
-        }
+        viewModel.toggleToolEnabled("controller.hosts_list", ToolSource.MCP, "aap", false)
+        assertTrue("MCP:aap:controller.hosts_list" in fakeAssistantRepo.savedDisabledTools)
     }
 
     @Test

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
@@ -8,6 +8,7 @@ import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
 import io.github.leogallego.ansiblejane.fakes.FakeUserPreferencesRepository
 import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
+import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
@@ -84,9 +85,9 @@ class SettingsViewModelTest {
         mcpServerManager = mcpServerManager,
         manifestRepository = io.github.leogallego.ansiblejane.fakes.FakeToolManifestRepository(),
         instanceDiscovery = io.github.leogallego.ansiblejane.network.InstanceDiscovery(json),
+        toolRouter = ToolRouter(initialLocalTools = localTools, repository = fakeAssistantRepo),
         httpClient = httpClient,
-        json = json,
-        localTools = localTools
+        json = json
     )
 
     @Test
@@ -231,13 +232,13 @@ class SettingsViewModelTest {
 
     @Test
     fun `init SHOULD load pre-existing disabled tools from repository`() = runTest {
-        fakeAssistantRepo.savedDisabledTools = setOf("LOCAL:list_hosts", "MCP:controller.jobs_list")
+        fakeAssistantRepo.savedDisabledTools = setOf("LOCAL:list_hosts", "MCP:aap:controller.jobs_list")
         val tools = listOf(fakeLocalTool("list_hosts"), fakeLocalTool("list_inventories"))
         val viewModel = createViewModel(localTools = tools)
 
         viewModel.uiState.test {
             val state = awaitItem() as SettingsUiState.Ready
-            assertEquals(setOf("LOCAL:list_hosts", "MCP:controller.jobs_list"), state.disabledTools)
+            assertEquals(setOf("LOCAL:list_hosts", "MCP:aap:controller.jobs_list"), state.disabledTools)
             val hostTool = state.localTools.find { it.name == "list_hosts" }
             assertFalse("list_hosts should be disabled", hostTool?.isEnabled ?: true)
             val invTool = state.localTools.find { it.name == "list_inventories" }
@@ -250,7 +251,7 @@ class SettingsViewModelTest {
         val viewModel = createViewModel()
         viewModel.uiState.test {
             skipItems(1)
-            viewModel.toggleToolEnabled("list_hosts", ToolSource.LOCAL, false)
+            viewModel.toggleToolEnabled("list_hosts", ToolSource.LOCAL, enabled = false)
             val state = awaitItem() as SettingsUiState.Ready
             assertTrue("LOCAL:list_hosts" in state.disabledTools)
             assertTrue("LOCAL:list_hosts" in fakeAssistantRepo.savedDisabledTools)
@@ -263,7 +264,7 @@ class SettingsViewModelTest {
         val viewModel = createViewModel()
         viewModel.uiState.test {
             skipItems(1)
-            viewModel.toggleToolEnabled("list_hosts", ToolSource.LOCAL, true)
+            viewModel.toggleToolEnabled("list_hosts", ToolSource.LOCAL, enabled = true)
             val state = awaitItem() as SettingsUiState.Ready
             assertFalse("LOCAL:list_hosts" in state.disabledTools)
         }
@@ -274,9 +275,9 @@ class SettingsViewModelTest {
         val viewModel = createViewModel()
         viewModel.uiState.test {
             skipItems(1)
-            viewModel.toggleToolEnabled("controller.hosts_list", ToolSource.MCP, false)
+            viewModel.toggleToolEnabled("controller.hosts_list", ToolSource.MCP, "aap", false)
             val state = awaitItem() as SettingsUiState.Ready
-            assertTrue("MCP:controller.hosts_list" in state.disabledTools)
+            assertTrue("MCP:aap:controller.hosts_list" in state.disabledTools)
         }
     }
 

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
@@ -81,6 +81,7 @@ class SettingsScreenTest {
             mcpServerManager = mcpServerManager,
             manifestRepository = io.github.leogallego.ansiblejane.fakes.FakeToolManifestRepository(),
             instanceDiscovery = io.github.leogallego.ansiblejane.network.InstanceDiscovery(json),
+            toolRouter = io.github.leogallego.ansiblejane.assistant.engine.ToolRouter(repository = fakeAssistantRepo),
             httpClient = HttpClient(MockEngine) { engine { addHandler { respond("{}") } } },
             json = json
         )


### PR DESCRIPTION
## Summary

- **ToolRouter singleton**: Registered as Koin `single{}`, shared between AssistantViewModel and SettingsViewModel. Eliminates per-message `ToolRouter()` instantiation and the `autoDisabledMcpNames` duplication in SettingsViewModel.
- **TOCTOU race fix**: `toggleToolEnabled()` now reads ToolRouter's internal state (always up-to-date) instead of a `uiState.value` snapshot. Two rapid toggles no longer overwrite each other.
- **MCP key collision fix**: Persistence key changes from `MCP:toolName` to `MCP:serverLabel:toolName`. Two MCP servers exposing the same tool name now have independent toggle state. Old format keys silently ignored (alpha, feature is 1 week old).
- **Cleanup**: Removed duplicate SettingsViewModel registration from `appPresentationModule`, removed deprecated `applyPersistedDisables`.

Closes three findings filed on #171 in [comment](https://github.com/leogallego/ansible-jane/issues/171#issuecomment-4700645757).

## Test plan

- [x] `scripts/test-all.sh` — all stages pass (531 unit tests, compile, lint, screenshot)
- [ ] Manual: Settings → Tools → toggle MCP tool, verify state persists across app restart
- [ ] Manual: Verify auto-disabled MCP tools show indicator and toggle works as override

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>