### PR TITLE
feat: add Abbenay as LLM provider endpoint (#320)

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/LlmProviderDefinitions.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/LlmProviderDefinitions.kt
@@ -72,6 +72,13 @@ enum class KnownProvider(
         requiresApiKey = true,
         urlEditable = false
     ),
+    ABBENAY(
+        displayName = "Abbenay",
+        baseUrl = "http://localhost:8787/v1",
+        defaultModels = emptyList(),
+        requiresApiKey = false,
+        urlEditable = true
+    ),
     CUSTOM(
         displayName = "Custom",
         baseUrl = "",


### PR DESCRIPTION
## Summary

Add `ABBENAY` as a new entry in `KnownProvider` enum, pointing at Abbenay's OpenAI-compatible endpoint at `localhost:8787/v1`. Since Abbenay speaks the OpenAI protocol, this reuses the existing `KoogLlmProvider` — zero new provider code.

## What is Abbenay?

[Abbenay](https://github.com/redhat-developer/abbenay) is a unified AI daemon supporting 19 LLM providers (OpenAI, Anthropic, Gemini, Mistral, Ollama, Groq, etc.) with an OpenAI-compatible API, dynamic model discovery, MCP aggregation, and system keychain credential management.

Desktop users running Abbenay get access to all 19 providers through a single Jane configuration.

## Changes

| File | Change |
|------|--------|
| `LlmProviderDefinitions.kt` | Added `ABBENAY` enum entry (`localhost:8787`, no API key, URL editable) |

One enum entry, 7 lines. No new classes, interfaces, or dependencies.

## Test plan

- [x] `shared:compileKotlinJvm` passes
- [ ] CI passes
- [ ] `ABBENAY` appears in Settings > Agent provider list
- [ ] With Abbenay running: models populate, chat works
- [ ] Without Abbenay: clear connection error, other providers unaffected

Closes #320
Parent: #319

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>