### PR TITLE
fix: add diagnostic logging for Desktop LLM auth chain (#313)

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -389,6 +389,7 @@ class AssistantViewModel(
         config: LlmProviderConfig.OpenAiCompatible,
         trustSelfSigned: Boolean
     ): LlmProvider {
+        Log.d(TAG, "PROVIDER: apiKeyPresent=${config.apiKey != null}, model=${config.model}")
         val key = "${config.url}|${config.model}|${config.apiKey}|$trustSelfSigned"
         cachedProvider?.let { if (cachedProviderKey == key) return it }
         cachedProvider?.close()

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
@@ -178,6 +178,7 @@ class AssistantRepository(
                 )
                 val config = configs[key] ?: return@map null
                 val apiKey = tokenManager.loadLlmApiKey(key)
+                DebugLog.d(TAG, "ACTIVE_FLOW: provider=$key, apiKeyPresent=${apiKey != null}")
                 if (apiKey != null) mergeApiKeyValue(config, apiKey) else config
             } catch (e: Exception) {
                 DebugLog.w(TAG, "Failed to deserialize active config from flow: ${e.message}")

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
@@ -363,14 +363,28 @@ class TokenManager(
     }
 
     override suspend fun saveLlmApiKey(providerKey: String, apiKey: String) {
+        Log.d(TAG, "SAVE_KEY: provider=$providerKey, keyLen=${apiKey.length}")
         val keys = readEncryptedLlmApiKeys().toMutableMap()
         keys[providerKey] = encrypt(apiKey)
         writeEncryptedLlmApiKeys(keys)
+        Log.d(TAG, "SAVE_KEY: done, ${keys.size} keys stored")
     }
 
     override suspend fun loadLlmApiKey(providerKey: String): String? {
-        val encrypted = readEncryptedLlmApiKeys()[providerKey] ?: return null
-        return try { decrypt(encrypted) } catch (_: Exception) { null }
+        val allKeys = readEncryptedLlmApiKeys()
+        Log.d(TAG, "LOAD_KEY: provider=$providerKey, storedKeys=${allKeys.keys}")
+        val encrypted = allKeys[providerKey] ?: run {
+            Log.d(TAG, "LOAD_KEY: NOT FOUND for $providerKey")
+            return null
+        }
+        return try {
+            val decrypted = decrypt(encrypted)
+            Log.d(TAG, "LOAD_KEY: OK, decryptedLen=${decrypted.length}")
+            decrypted
+        } catch (e: Exception) {
+            Log.d(TAG, "LOAD_KEY: DECRYPT FAILED: ${e::class.simpleName}: ${e.message}")
+            null
+        }
     }
 
     override suspend fun loadAllLlmApiKeys(): Map<String, String> {


### PR DESCRIPTION
## Summary

- Add sanitized debug logs to the LLM API key save/load/merge pipeline (TokenManager, AssistantRepository, AssistantViewModel)
- Logs emit provider name, key presence (boolean), key count, and decrypt success/failure — **no key content is logged**
- Investigation confirmed the Desktop encrypt/decrypt pipeline (PKCS12 + AES-256-GCM + DataStore) works correctly

## Context

Issue #313 reported 401/400 errors when using LLM providers on Desktop. Investigation traced the full auth chain and confirmed the crypto pipeline round-trips correctly. The original errors were caused by incorrect API key values being entered, not a code bug.

The diagnostic logs added here would have immediately revealed the problem (key length mismatch, wrong key format) and will help debug future auth issues.

## Follow-up

- #316 — audit all `DebugLog` usage and add release-build stripping

## Test plan

- [x] Verified Desktop LLM auth works with correct Gemini API key (39 chars, `AIza...`)
- [x] Verified Desktop LLM auth works with correct OpenRouter API key (73 chars, `sk-or-...`)
- [x] Confirmed logs contain no key content (only boolean presence and length)

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>