### PR TITLE
fix: RPM build — git safe.directory in Fedora container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,9 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Fix git safe.directory in container
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Set execution flag for gradlew
         run: chmod +x gradlew
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,8 +35,9 @@ android {
         debug {
             val gitSha = providers.exec {
                 commandLine("git", "rev-parse", "--short", "HEAD")
-            }.standardOutput.asText.get().trim()
-            versionNameSuffix = "-dev+$gitSha"
+                isIgnoreExitValue = true
+            }.standardOutput.asText.map { it.trim().ifEmpty { "unknown" } }
+            versionNameSuffix = "-dev+${gitSha.get()}"
         }
         release {
             isMinifyEnabled = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.experimental.enableScreenshotTest=true
 kotlin.native.ignoreDisabledTargets=true
-appVersionName=0.8.4-alpha.5
-appVersionCode=26061805
+appVersionName=0.8.4-alpha.6
+appVersionCode=26061806


### PR DESCRIPTION
## Summary
- Fix RPM build failure in release workflow: `git rev-parse` fails with exit 128 inside the Fedora container because `actions/checkout` sets `safe.directory` in a temporary HOME that Gradle doesn't inherit
- Add explicit `git config --global --add safe.directory` step in the RPM job
- Make `app/build.gradle.kts` debug git SHA resilient with `isIgnoreExitValue` + fallback (defense in depth)
- Bump version to v0.8.4-alpha.6

## Test plan
- [ ] Merge and tag — release workflow RPM job should pass

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>