### PR TITLE
fix: package name, JDK 25 upgrade, JAR glob (#259)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: jetbrains
-          java-version: "21"
+          java-version: "25"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Android SDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: jetbrains
-          java-version: "21"
+          java-version: "25"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Android SDK
@@ -72,7 +72,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: jetbrains
-          java-version: "21"
+          java-version: "25"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install RPM tools
@@ -96,7 +96,7 @@ jobs:
       - name: Rename artifacts
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          mv composeApp/build/compose/jars/AnsibleJane-*.jar "ansible-jane-desktop-linux-${VERSION}.jar"
+          mv composeApp/build/compose/jars/*.jar "ansible-jane-desktop-linux-${VERSION}.jar"
           mv composeApp/build/compose/binaries/main/deb/*.deb "ansible-jane-desktop-linux-${VERSION}.deb"
           mv composeApp/build/compose/binaries/main/rpm/*.rpm "ansible-jane-desktop-linux-${VERSION}.rpm"
 
@@ -123,7 +123,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: jetbrains
-          java-version: "21"
+          java-version: "25"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set execution flag for gradlew
@@ -165,7 +165,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: jetbrains
-          java-version: "21"
+          java-version: "25"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build MSI package

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -152,7 +152,7 @@ compose.desktop {
 
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb, TargetFormat.Rpm)
-            packageName = "AnsibleJane"
+            packageName = "Ansible Jane"
             packageVersion = providers.gradleProperty("appVersionName").get().substringBefore("-")
 
             macOS {


### PR DESCRIPTION
## Summary

- Change `packageName` from `"AnsibleJane"` to `"Ansible Jane"` → installs as `ansible-jane` not `ansiblejane`
- Upgrade JetBrains Runtime from 21 to 25 across CI and release workflows
- Use `*.jar` wildcard glob in release workflow instead of hardcoded name

## Why JDK 25?

The jpackage launcher built with JDK 21 segfaults on Fedora 42+ due to a glibc `setenv` incompatibility. JBR 25 has a newer launcher binary that's compatible. JDK 25 is backwards compatible with our JVM 17 bytecode target, and is what JetBrains ships with IntelliJ 2025.x.

```
Stack trace of thread 584504:
#0  setenv (libc.so.6)
#1  jvmLauncherStartJvm (AnsibleJane)
#2  main (AnsibleJane)
```

## Changes

| File | Change |
|------|--------|
| `composeApp/build.gradle.kts` | `packageName = "Ansible Jane"` |
| `.github/workflows/release.yml` | JDK 21→25, `*.jar` glob |
| `.github/workflows/ci.yml` | JDK 21→25 |

## Test plan

- [ ] CI passes with JDK 25
- [ ] RPM installs as `ansible-jane`
- [ ] RPM launches without segfault on Fedora 42

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>