### PR TITLE
fix: build RPM in Fedora container to fix jpackage segfault (#259)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: Build and test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,8 @@ jobs:
           name: apk
           path: ansible-jane-*.apk
 
-  desktop-linux:
-    name: Build Desktop Linux packages
+  desktop-linux-deb:
+    name: Build Desktop DEB + JAR
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -75,9 +75,6 @@ jobs:
           java-version: "25"
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install RPM tools
-        run: sudo apt-get update && sudo apt-get install -y rpm
-
       - name: Set execution flag for gradlew
         run: chmod +x gradlew
 
@@ -90,24 +87,51 @@ jobs:
       - name: Build DEB package
         run: ./gradlew :composeApp:packageDeb --stacktrace
 
-      - name: Build RPM package
-        run: ./gradlew :composeApp:packageRpm --stacktrace
-
       - name: Rename artifacts
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           mv composeApp/build/compose/jars/*.jar "ansible-jane-desktop-linux-${VERSION}.jar"
           mv composeApp/build/compose/binaries/main/deb/*.deb "ansible-jane-desktop-linux-${VERSION}.deb"
-          mv composeApp/build/compose/binaries/main/rpm/*.rpm "ansible-jane-desktop-linux-${VERSION}.rpm"
 
-      - name: Upload Linux artifacts
+      - name: Upload DEB + JAR artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: desktop-linux
+          name: desktop-linux-deb
           path: |
             ansible-jane-desktop-linux-*.jar
             ansible-jane-desktop-linux-*.deb
-            ansible-jane-desktop-linux-*.rpm
+
+  desktop-linux-rpm:
+    name: Build Desktop RPM (Fedora)
+    runs-on: ubuntu-latest
+    container: fedora:44
+    steps:
+      - name: Install build dependencies
+        run: dnf -y install java-25-openjdk-devel rpm-build findutils which git
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Set execution flag for gradlew
+        run: chmod +x gradlew
+
+      - name: Build RPM package
+        run: ./gradlew :composeApp:packageRpm --stacktrace
+        env:
+          JAVA_HOME: /usr/lib/jvm/java-25-openjdk
+
+      - name: Rename artifact
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          mv composeApp/build/compose/binaries/main/rpm/*.rpm "ansible-jane-desktop-linux-${VERSION}.rpm"
+
+      - name: Upload RPM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-linux-rpm
+          path: ansible-jane-desktop-linux-*.rpm
 
   desktop-macos:
     name: Build Desktop macOS package
@@ -186,7 +210,7 @@ jobs:
   release:
     name: Create GitHub Release
     if: always() && !cancelled()
-    needs: [apk, desktop-linux, desktop-macos, desktop-windows]
+    needs: [apk, desktop-linux-deb, desktop-linux-rpm, desktop-macos, desktop-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Split the `desktop-linux` job into two:
- **`desktop-linux-deb`** — Ubuntu runner (DEB + JAR + desktop tests, as before)
- **`desktop-linux-rpm`** — Fedora 43 container on Ubuntu runner (RPM only)

## Why

The jpackage native launcher segfaults on Fedora 42+ (glibc 2.41) due to [JDK-8345810](https://bugs.openjdk.org/browse/JDK-8345810): the launcher isn't linked with `-lpthread`, causing a crash in glibc's `setenv`. Building inside a Fedora container compiles the launcher against the correct glibc.

```
#0  setenv (libc.so.6)
#1  jvmLauncherStartJvm (Ansible Jane)
```

## Cost

No extra cost — `container: fedora:43` runs on the same `ubuntu-latest` runner (1x multiplier). The two jobs run in parallel so wall-clock time is similar.

## Test plan

- [ ] CI passes
- [ ] RPM builds in Fedora container
- [ ] RPM installs and launches without segfault on Fedora 42

Related: #259

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>