### PR TITLE
chore: bump version to v0.8.4-alpha.7

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,32 @@
+name: Auto-tag on version bump
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+    paths:
+      - 'gradle.properties'
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create release tag
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Read version and tag
+        run: |
+          VERSION=$(grep '^appVersionName=' gradle.properties | cut -d= -f2)
+          TAG="v${VERSION}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists, skipping"
+            exit 0
+          fi
+          echo "Tagging ${TAG}"
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,62 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 0.8.4-alpha.7)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: Create version bump PR
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Validate version format
+        run: |
+          if ! echo "$VERSION" | grep -qP '^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Invalid version format: ${VERSION}"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Compute version code
+        id: version
+        run: |
+          ALPHA_NUM=$(echo "$VERSION" | grep -oP 'alpha\.\K\d+' || echo "0")
+          DATE_PART=$(date +%y%m%d)
+          VERSION_CODE="${DATE_PART}$(printf '%02d' "$ALPHA_NUM")"
+          echo "code=${VERSION_CODE}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version in gradle.properties
+        env:
+          VERSION_CODE: ${{ steps.version.outputs.code }}
+        run: |
+          sed -i "s/^appVersionName=.*/appVersionName=${VERSION}/" gradle.properties
+          sed -i "s/^appVersionCode=.*/appVersionCode=${VERSION_CODE}/" gradle.properties
+          grep appVersion gradle.properties
+
+      - name: Create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="chore/bump-v${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add gradle.properties
+          git commit -m "chore: bump version to v${VERSION}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: bump version to v${VERSION}" \
+            --body "Automated version bump for release v${VERSION}." \
+            --label "release"

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.experimental.enableScreenshotTest=true
 kotlin.native.ignoreDisabledTargets=true
-appVersionName=0.8.4-alpha.6
-appVersionCode=26061806
+appVersionName=0.8.4-alpha.7
+appVersionCode=26061807


### PR DESCRIPTION
Version bump for pre-release with RPM segfault fix, AppImage, Flatpak, and tarball packaging.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>