### PR TITLE
fix: prevent lifecycle version drift with resolution strategy (#301)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,16 @@ jobs:
 
       - name: Run Desktop UI tests
         run: ./gradlew :composeApp:desktopTest --no-daemon --stacktrace
+
+      - name: Check for lifecycle artifact version drift
+        run: |
+          echo "Checking desktopRuntimeClasspath for dual lifecycle artifacts..."
+          DEPS=$(./gradlew :composeApp:dependencies --configuration desktopRuntimeClasspath --no-daemon -q 2>/dev/null)
+          ANDROIDX=$(echo "$DEPS" | grep -oP 'androidx\.lifecycle:lifecycle-viewmodel-compose-desktop:\K[^\s]+' | head -1)
+          JETBRAINS=$(echo "$DEPS" | grep -oP 'org\.jetbrains\.androidx\.lifecycle:lifecycle-viewmodel-compose-desktop:\K[^\s]+' | head -1)
+          if [ -n "$ANDROIDX" ] && [ -n "$JETBRAINS" ] && [ "$ANDROIDX" != "$JETBRAINS" ]; then
+            echo "::error::Lifecycle version drift detected! androidx.lifecycle=$ANDROIDX vs org.jetbrains.androidx.lifecycle=$JETBRAINS"
+            echo "Fix: align lifecycle version in gradle/libs.versions.toml or check resolution strategy in composeApp/build.gradle.kts"
+            exit 1
+          fi
+          echo "OK: no lifecycle version drift (androidx=${ANDROIDX:-none} jetbrains=${JETBRAINS:-none})"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -133,6 +133,19 @@ kotlin {
     }
 }
 
+// Force transitive androidx.lifecycle artifacts to match the JetBrains lifecycle
+// version declared in libs.versions.toml. Without this, a Dependabot bump to
+// compose-material3 or compose-ui can pull a newer androidx.lifecycle transitively,
+// putting two LocalViewModelStoreOwner implementations on the Desktop classpath
+// and causing a StackOverflowError. See #301.
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "androidx.lifecycle") {
+            useVersion(libs.versions.lifecycle.get())
+        }
+    }
+}
+
 compose.desktop {
     application {
         mainClass = "io.github.leogallego.ansiblejane.MainKt"


### PR DESCRIPTION
## Summary

- Add Gradle resolution strategy to force `androidx.lifecycle` transitive versions to match `org.jetbrains.androidx.lifecycle` version from version catalog
- Add CI step to detect lifecycle artifact version drift on `desktopRuntimeClasspath`

## Problem

Dependabot PR #246 bumped `compose-material3` to `1.12.0-alpha01` independently of `lifecycle`, pulling `androidx.lifecycle:2.11.0-beta01` transitively while the project had `org.jetbrains.androidx.lifecycle:2.10.0`. Two `LocalViewModelStoreOwner` implementations on the Desktop classpath caused a StackOverflowError.

The lifecycle version was aligned in PR #302, but nothing prevented this from happening again on the next Dependabot bump.

## Fix

**Resolution strategy** in `composeApp/build.gradle.kts`:
```kotlin
configurations.all {
    resolutionStrategy.eachDependency {
        if (requested.group == "androidx.lifecycle") {
            useVersion(libs.versions.lifecycle.get())
        }
    }
}
```

**CI check** in `.github/workflows/ci.yml` that fails if `androidx.lifecycle` and `org.jetbrains.androidx.lifecycle` viewmodel-compose artifacts resolve to different versions.

## Test plan

- [x] `./gradlew :composeApp:compileKotlinDesktop` — Desktop compiles
- [x] `./gradlew :app:assembleDebug` — Android compiles
- [x] `./gradlew :shared:jvmTest :composeApp:desktopTest` — tests pass
- [x] Dependency tree shows both lifecycle artifacts at `2.11.0-beta01`

Closes #301

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>