### PR TITLE
chore: bump version to v0.8.4-alpha.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.experimental.enableScreenshotTest=true
 kotlin.native.ignoreDisabledTargets=true
-appVersionName=0.8.4-alpha.3
-appVersionCode=26061803
+appVersionName=0.8.4-alpha.4
+appVersionCode=26061804


### PR DESCRIPTION
Version bump for testing JDK 25 RPM on Fedora 42.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>