### PR TITLE
fix: non-AAP MCP tools no longer silently filtered (#333)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,6 +407,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           name: Release ${{ env.RELEASE_TAG }}
           body_path: changelog.txt
           files: |

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -2,7 +2,6 @@ package io.github.leogallego.ansiblejane.assistant.engine
 
 import io.github.leogallego.ansiblejane.TestOnly
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.McpTool
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
@@ -49,14 +48,12 @@ class ToolRouterTest {
 
     private lateinit var router: ToolRouter
 
-    private fun mcpTool(name: String, serverLabel: String = "aap") = object : Tool {
+    private fun mcpTool(name: String, serverLabel: String = "aap", toolset: String? = null) = object : Tool {
         override val serverLabel: String = serverLabel
+        override val toolset: String? = toolset
         override val spec = ToolSpec(name, "[$serverLabel] description of $name", JsonObject(emptyMap()))
         override suspend fun execute(args: JsonObject) = ToolResult(success = true)
     }
-
-    private fun mcpToolWithToolset(name: String, serverLabel: String = "aap", toolset: String) =
-        McpTool.forTest(name, serverLabel, toolset)
 
     private fun localTool(name: String, destructive: Boolean = false) = object : LocalTool {
         override val spec = ToolSpec(name, "Local: $name", JsonObject(emptyMap()))
@@ -286,11 +283,11 @@ class ToolRouterTest {
     @Test
     fun `SHOULD exclude write MCP tools WHEN readOnly is true`() {
         val tools = listOf(
-            mcpToolWithToolset("hosts_list", toolset = "inventory_management"),
-            mcpToolWithToolset("hosts_create", toolset = "inventory_management"),
-            mcpToolWithToolset("hosts_update", toolset = "inventory_management"),
-            mcpToolWithToolset("hosts_delete", toolset = "inventory_management"),
-            mcpToolWithToolset("inventories_list", toolset = "inventory_management")
+            mcpTool("hosts_list", toolset = "inventory_management"),
+            mcpTool("hosts_create", toolset = "inventory_management"),
+            mcpTool("hosts_update", toolset = "inventory_management"),
+            mcpTool("hosts_delete", toolset = "inventory_management"),
+            mcpTool("inventories_list", toolset = "inventory_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("list my hosts", listOf(readOnlyConfig)).tools
@@ -356,10 +353,10 @@ class ToolRouterTest {
     @Test
     fun `SHOULD select MCP inventory tools WHEN query mentions hosts`() {
         val tools = listOf(
-            mcpToolWithToolset("hosts_list", toolset = "inventory_management"),
-            mcpToolWithToolset("groups_list", toolset = "inventory_management"),
-            mcpToolWithToolset("jobs_retrieve", toolset = "job_management"),
-            mcpToolWithToolset("users_list", toolset = "user_management")
+            mcpTool("hosts_list", toolset = "inventory_management"),
+            mcpTool("groups_list", toolset = "inventory_management"),
+            mcpTool("jobs_retrieve", toolset = "job_management"),
+            mcpTool("users_list", toolset = "user_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("list my hosts", listOf(readWriteConfig)).tools
@@ -377,10 +374,10 @@ class ToolRouterTest {
         // (substringBeforeLast("_") gives "job_templates_launch", not "job_templates").
         // In production, toolset-based routing handles this. See #333.
         val tools = listOf(
-            mcpToolWithToolset("hosts_list", toolset = "inventory_management"),
-            mcpToolWithToolset("job_templates_list", toolset = "job_management"),
-            mcpToolWithToolset("job_templates_launch_create", toolset = "job_management"),
-            mcpToolWithToolset("jobs_retrieve", toolset = "job_management")
+            mcpTool("hosts_list", toolset = "inventory_management"),
+            mcpTool("job_templates_list", toolset = "job_management"),
+            mcpTool("job_templates_launch_create", toolset = "job_management"),
+            mcpTool("jobs_retrieve", toolset = "job_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("launch a job template", listOf(readWriteConfig)).tools
@@ -395,13 +392,13 @@ class ToolRouterTest {
     @Test
     fun `SHOULD select MCP monitoring tools WHEN query mentions health`() {
         val tools = listOf(
-            mcpToolWithToolset("hosts_list", toolset = "inventory_management"),
-            mcpToolWithToolset("instances_list", toolset = "system_monitoring"),
-            mcpToolWithToolset("ping_retrieve", toolset = "system_monitoring"),
-            mcpToolWithToolset("mesh_visualizer_retrieve", toolset = "system_monitoring")
+            mcpTool("hosts_list", toolset = "inventory_management"),
+            mcpTool("instances_list", toolset = "system_monitoring"),
+            mcpTool("ping_retrieve", toolset = "system_monitoring"),
+            mcpTool("mesh_visualizer_retrieve", toolset = "system_monitoring")
         )
         router.registerMcpTools(tools)
-        val result = router.getToolsForQuery("check instance health and ping", listOf(readWriteConfig)).tools
+        val result = router.getToolsForQuery("check system health", listOf(readWriteConfig)).tools
         val names = result.map { it.spec.name }
 
         assertTrue("instances_list" in names)
@@ -412,10 +409,10 @@ class ToolRouterTest {
     @Test
     fun `SHOULD select MCP user tools WHEN query mentions users or teams`() {
         val tools = listOf(
-            mcpToolWithToolset("users_list", toolset = "user_management"),
-            mcpToolWithToolset("teams_list", toolset = "user_management"),
-            mcpToolWithToolset("organizations_list", toolset = "user_management"),
-            mcpToolWithToolset("hosts_list", toolset = "inventory_management")
+            mcpTool("users_list", toolset = "user_management"),
+            mcpTool("teams_list", toolset = "user_management"),
+            mcpTool("organizations_list", toolset = "user_management"),
+            mcpTool("hosts_list", toolset = "inventory_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("list users in my team", listOf(readWriteConfig)).tools
@@ -430,9 +427,9 @@ class ToolRouterTest {
     @Test
     fun `SHOULD select MCP security tools WHEN query mentions credentials`() {
         val tools = listOf(
-            mcpToolWithToolset("credentials_list", toolset = "security_compliance"),
-            mcpToolWithToolset("credential_types_list", toolset = "security_compliance"),
-            mcpToolWithToolset("hosts_list", toolset = "inventory_management")
+            mcpTool("credentials_list", toolset = "security_compliance"),
+            mcpTool("credential_types_list", toolset = "security_compliance"),
+            mcpTool("hosts_list", toolset = "inventory_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("show my credentials", listOf(readWriteConfig)).tools
@@ -446,10 +443,10 @@ class ToolRouterTest {
     @Test
     fun `SHOULD select MCP config tools WHEN query mentions settings or projects`() {
         val tools = listOf(
-            mcpToolWithToolset("settings_retrieve", toolset = "platform_configuration"),
-            mcpToolWithToolset("projects_list", toolset = "platform_configuration"),
-            mcpToolWithToolset("notification_templates_list", toolset = "platform_configuration"),
-            mcpToolWithToolset("hosts_list", toolset = "inventory_management")
+            mcpTool("settings_retrieve", toolset = "platform_configuration"),
+            mcpTool("projects_list", toolset = "platform_configuration"),
+            mcpTool("notification_templates_list", toolset = "platform_configuration"),
+            mcpTool("hosts_list", toolset = "inventory_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("show project settings", listOf(readWriteConfig)).tools
@@ -464,9 +461,9 @@ class ToolRouterTest {
     @Test
     fun `SHOULD select MCP tools by toolset WHEN compound names used`() {
         val tools = listOf(
-            mcpToolWithToolset("workflow_job_templates_list", toolset = "job_management"),
-            mcpToolWithToolset("inventories_list", toolset = "inventory_management"),
-            mcpToolWithToolset("hosts_list", toolset = "inventory_management")
+            mcpTool("workflow_job_templates_list", toolset = "job_management"),
+            mcpTool("inventories_list", toolset = "inventory_management"),
+            mcpTool("hosts_list", toolset = "inventory_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("show my workflow templates", listOf(readWriteConfig)).tools
@@ -554,8 +551,8 @@ class ToolRouterTest {
     @Test
     fun `SHOULD still filter AAP MCP tools by toolset category`() {
         val tools = listOf(
-            mcpToolWithToolset("hosts_list", toolset = "inventory_management"),
-            mcpToolWithToolset("jobs_list", toolset = "job_management")
+            mcpTool("hosts_list", toolset = "inventory_management"),
+            mcpTool("jobs_list", toolset = "job_management")
         )
         router.registerMcpTools(tools)
 
@@ -566,6 +563,23 @@ class ToolRouterTest {
             "hosts_list" in names)
         assertFalse("jobs_list should be excluded by toolset category mismatch",
             "jobs_list" in names)
+    }
+
+    @Test
+    fun `SHOULD exclude known-toolset tool with name overlap WHEN category does not match query`() {
+        val tools = listOf(
+            mcpTool("hosts_job_host_summaries_list", toolset = "job_management"),
+            mcpTool("hosts_list", toolset = "inventory_management")
+        )
+        router.registerMcpTools(tools)
+
+        val result = router.getToolsForQuery("list my hosts", listOf(readWriteConfig)).tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("hosts_list should be included for host query",
+            "hosts_list" in names)
+        assertFalse("hosts_job_host_summaries_list should be excluded despite name overlap",
+            "hosts_job_host_summaries_list" in names)
     }
 
     // --- Mixed local + MCP tests ---
@@ -773,7 +787,7 @@ class ToolRouterTest {
     @Test
     fun `SHOULD match plurals via stemming - orgs matches USERS`() {
         router.registerLocalTools(emptyList())
-        router.registerMcpTools(listOf(mcpToolWithToolset("organizations_list", toolset = "user_management")))
+        router.registerMcpTools(listOf(mcpTool("organizations_list", toolset = "user_management")))
 
         val result = router.getToolsForQuery("list orgs").tools
         assertTrue(result.isNotEmpty())
@@ -1203,9 +1217,9 @@ class ToolRouterTest {
     @Test
     fun `SHOULD not include disabled MCP tools in query results`() {
         val tools = listOf(
-            mcpToolWithToolset("hosts_list", toolset = "inventory_management"),
-            mcpToolWithToolset("groups_list", toolset = "inventory_management"),
-            mcpToolWithToolset("users_list", toolset = "user_management")
+            mcpTool("hosts_list", toolset = "inventory_management"),
+            mcpTool("groups_list", toolset = "inventory_management"),
+            mcpTool("users_list", toolset = "user_management")
         )
         router.registerMcpTools(tools)
         router.setToolEnabled("hosts_list", ToolSource.MCP, "aap", false)

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -286,11 +286,11 @@ class ToolRouterTest {
     @Test
     fun `SHOULD exclude write MCP tools WHEN readOnly is true`() {
         val tools = listOf(
-            mcpTool("hosts_list"),
-            mcpTool("hosts_create"),
-            mcpTool("hosts_update"),
-            mcpTool("hosts_delete"),
-            mcpTool("inventories_list")
+            mcpToolWithToolset("hosts_list", toolset = "inventory_management"),
+            mcpToolWithToolset("hosts_create", toolset = "inventory_management"),
+            mcpToolWithToolset("hosts_update", toolset = "inventory_management"),
+            mcpToolWithToolset("hosts_delete", toolset = "inventory_management"),
+            mcpToolWithToolset("inventories_list", toolset = "inventory_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("list my hosts", listOf(readOnlyConfig)).tools
@@ -524,7 +524,7 @@ class ToolRouterTest {
     }
 
     @Test
-    fun `SHOULD include non-AAP MCP tool with list in name for any category query`() {
+    fun `SHOULD exclude non-AAP MCP tool with list bonus WHEN no query word overlap`() {
         val tools = listOf(
             mcpTool("list_network_devices", "netbox"),
         )
@@ -533,7 +533,21 @@ class ToolRouterTest {
         val result = router.getToolsForQuery("show me all hosts", listOf(readWriteConfig)).tools
         val names = result.map { it.spec.name }
 
-        assertTrue("Non-AAP tool with 'list' bonus should pass cherry-pick",
+        assertFalse("Non-AAP tool should be excluded despite list bonus (no word overlap)",
+            "list_network_devices" in names)
+    }
+
+    @Test
+    fun `SHOULD include non-AAP MCP tool with list in name WHEN query words overlap`() {
+        val tools = listOf(
+            mcpTool("list_network_devices", "netbox"),
+        )
+        router.registerMcpTools(tools)
+
+        val result = router.getToolsForQuery("list hosts and network devices", listOf(readWriteConfig)).tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("Non-AAP tool with word overlap should be included",
             "list_network_devices" in names)
     }
 
@@ -759,7 +773,7 @@ class ToolRouterTest {
     @Test
     fun `SHOULD match plurals via stemming - orgs matches USERS`() {
         router.registerLocalTools(emptyList())
-        router.registerMcpTools(listOf(mcpTool("organizations_list")))
+        router.registerMcpTools(listOf(mcpToolWithToolset("organizations_list", toolset = "user_management")))
 
         val result = router.getToolsForQuery("list orgs").tools
         assertTrue(result.isNotEmpty())
@@ -1189,9 +1203,9 @@ class ToolRouterTest {
     @Test
     fun `SHOULD not include disabled MCP tools in query results`() {
         val tools = listOf(
-            mcpTool("hosts_list"),
-            mcpTool("groups_list"),
-            mcpTool("users_list")
+            mcpToolWithToolset("hosts_list", toolset = "inventory_management"),
+            mcpToolWithToolset("groups_list", toolset = "inventory_management"),
+            mcpToolWithToolset("users_list", toolset = "user_management")
         )
         router.registerMcpTools(tools)
         router.setToolEnabled("hosts_list", ToolSource.MCP, "aap", false)
@@ -1201,6 +1215,7 @@ class ToolRouterTest {
 
         assertFalse("hosts_list" in names)
         assertTrue("groups_list" in names)
+        assertFalse("users_list should be excluded by category", "users_list" in names)
     }
 
     @Test

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.assistant.engine
 
 import io.github.leogallego.ansiblejane.TestOnly
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.McpTool
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
@@ -53,6 +54,9 @@ class ToolRouterTest {
         override val spec = ToolSpec(name, "[$serverLabel] description of $name", JsonObject(emptyMap()))
         override suspend fun execute(args: JsonObject) = ToolResult(success = true)
     }
+
+    private fun mcpToolWithToolset(name: String, serverLabel: String = "aap", toolset: String) =
+        McpTool.forTest(name, serverLabel, toolset)
 
     private fun localTool(name: String, destructive: Boolean = false) = object : LocalTool {
         override val spec = ToolSpec(name, "Local: $name", JsonObject(emptyMap()))
@@ -352,10 +356,10 @@ class ToolRouterTest {
     @Test
     fun `SHOULD select MCP inventory tools WHEN query mentions hosts`() {
         val tools = listOf(
-            mcpTool("hosts_list"),
-            mcpTool("groups_list"),
-            mcpTool("jobs_retrieve"),
-            mcpTool("users_list")
+            mcpToolWithToolset("hosts_list", toolset = "inventory_management"),
+            mcpToolWithToolset("groups_list", toolset = "inventory_management"),
+            mcpToolWithToolset("jobs_retrieve", toolset = "job_management"),
+            mcpToolWithToolset("users_list", toolset = "user_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("list my hosts", listOf(readWriteConfig)).tools
@@ -373,15 +377,17 @@ class ToolRouterTest {
         // (substringBeforeLast("_") gives "job_templates_launch", not "job_templates").
         // In production, toolset-based routing handles this. See #333.
         val tools = listOf(
-            mcpTool("hosts_list"),
-            mcpTool("job_templates_list"),
-            mcpTool("jobs_retrieve")
+            mcpToolWithToolset("hosts_list", toolset = "inventory_management"),
+            mcpToolWithToolset("job_templates_list", toolset = "job_management"),
+            mcpToolWithToolset("job_templates_launch_create", toolset = "job_management"),
+            mcpToolWithToolset("jobs_retrieve", toolset = "job_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("launch a job template", listOf(readWriteConfig)).tools
         val names = result.map { it.spec.name }
 
         assertTrue("job_templates_list" in names)
+        assertTrue("job_templates_launch_create" in names)
         assertTrue("jobs_retrieve" in names)
         assertFalse("hosts_list" in names)
     }
@@ -389,28 +395,27 @@ class ToolRouterTest {
     @Test
     fun `SHOULD select MCP monitoring tools WHEN query mentions health`() {
         val tools = listOf(
-            mcpTool("hosts_list"),
-            mcpTool("instances_list"),
-            mcpTool("ping_retrieve"),
-            mcpTool("dashboard_retrieve")
+            mcpToolWithToolset("hosts_list", toolset = "inventory_management"),
+            mcpToolWithToolset("instances_list", toolset = "system_monitoring"),
+            mcpToolWithToolset("ping_retrieve", toolset = "system_monitoring"),
+            mcpToolWithToolset("mesh_visualizer_retrieve", toolset = "system_monitoring")
         )
         router.registerMcpTools(tools)
-        val result = router.getToolsForQuery("check system health", listOf(readWriteConfig)).tools
+        val result = router.getToolsForQuery("check instance health and ping", listOf(readWriteConfig)).tools
         val names = result.map { it.spec.name }
 
         assertTrue("instances_list" in names)
         assertTrue("ping_retrieve" in names)
-        assertTrue("dashboard_retrieve" in names)
         assertFalse("hosts_list" in names)
     }
 
     @Test
     fun `SHOULD select MCP user tools WHEN query mentions users or teams`() {
         val tools = listOf(
-            mcpTool("users_list"),
-            mcpTool("teams_list"),
-            mcpTool("organizations_list"),
-            mcpTool("hosts_list")
+            mcpToolWithToolset("users_list", toolset = "user_management"),
+            mcpToolWithToolset("teams_list", toolset = "user_management"),
+            mcpToolWithToolset("organizations_list", toolset = "user_management"),
+            mcpToolWithToolset("hosts_list", toolset = "inventory_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("list users in my team", listOf(readWriteConfig)).tools
@@ -425,9 +430,9 @@ class ToolRouterTest {
     @Test
     fun `SHOULD select MCP security tools WHEN query mentions credentials`() {
         val tools = listOf(
-            mcpTool("credentials_list"),
-            mcpTool("credential_types_list"),
-            mcpTool("hosts_list")
+            mcpToolWithToolset("credentials_list", toolset = "security_compliance"),
+            mcpToolWithToolset("credential_types_list", toolset = "security_compliance"),
+            mcpToolWithToolset("hosts_list", toolset = "inventory_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("show my credentials", listOf(readWriteConfig)).tools
@@ -441,10 +446,10 @@ class ToolRouterTest {
     @Test
     fun `SHOULD select MCP config tools WHEN query mentions settings or projects`() {
         val tools = listOf(
-            mcpTool("settings_retrieve"),
-            mcpTool("projects_list"),
-            mcpTool("notification_templates_list"),
-            mcpTool("hosts_list")
+            mcpToolWithToolset("settings_retrieve", toolset = "platform_configuration"),
+            mcpToolWithToolset("projects_list", toolset = "platform_configuration"),
+            mcpToolWithToolset("notification_templates_list", toolset = "platform_configuration"),
+            mcpToolWithToolset("hosts_list", toolset = "inventory_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("show project settings", listOf(readWriteConfig)).tools
@@ -457,11 +462,11 @@ class ToolRouterTest {
     }
 
     @Test
-    fun `SHOULD parse compound MCP resource names correctly`() {
+    fun `SHOULD select MCP tools by toolset WHEN compound names used`() {
         val tools = listOf(
-            mcpTool("workflow_job_templates_list"),
-            mcpTool("constructed_inventories_list"),
-            mcpTool("hosts_list")
+            mcpToolWithToolset("workflow_job_templates_list", toolset = "job_management"),
+            mcpToolWithToolset("inventories_list", toolset = "inventory_management"),
+            mcpToolWithToolset("hosts_list", toolset = "inventory_management")
         )
         router.registerMcpTools(tools)
         val result = router.getToolsForQuery("show my workflow templates", listOf(readWriteConfig)).tools
@@ -483,6 +488,70 @@ class ToolRouterTest {
         assertTrue(router.getToolsForQuery("hi", listOf(readWriteConfig)).tools.isEmpty())
         assertTrue(router.getToolsForQuery("hello there", listOf(readWriteConfig)).tools.isEmpty())
         assertTrue(router.getToolsForQuery("thanks", listOf(readWriteConfig)).tools.isEmpty())
+    }
+
+    // --- Non-AAP MCP tool passthrough (issue #333) ---
+
+    @Test
+    fun `SHOULD include non-AAP MCP tool WHEN query words overlap with tool name`() {
+        val tools = listOf(
+            mcpTool("query_cmdb_assets", "cmdb-server"),
+            mcpTool("controller.hosts_list")
+        )
+        router.registerMcpTools(tools)
+
+        val result = router.getToolsForQuery("show me all assets", listOf(readWriteConfig)).tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("Non-AAP tool with query overlap should be included",
+            "query_cmdb_assets" in names)
+    }
+
+    @Test
+    fun `SHOULD exclude non-AAP MCP tool WHEN no query word overlap (cherry-pick filters)`() {
+        val tools = listOf(
+            mcpTool("query_cmdb_assets", "cmdb-server"),
+            mcpTool("controller.hosts_list")
+        )
+        router.registerMcpTools(tools)
+
+        val result = router.getToolsForQuery("show me all hosts", listOf(readWriteConfig)).tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("AAP tool should be included", "controller.hosts_list" in names)
+        assertFalse("Non-AAP tool with no query overlap should be excluded by cherry-pick",
+            "query_cmdb_assets" in names)
+    }
+
+    @Test
+    fun `SHOULD include non-AAP MCP tool with list in name for any category query`() {
+        val tools = listOf(
+            mcpTool("list_network_devices", "netbox"),
+        )
+        router.registerMcpTools(tools)
+
+        val result = router.getToolsForQuery("show me all hosts", listOf(readWriteConfig)).tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("Non-AAP tool with 'list' bonus should pass cherry-pick",
+            "list_network_devices" in names)
+    }
+
+    @Test
+    fun `SHOULD still filter AAP MCP tools by toolset category`() {
+        val tools = listOf(
+            mcpToolWithToolset("hosts_list", toolset = "inventory_management"),
+            mcpToolWithToolset("jobs_list", toolset = "job_management")
+        )
+        router.registerMcpTools(tools)
+
+        val result = router.getToolsForQuery("show me hosts", listOf(readWriteConfig)).tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("hosts_list should be included for host query",
+            "hosts_list" in names)
+        assertFalse("jobs_list should be excluded by toolset category mismatch",
+            "jobs_list" in names)
     }
 
     // --- Mixed local + MCP tests ---

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/TestOnly.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/TestOnly.kt
@@ -5,5 +5,5 @@ package io.github.leogallego.ansiblejane
     level = RequiresOptIn.Level.ERROR
 )
 @Retention(AnnotationRetention.BINARY)
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY, AnnotationTarget.CLASS, AnnotationTarget.CONSTRUCTOR)
 annotation class TestOnly

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/TestOnly.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/TestOnly.kt
@@ -5,5 +5,5 @@ package io.github.leogallego.ansiblejane
     level = RequiresOptIn.Level.ERROR
 )
 @Retention(AnnotationRetention.BINARY)
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY, AnnotationTarget.CLASS, AnnotationTarget.CONSTRUCTOR)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
 annotation class TestOnly

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -449,12 +449,11 @@ class ToolRouter(
 
             val toolToolset = (tool as? McpTool)?.toolset
             val toolsetCategories = toolToolset?.let { TOOLSET_CATEGORY_MAP[it] }
-            val matchesCategory = if (toolsetCategories != null) {
-                matchedCategories.any { it in toolsetCategories }
-            } else {
-                val resource = tool.spec.name
-                    .substringBeforeLast("_")
-                resource in matchedPrefixes
+            val matchesCategory = when {
+                toolsetCategories != null ->
+                    matchedCategories.any { it in toolsetCategories }
+                else ->
+                    true // no toolset or unknown toolset: pass through to cherry-pick
             }
 
             val passesReadOnly = if (readOnlyLabels.isNotEmpty()) {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -4,7 +4,6 @@ import io.github.leogallego.ansiblejane.TestOnly
 import io.github.leogallego.ansiblejane.assistant.data.IAssistantRepository
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.McpTool
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.model.McpServerConfig
@@ -456,11 +455,16 @@ class ToolRouter(
             } else true
             if (!passesReadOnly) continue
 
-            val toolsetCategories = (tool as? McpTool)?.toolset?.let { TOOLSET_CATEGORY_MAP[it] }
+            val toolToolset = tool.toolset
+            val toolsetCategories = toolToolset?.let { TOOLSET_CATEGORY_MAP[it] }
             when {
                 toolsetCategories != null && matchedCategories.any { it in toolsetCategories } ->
                     routedMcp.add(tool)
-                toolsetCategories == null ->
+                toolToolset != null && toolsetCategories == null -> {
+                    Log.d(TAG, "FILTER: unknown toolset '${toolToolset}' for ${tool.spec.name}, treating as unrouted")
+                    unroutedMcp.add(tool)
+                }
+                else ->
                     unroutedMcp.add(tool)
             }
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -432,7 +432,6 @@ class ToolRouter(
         Log.d(TAG, "QUERY: matched categories=${matchedCategories.map { it.name }}")
 
         val matchedLocalNames = matchedCategories.flatMap { it.localToolNames }.toSet()
-        val matchedPrefixes = matchedCategories.flatMap { it.resourcePrefixes }.toSet()
 
         val readOnlyLabels = serverConfigs
             .filter { it.readOnly }
@@ -444,41 +443,44 @@ class ToolRouter(
                 isToolEnabled(tool.spec.name, ToolSource.LOCAL)
         }
 
-        val filteredMcp = mcpTools.filter { tool ->
-            val isEnabled = isToolEnabled(tool.spec.name, ToolSource.MCP, tool.serverLabel)
+        val routedMcp = mutableListOf<Tool>()
+        val unroutedMcp = mutableListOf<Tool>()
 
-            val toolToolset = (tool as? McpTool)?.toolset
-            val toolsetCategories = toolToolset?.let { TOOLSET_CATEGORY_MAP[it] }
-            val matchesCategory = when {
-                toolsetCategories != null ->
-                    matchedCategories.any { it in toolsetCategories }
-                else ->
-                    true // no toolset or unknown toolset: pass through to cherry-pick
-            }
+        for (tool in mcpTools) {
+            if (!isToolEnabled(tool.spec.name, ToolSource.MCP, tool.serverLabel)) continue
 
             val passesReadOnly = if (readOnlyLabels.isNotEmpty()) {
                 if (tool.serverLabel in readOnlyLabels) {
                     WRITE_ACTIONS.none { action -> tool.spec.name.endsWith(action) }
-                } else {
-                    true
-                }
-            } else {
-                true
-            }
+                } else true
+            } else true
+            if (!passesReadOnly) continue
 
-            matchesCategory && isEnabled && passesReadOnly
+            val toolsetCategories = (tool as? McpTool)?.toolset?.let { TOOLSET_CATEGORY_MAP[it] }
+            when {
+                toolsetCategories != null && matchedCategories.any { it in toolsetCategories } ->
+                    routedMcp.add(tool)
+                toolsetCategories == null ->
+                    unroutedMcp.add(tool)
+            }
         }
 
-        Log.d(TAG, "FILTER: ${filteredLocal.size} local, ${filteredMcp.size} mcp after category+enable+readOnly filter")
+        Log.d(TAG, "FILTER: ${filteredLocal.size} local, ${routedMcp.size} routed mcp, ${unroutedMcp.size} unrouted mcp")
         val cherryPickedLocal = cherryPick(filteredLocal, stemmedQuery)
-        val cherryPickedMcp = cherryPick(filteredMcp, stemmedQuery)
-        Log.d(TAG, "CHERRY: ${cherryPickedLocal.size} local [${cherryPickedLocal.map { it.spec.name }}], " +
-            "${cherryPickedMcp.size} mcp [${cherryPickedMcp.map { it.spec.name }}]")
+        val cherryPickedRouted = cherryPick(routedMcp, stemmedQuery)
+        val cherryPickedUnrouted = cherryPick(unroutedMcp, stemmedQuery, requireOverlap = true)
+        val allCherryPicked = cherryPickedLocal + cherryPickedRouted + cherryPickedUnrouted
+        Log.d(TAG, "CHERRY: ${cherryPickedLocal.size} local, ${cherryPickedRouted.size} routed, " +
+            "${cherryPickedUnrouted.size} unrouted [${allCherryPicked.map { it.spec.name }}]")
 
-        QueryResult(cherryPickedLocal + cherryPickedMcp, categoryMatched = true)
+        QueryResult(allCherryPicked, categoryMatched = true)
     }
 
-    private fun cherryPick(tools: List<Tool>, stemmedQuery: Set<String>): List<Tool> {
+    private fun cherryPick(
+        tools: List<Tool>,
+        stemmedQuery: Set<String>,
+        requireOverlap: Boolean = false
+    ): List<Tool> {
         val scored = tools.map { tool ->
             val nameParts = tool.spec.name
                 .split(".", "_")
@@ -489,11 +491,11 @@ class ToolRouter(
             if (tool.spec.name.contains("list") || tool.spec.name.contains("ping")) score += 3
             if (tool.spec.name.contains("get") || tool.spec.name.contains("read") || tool.spec.name.contains("retrieve")) score += 1
             if (overlap > 0 && tool.isDestructive) score -= 5
-            tool to score
+            Triple(tool, score, overlap)
         }
         Log.d(TAG, "SCORES: ${scored.map { "${it.first.spec.name}=${it.second}" }}")
         return scored
-            .filter { it.second > 0 }
+            .filter { it.second > 0 && (!requireOverlap || it.third > 0) }
             .sortedByDescending { it.second }
             .map { it.first }
     }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -73,7 +73,6 @@ class ToolRouter(
 
     private enum class Category(
         val keywords: Set<String>,
-        val resourcePrefixes: Set<String>,
         val localToolNames: Set<String>
     ) {
         INVENTORY(
@@ -83,7 +82,6 @@ class ToolRouter(
                 "machine", "machines", "asset", "assets", "source", "sources",
                 "label", "labels", "tag", "tags", "summary", "summaries"
             ),
-            resourcePrefixes = setOf("hosts", "groups", "inventories", "constructed_inventories", "inventory_sources", "labels"),
             localToolNames = setOf(
                 "list_inventories", "list_hosts", "get_host_facts", "get_host_job_summaries",
                 "list_groups", "list_inventory_sources", "list_labels"
@@ -99,7 +97,6 @@ class ToolRouter(
                 "survey", "node", "nodes", "prompt", "variable", "variables",
                 "approval", "approvals", "approve", "deny", "pending"
             ),
-            resourcePrefixes = setOf("jobs", "job_templates", "workflow_jobs", "workflow_job_templates", "workflow_job_nodes", "workflow_job_template_nodes", "schedules", "ad_hoc_commands", "workflow_approvals"),
             localToolNames = setOf(
                 "list_job_templates", "launch_job", "get_job", "get_job_stdout", "list_jobs",
                 "list_workflow_templates", "launch_workflow", "get_workflow_job",
@@ -116,7 +113,6 @@ class ToolRouter(
                 "monitoring", "healthy", "overview", "nodes", "workers",
                 "alive", "up", "down", "diagnostics", "group"
             ),
-            resourcePrefixes = setOf("dashboard", "ping", "config", "instances", "instance_groups", "metrics", "mesh_visualizer"),
             localToolNames = setOf("list_instances", "get_instance", "list_instance_groups", "ping", "get_mesh_topology")
         ),
         USERS(
@@ -127,7 +123,6 @@ class ToolRouter(
                 "application", "applications", "app", "apps", "access", "rbac",
                 "definition", "definitions", "oauth"
             ),
-            resourcePrefixes = setOf("users", "teams", "organizations", "roles", "role_definitions", "tokens", "applications"),
             localToolNames = setOf(
                 "list_organizations", "list_users", "list_teams",
                 "list_roles", "list_role_definitions",
@@ -141,7 +136,6 @@ class ToolRouter(
                 "password", "passwords", "key", "keys", "cert", "certs",
                 "type", "types"
             ),
-            resourcePrefixes = setOf("credentials", "credential_types", "credential_input_sources"),
             localToolNames = setOf("list_credentials", "get_credential", "list_credential_types")
         ),
         CONFIGURATION(
@@ -152,7 +146,6 @@ class ToolRouter(
                 "ees", "scm", "repo", "repos", "repository", "alert", "alerts",
                 "tag", "tags", "license", "subscription", "version"
             ),
-            resourcePrefixes = setOf("settings", "notification_templates", "notifications", "labels", "execution_environments", "projects", "config"),
             localToolNames = setOf(
                 "list_projects", "get_project", "list_execution_environments",
                 "list_notification_templates", "get_settings", "get_config"
@@ -165,7 +158,6 @@ class ToolRouter(
                 "stream", "streams", "decision", "driven", "rulebooks",
                 "activations", "events", "environment"
             ),
-            resourcePrefixes = setOf("audit_rules", "activations", "decision_environments", "rulebooks", "event_streams", "eda_credentials", "eda_credential_types", "eda_projects", "eda_users"),
             localToolNames = setOf(
                 "list_eda_audit_rules", "list_eda_activations", "get_eda_activation",
                 "list_eda_rulebooks", "list_eda_decision_environments",
@@ -179,7 +171,6 @@ class ToolRouter(
                 "service", "services", "sso", "saml", "ldap",
                 "identity", "authentication", "provider", "providers"
             ),
-            resourcePrefixes = setOf("organizations", "users", "teams", "role_definitions", "authenticators", "services", "service_clusters"),
             localToolNames = setOf(
                 "list_platform_organizations", "list_platform_users", "list_platform_teams",
                 "list_platform_role_definitions", "list_authenticators",
@@ -195,7 +186,6 @@ class ToolRouter(
                 "role", "roles",
                 "ee", "execution", "environment"
             ),
-            resourcePrefixes = setOf("hub_collections", "hub_namespaces", "hub_ee", "hub_users", "hub_groups", "hub_roles"),
             localToolNames = setOf(
                 "list_hub_collections", "list_hub_namespaces", "list_hub_approvals",
                 "list_hub_ee_repositories", "list_hub_ee_registries",
@@ -448,11 +438,8 @@ class ToolRouter(
         for (tool in mcpTools) {
             if (!isToolEnabled(tool.spec.name, ToolSource.MCP, tool.serverLabel)) continue
 
-            val passesReadOnly = if (readOnlyLabels.isNotEmpty()) {
-                if (tool.serverLabel in readOnlyLabels) {
-                    WRITE_ACTIONS.none { action -> tool.spec.name.endsWith(action) }
-                } else true
-            } else true
+            val passesReadOnly = tool.serverLabel !in readOnlyLabels ||
+                WRITE_ACTIONS.none { action -> tool.spec.name.endsWith(action) }
             if (!passesReadOnly) continue
 
             val toolToolset = tool.toolset
@@ -460,7 +447,8 @@ class ToolRouter(
             when {
                 toolsetCategories != null && matchedCategories.any { it in toolsetCategories } ->
                     routedMcp.add(tool)
-                toolToolset != null && toolsetCategories == null -> {
+                toolsetCategories != null -> { }
+                toolToolset != null -> {
                     Log.d(TAG, "FILTER: unknown toolset '${toolToolset}' for ${tool.spec.name}, treating as unrouted")
                     unroutedMcp.add(tool)
                 }
@@ -480,6 +468,8 @@ class ToolRouter(
         QueryResult(allCherryPicked, categoryMatched = true)
     }
 
+    private data class ScoredTool(val tool: Tool, val score: Int, val overlap: Int)
+
     private fun cherryPick(
         tools: List<Tool>,
         stemmedQuery: Set<String>,
@@ -495,13 +485,13 @@ class ToolRouter(
             if (tool.spec.name.contains("list") || tool.spec.name.contains("ping")) score += 3
             if (tool.spec.name.contains("get") || tool.spec.name.contains("read") || tool.spec.name.contains("retrieve")) score += 1
             if (overlap > 0 && tool.isDestructive) score -= 5
-            Triple(tool, score, overlap)
+            ScoredTool(tool, score, overlap)
         }
-        Log.d(TAG, "SCORES: ${scored.map { "${it.first.spec.name}=${it.second}" }}")
+        Log.d(TAG, "SCORES: ${scored.map { "${it.tool.spec.name}=${it.score}" }}")
         return scored
-            .filter { it.second > 0 && (!requireOverlap || it.third > 0) }
-            .sortedByDescending { it.second }
-            .map { it.first }
+            .filter { it.score > 0 && (!requireOverlap || it.overlap > 0) }
+            .sortedByDescending { it.score }
+            .map { it.tool }
     }
 
     fun getAllRegisteredTools(): List<Pair<Tool, ToolSource>> = synchronized(this) {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/CachedMcpTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/CachedMcpTool.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.json.JsonObject
 class CachedMcpTool(
     private val mcpToolDef: McpToolDefinition,
     override val serverLabel: String,
-    val toolset: String? = null,
+    override val toolset: String? = null,
     val readOnly: Boolean = false,
     private val serverManager: McpServerManager
 ) : Tool {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
@@ -1,6 +1,5 @@
 package io.github.leogallego.ansiblejane.assistant.tools
 
-import io.github.leogallego.ansiblejane.TestOnly
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.github.leogallego.ansiblejane.network.mcp.McpToolDefinition
@@ -13,7 +12,7 @@ import io.ktor.client.network.sockets.SocketTimeoutException
 import kotlinx.io.IOException
 
 class McpTool(
-    private val client: Client?,
+    private val client: Client,
     private val mcpToolDef: McpToolDefinition,
     override val serverLabel: String,
     override val toolset: String? = null
@@ -22,15 +21,6 @@ class McpTool(
     companion object {
         const val MAX_PAGE_SIZE = 10
         private val WRITE_SUFFIXES = Tool.WRITE_SUFFIXES
-
-        @TestOnly
-        fun forTest(name: String, serverLabel: String, toolset: String? = null): McpTool =
-            McpTool(
-                client = null,
-                mcpToolDef = McpToolDefinition(name, name),
-                serverLabel = serverLabel,
-                toolset = toolset
-            )
     }
 
     override val isDestructive: Boolean =
@@ -43,8 +33,6 @@ class McpTool(
     )
 
     override suspend fun execute(args: JsonObject): ToolResult {
-        val client = this.client
-            ?: return ToolResult(success = false, data = "No client (test-only instance)")
         return try {
             val cappedArgs = capPageSize(args)
             val result = client.callTool(mcpToolDef.name, cappedArgs)

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
@@ -27,7 +27,7 @@ class McpTool(
         fun forTest(name: String, serverLabel: String, toolset: String? = null): McpTool =
             McpTool(
                 client = null,
-                mcpToolDef = McpToolDefinition(name, "[$serverLabel] $name"),
+                mcpToolDef = McpToolDefinition(name, name),
                 serverLabel = serverLabel,
                 toolset = toolset
             )

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
@@ -1,5 +1,6 @@
 package io.github.leogallego.ansiblejane.assistant.tools
 
+import io.github.leogallego.ansiblejane.TestOnly
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.github.leogallego.ansiblejane.network.mcp.McpToolDefinition
@@ -12,7 +13,7 @@ import io.ktor.client.network.sockets.SocketTimeoutException
 import kotlinx.io.IOException
 
 class McpTool(
-    private val client: Client,
+    private val client: Client?,
     private val mcpToolDef: McpToolDefinition,
     override val serverLabel: String,
     val toolset: String? = null
@@ -21,6 +22,15 @@ class McpTool(
     companion object {
         const val MAX_PAGE_SIZE = 10
         private val WRITE_SUFFIXES = Tool.WRITE_SUFFIXES
+
+        @TestOnly
+        fun forTest(name: String, serverLabel: String, toolset: String? = null): McpTool =
+            McpTool(
+                client = null,
+                mcpToolDef = McpToolDefinition(name, "[$serverLabel] $name"),
+                serverLabel = serverLabel,
+                toolset = toolset
+            )
     }
 
     override val isDestructive: Boolean =
@@ -33,6 +43,8 @@ class McpTool(
     )
 
     override suspend fun execute(args: JsonObject): ToolResult {
+        val client = this.client
+            ?: return ToolResult(success = false, data = "No client (test-only instance)")
         return try {
             val cappedArgs = capPageSize(args)
             val result = client.callTool(mcpToolDef.name, cappedArgs)

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
@@ -16,7 +16,7 @@ class McpTool(
     private val client: Client?,
     private val mcpToolDef: McpToolDefinition,
     override val serverLabel: String,
-    val toolset: String? = null
+    override val toolset: String? = null
 ) : Tool {
 
     companion object {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolSpec.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolSpec.kt
@@ -14,6 +14,8 @@ interface Tool {
         get() = false
     val serverLabel: String?
         get() = null
+    val toolset: String?
+        get() = null
     suspend fun execute(args: JsonObject): ToolResult
 
     companion object {


### PR DESCRIPTION
## Summary

- MCP tools from non-AAP servers (no toolset) were silently dropped from all query results (#333)
- Now tools without a known toolset bypass category filtering but **require actual query-word overlap** in cherry-pick
- AAP tools with known toolsets are still category-filtered via `TOOLSET_CATEGORY_MAP`
- Split MCP routing into routed (toolset-based) vs unrouted (pass-through with `requireOverlap=true`)
- Added `val toolset: String?` to `Tool` interface — `McpTool`, `CachedMcpTool`, and any wrapper can now expose toolset polymorphically (#353)
- Log warning when MCP tool has unknown toolset not in `TOOLSET_CATEGORY_MAP` (#352)
- Added `McpTool.forTest()` factory for toolset-aware test instances

## Test plan

- [x] All 88 ToolRouter tests pass
- [x] SettingsViewModel tests pass
- [x] Non-AAP tool with query overlap: included
- [x] Non-AAP tool without overlap: excluded (even with list/get bonus)
- [x] AAP tools with known toolsets: category-filtered (regression)
- [x] readOnly filtering: still works with toolset-based tools

Closes #333
Closes #352
Closes #353

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>