### PR TITLE
feat: add 8 Hub read-only local tools

### DIFF
--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -1061,6 +1061,60 @@ class ToolRouterTest {
         assertFalse("list_hosts" in names)
     }
 
+    // --- Hub routing tests ---
+
+    @Test
+    fun `SHOULD select hub tools WHEN query mentions hub or collections`() {
+        val tools = listOf(
+            localTool("list_hub_collections"),
+            localTool("list_hub_namespaces"),
+            localTool("list_hub_ee_repositories"),
+            localTool("list_hosts")
+        )
+        router.registerLocalTools(tools)
+        val result = router.getToolsForQuery("show hub collections").tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("list_hub_collections" in names)
+        assertTrue("list_hub_namespaces" in names)
+        assertFalse("list_hosts" in names)
+    }
+
+    @Test
+    fun `SHOULD select hub tools WHEN query mentions galaxy or namespaces`() {
+        val tools = listOf(
+            localTool("list_hub_namespaces"),
+            localTool("list_hub_collections"),
+            localTool("list_hosts")
+        )
+        router.registerLocalTools(tools)
+        val result = router.getToolsForQuery("list galaxy namespaces").tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("list_hub_namespaces" in names)
+        assertFalse("list_hosts" in names)
+    }
+
+    @Test
+    fun `SHOULD auto-disable hub MCP overlaps WHEN local tools registered`() {
+        val localTools = listOf(
+            localTool("list_hub_collections"),
+            localTool("list_hub_users"),
+            localTool("list_hub_ee_repositories")
+        )
+        router.registerLocalTools(localTools)
+
+        assertFalse(router.isToolEnabled("collections_list", ToolSource.MCP))
+        assertFalse(router.isToolEnabled("hub_users_list", ToolSource.MCP))
+        assertFalse(router.isToolEnabled("execution_environments_repositories_list", ToolSource.MCP))
+        assertTrue(router.isToolEnabled("hub_groups_list", ToolSource.MCP))
+    }
+
+    @Test
+    fun `getCategoryForTool SHOULD return HUB for list_hub_collections`() {
+        assertEquals("HUB", ToolRouter.getCategoryForTool("list_hub_collections"))
+    }
+
     // --- Disabled tools filtering (issue #282) ---
 
     @Test

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -39,7 +39,10 @@ class ToolRouterTest {
             "list_eda_audit_rules", "list_eda_activations", "get_eda_activation",
             "list_eda_rulebooks", "list_eda_decision_environments",
             "list_eda_projects", "list_eda_credentials", "list_eda_credential_types",
-            "list_eda_event_streams", "list_eda_users"
+            "list_eda_event_streams", "list_eda_users",
+            "list_hub_collections", "list_hub_namespaces", "list_hub_approvals",
+            "list_hub_ee_repositories", "list_hub_ee_registries",
+            "list_hub_users", "list_hub_groups", "list_hub_roles"
         )
     }
 
@@ -1408,6 +1411,10 @@ class ToolRouterTest {
             "projects_retrieve", "job_templates_survey_spec_retrieve",
             "workflow_approvals_list", "workflow_approvals_approve_create",
             "workflow_approvals_deny_create", "services_list", "service_clusters_list",
+            // Hub — no MCP server exists yet
+            "collections_list", "namespaces_list", "collection_versions_list",
+            "execution_environments_repositories_list", "execution_environments_registries_list",
+            "hub_users_list", "hub_groups_list", "hub_role_definitions_list",
         )
         val verifiable = mappedMcpNames - notInEda - notYetExposed
         val notFound = verifiable.filter { it !in verifiedToolNames }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAapApiProvider.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAapApiProvider.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.fakes
 
 import io.github.leogallego.ansiblejane.network.AapApiClient
 import io.github.leogallego.ansiblejane.network.EdaApiClient
+import io.github.leogallego.ansiblejane.network.HubApiClient
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import io.github.leogallego.ansiblejane.network.PlatformApiClient
 
@@ -17,6 +18,10 @@ class FakeAapApiProvider : IAapApiProvider {
     }
 
     override fun getPlatformApiService(): PlatformApiClient {
+        throw UnsupportedOperationException("Use repository fakes instead")
+    }
+
+    override fun getHubApiService(): HubApiClient {
         throw UnsupportedOperationException("Use repository fakes instead")
     }
 

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiverTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalActionReceiverTest.kt
@@ -6,6 +6,7 @@ import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
 import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.network.AapApiClient
 import io.github.leogallego.ansiblejane.network.EdaApiClient
+import io.github.leogallego.ansiblejane.network.HubApiClient
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import io.github.leogallego.ansiblejane.network.PlatformApiClient
 import io.ktor.client.HttpClient
@@ -57,6 +58,7 @@ class ApprovalActionReceiverTest {
             override fun getApiService() = apiClient
             override fun getEdaApiService(): EdaApiClient = throw UnsupportedOperationException()
             override fun getPlatformApiService(): PlatformApiClient = throw UnsupportedOperationException()
+            override fun getHubApiService(): HubApiClient = throw UnsupportedOperationException()
             override fun evictInstance(instanceId: String) {}
         }
     }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorkerTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ApprovalPollingWorkerTest.kt
@@ -14,6 +14,7 @@ import io.github.leogallego.ansiblejane.model.PaginatedResponse
 import io.github.leogallego.ansiblejane.model.WorkflowApproval
 import io.github.leogallego.ansiblejane.network.AapApiClient
 import io.github.leogallego.ansiblejane.network.EdaApiClient
+import io.github.leogallego.ansiblejane.network.HubApiClient
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import io.github.leogallego.ansiblejane.network.PlatformApiClient
 import io.github.leogallego.ansiblejane.notification.IApprovalNotificationManager
@@ -104,6 +105,7 @@ class ApprovalPollingWorkerTest {
             override fun getApiService() = apiClient
             override fun getEdaApiService(): EdaApiClient = throw UnsupportedOperationException()
             override fun getPlatformApiService(): PlatformApiClient = throw UnsupportedOperationException()
+            override fun getHubApiService(): HubApiClient = throw UnsupportedOperationException()
             override fun evictInstance(instanceId: String) {}
         }
     }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
@@ -126,6 +126,16 @@ val sharedAssistantModule = module {
     single { ListEdaEventStreamsLocalTool(get()) } bind LocalTool::class
     single { ListEdaUsersLocalTool(get()) } bind LocalTool::class
 
+    // Hub
+    single { ListHubCollectionsLocalTool(get(), get()) } bind LocalTool::class
+    single { ListHubNamespacesLocalTool(get(), get()) } bind LocalTool::class
+    single { ListHubApprovalsLocalTool(get(), get()) } bind LocalTool::class
+    single { ListHubEeRepositoriesLocalTool(get(), get()) } bind LocalTool::class
+    single { ListHubEeRegistriesLocalTool(get(), get()) } bind LocalTool::class
+    single { ListHubUsersLocalTool(get(), get()) } bind LocalTool::class
+    single { ListHubGroupsLocalTool(get(), get()) } bind LocalTool::class
+    single { ListHubRolesLocalTool(get(), get()) } bind LocalTool::class
+
     // Meta
     single { ListToolsLocalTool { get<ToolRouter>().getAllRegisteredTools() } } bind LocalTool::class
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -186,6 +186,22 @@ class ToolRouter(
                 "list_platform_role_definitions", "list_authenticators",
                 "list_platform_services", "list_service_clusters"
             )
+        ),
+        HUB(
+            keywords = setOf(
+                "hub", "galaxy", "collection", "collections", "namespace", "namespaces",
+                "registry", "registries", "certified", "validated", "published",
+                "container", "image", "images",
+                "approval", "approvals",
+                "role", "roles",
+                "ee", "execution", "environment"
+            ),
+            resourcePrefixes = setOf("hub_collections", "hub_namespaces", "hub_ee", "hub_users", "hub_groups", "hub_roles"),
+            localToolNames = setOf(
+                "list_hub_collections", "list_hub_namespaces", "list_hub_approvals",
+                "list_hub_ee_repositories", "list_hub_ee_registries",
+                "list_hub_users", "list_hub_groups", "list_hub_roles"
+            )
         );
 
         val stemmedKeywords: Set<String> by lazy {
@@ -249,6 +265,15 @@ class ToolRouter(
             "list_role_definitions" to setOf("role_definitions_list"),
             "list_applications" to setOf("applications_list"),
             "list_tokens" to setOf("tokens_list"),
+            // Hub (no MCP server exists yet — names are speculative)
+            "list_hub_collections" to setOf("collections_list"),
+            "list_hub_namespaces" to setOf("namespaces_list"),
+            "list_hub_approvals" to setOf("collection_versions_list"),
+            "list_hub_ee_repositories" to setOf("execution_environments_repositories_list"),
+            "list_hub_ee_registries" to setOf("execution_environments_registries_list"),
+            "list_hub_users" to setOf("hub_users_list"),
+            "list_hub_groups" to setOf("hub_groups_list"),
+            "list_hub_roles" to setOf("hub_role_definitions_list"),
             // Platform / Gateway
             "list_platform_organizations" to setOf("organizations_list"),
             "list_platform_users" to setOf("users_list"),
@@ -290,6 +315,7 @@ class ToolRouter(
             "event_management" to setOf(Category.EDA),
             "integration" to setOf(Category.CONFIGURATION, Category.SECURITY, Category.USERS),
             "developer_integration" to setOf(Category.JOBS, Category.MONITORING),
+            "hub_management" to setOf(Category.HUB),
         )
 
         fun getCategoryForTool(toolName: String): String? {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubApprovalsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubApprovalsLocalTool.kt
@@ -1,0 +1,48 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.serialization.typeToken
+import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.model.AapComponent
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+
+class ListHubApprovalsLocalTool(
+    private val repository: HubRepository,
+    private val tokenManager: TokenManager
+) : AapLocalTool<ListHubApprovalsLocalTool.Args>(
+    typeToken<Args>(), Args.serializer(),
+    name = "list_hub_approvals",
+    description = "List collection versions pending approval in Private Automation Hub"
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("Filter by repository label (e.g. 'staging' for pending approval)")
+        val status: String? = null,
+        @property:LLMDescription("Page number (default 1)")
+        val page: Int = 1,
+        @property:LLMDescription("Results per page (default 20, max 20)")
+        @SerialName("page_size")
+        val pageSize: Int = 20
+    )
+
+    override suspend fun execute(args: Args): String {
+        val info = tokenManager.activeInstance.value?.instanceInfo
+        if (info != null && !info.hasComponent(AapComponent.HUB)) {
+            return """{"error": "Hub is not available on this instance"}"""
+        }
+        val result = repository.getCollectionVersions(
+            page = args.page.coerceAtLeast(1),
+            pageSize = args.pageSize.coerceIn(1, 20),
+            status = args.status
+        ).getOrThrow()
+        return networkJson.encodeToString(mapOf(
+            "count" to result.totalCount.toString(),
+            "collection_versions" to networkJson.encodeToString(result.items)
+        ))
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubCollectionsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubCollectionsLocalTool.kt
@@ -1,0 +1,48 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.serialization.typeToken
+import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.model.AapComponent
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+
+class ListHubCollectionsLocalTool(
+    private val repository: HubRepository,
+    private val tokenManager: TokenManager
+) : AapLocalTool<ListHubCollectionsLocalTool.Args>(
+    typeToken<Args>(), Args.serializer(),
+    name = "list_hub_collections",
+    description = "List Ansible content collections available in Private Automation Hub"
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("Search term to filter collections by keyword")
+        val search: String? = null,
+        @property:LLMDescription("Page number (default 1)")
+        val page: Int = 1,
+        @property:LLMDescription("Results per page (default 20, max 20)")
+        @SerialName("page_size")
+        val pageSize: Int = 20
+    )
+
+    override suspend fun execute(args: Args): String {
+        val info = tokenManager.activeInstance.value?.instanceInfo
+        if (info != null && !info.hasComponent(AapComponent.HUB)) {
+            return """{"error": "Hub is not available on this instance"}"""
+        }
+        val result = repository.getCollections(
+            page = args.page.coerceAtLeast(1),
+            pageSize = args.pageSize.coerceIn(1, 20),
+            search = args.search
+        ).getOrThrow()
+        return networkJson.encodeToString(mapOf(
+            "count" to result.totalCount.toString(),
+            "collections" to networkJson.encodeToString(result.items)
+        ))
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRegistriesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRegistriesLocalTool.kt
@@ -1,0 +1,48 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.serialization.typeToken
+import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.model.AapComponent
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+
+class ListHubEeRegistriesLocalTool(
+    private val repository: HubRepository,
+    private val tokenManager: TokenManager
+) : AapLocalTool<ListHubEeRegistriesLocalTool.Args>(
+    typeToken<Args>(), Args.serializer(),
+    name = "list_hub_ee_registries",
+    description = "List remote container registries configured in Private Automation Hub"
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("Search term to filter registries by name")
+        val search: String? = null,
+        @property:LLMDescription("Page number (default 1)")
+        val page: Int = 1,
+        @property:LLMDescription("Results per page (default 20, max 20)")
+        @SerialName("page_size")
+        val pageSize: Int = 20
+    )
+
+    override suspend fun execute(args: Args): String {
+        val info = tokenManager.activeInstance.value?.instanceInfo
+        if (info != null && !info.hasComponent(AapComponent.HUB)) {
+            return """{"error": "Hub is not available on this instance"}"""
+        }
+        val result = repository.getEeRegistries(
+            page = args.page.coerceAtLeast(1),
+            pageSize = args.pageSize.coerceIn(1, 20),
+            search = args.search
+        ).getOrThrow()
+        return networkJson.encodeToString(mapOf(
+            "count" to result.totalCount.toString(),
+            "ee_registries" to networkJson.encodeToString(result.items)
+        ))
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRepositoriesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRepositoriesLocalTool.kt
@@ -1,0 +1,48 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.serialization.typeToken
+import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.model.AapComponent
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+
+class ListHubEeRepositoriesLocalTool(
+    private val repository: HubRepository,
+    private val tokenManager: TokenManager
+) : AapLocalTool<ListHubEeRepositoriesLocalTool.Args>(
+    typeToken<Args>(), Args.serializer(),
+    name = "list_hub_ee_repositories",
+    description = "List execution environment image repositories in Private Automation Hub"
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("Search term to filter repositories by name")
+        val search: String? = null,
+        @property:LLMDescription("Page number (default 1)")
+        val page: Int = 1,
+        @property:LLMDescription("Results per page (default 20, max 20)")
+        @SerialName("page_size")
+        val pageSize: Int = 20
+    )
+
+    override suspend fun execute(args: Args): String {
+        val info = tokenManager.activeInstance.value?.instanceInfo
+        if (info != null && !info.hasComponent(AapComponent.HUB)) {
+            return """{"error": "Hub is not available on this instance"}"""
+        }
+        val result = repository.getEeRepositories(
+            page = args.page.coerceAtLeast(1),
+            pageSize = args.pageSize.coerceIn(1, 20),
+            search = args.search
+        ).getOrThrow()
+        return networkJson.encodeToString(mapOf(
+            "count" to result.totalCount.toString(),
+            "ee_repositories" to networkJson.encodeToString(result.items)
+        ))
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubGroupsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubGroupsLocalTool.kt
@@ -1,0 +1,45 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.serialization.typeToken
+import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.model.AapComponent
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+
+class ListHubGroupsLocalTool(
+    private val repository: HubRepository,
+    private val tokenManager: TokenManager
+) : AapLocalTool<ListHubGroupsLocalTool.Args>(
+    typeToken<Args>(), Args.serializer(),
+    name = "list_hub_groups",
+    description = "List groups in Private Automation Hub for role-based access control"
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("Page number (default 1)")
+        val page: Int = 1,
+        @property:LLMDescription("Results per page (default 20, max 20)")
+        @SerialName("page_size")
+        val pageSize: Int = 20
+    )
+
+    override suspend fun execute(args: Args): String {
+        val info = tokenManager.activeInstance.value?.instanceInfo
+        if (info != null && !info.hasComponent(AapComponent.HUB)) {
+            return """{"error": "Hub is not available on this instance"}"""
+        }
+        val result = repository.getGroups(
+            page = args.page.coerceAtLeast(1),
+            pageSize = args.pageSize.coerceIn(1, 20)
+        ).getOrThrow()
+        return networkJson.encodeToString(mapOf(
+            "count" to result.totalCount.toString(),
+            "groups" to networkJson.encodeToString(result.items)
+        ))
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubNamespacesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubNamespacesLocalTool.kt
@@ -1,0 +1,48 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.serialization.typeToken
+import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.model.AapComponent
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+
+class ListHubNamespacesLocalTool(
+    private val repository: HubRepository,
+    private val tokenManager: TokenManager
+) : AapLocalTool<ListHubNamespacesLocalTool.Args>(
+    typeToken<Args>(), Args.serializer(),
+    name = "list_hub_namespaces",
+    description = "List namespaces in Private Automation Hub that organize collections"
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("Search term to filter namespaces by keyword")
+        val search: String? = null,
+        @property:LLMDescription("Page number (default 1)")
+        val page: Int = 1,
+        @property:LLMDescription("Results per page (default 20, max 20)")
+        @SerialName("page_size")
+        val pageSize: Int = 20
+    )
+
+    override suspend fun execute(args: Args): String {
+        val info = tokenManager.activeInstance.value?.instanceInfo
+        if (info != null && !info.hasComponent(AapComponent.HUB)) {
+            return """{"error": "Hub is not available on this instance"}"""
+        }
+        val result = repository.getNamespaces(
+            page = args.page.coerceAtLeast(1),
+            pageSize = args.pageSize.coerceIn(1, 20),
+            search = args.search
+        ).getOrThrow()
+        return networkJson.encodeToString(mapOf(
+            "count" to result.totalCount.toString(),
+            "namespaces" to networkJson.encodeToString(result.items)
+        ))
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubRolesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubRolesLocalTool.kt
@@ -1,0 +1,45 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.serialization.typeToken
+import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.model.AapComponent
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+
+class ListHubRolesLocalTool(
+    private val repository: HubRepository,
+    private val tokenManager: TokenManager
+) : AapLocalTool<ListHubRolesLocalTool.Args>(
+    typeToken<Args>(), Args.serializer(),
+    name = "list_hub_roles",
+    description = "List role definitions in Private Automation Hub for permissions management"
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("Page number (default 1)")
+        val page: Int = 1,
+        @property:LLMDescription("Results per page (default 20, max 20)")
+        @SerialName("page_size")
+        val pageSize: Int = 20
+    )
+
+    override suspend fun execute(args: Args): String {
+        val info = tokenManager.activeInstance.value?.instanceInfo
+        if (info != null && !info.hasComponent(AapComponent.HUB)) {
+            return """{"error": "Hub is not available on this instance"}"""
+        }
+        val result = repository.getRoleDefinitions(
+            page = args.page.coerceAtLeast(1),
+            pageSize = args.pageSize.coerceIn(1, 20)
+        ).getOrThrow()
+        return networkJson.encodeToString(mapOf(
+            "count" to result.totalCount.toString(),
+            "role_definitions" to networkJson.encodeToString(result.items)
+        ))
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubUsersLocalTool.kt
@@ -1,0 +1,45 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.serialization.typeToken
+import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.model.AapComponent
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+
+class ListHubUsersLocalTool(
+    private val repository: HubRepository,
+    private val tokenManager: TokenManager
+) : AapLocalTool<ListHubUsersLocalTool.Args>(
+    typeToken<Args>(), Args.serializer(),
+    name = "list_hub_users",
+    description = "List users in Private Automation Hub"
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("Page number (default 1)")
+        val page: Int = 1,
+        @property:LLMDescription("Results per page (default 20, max 20)")
+        @SerialName("page_size")
+        val pageSize: Int = 20
+    )
+
+    override suspend fun execute(args: Args): String {
+        val info = tokenManager.activeInstance.value?.instanceInfo
+        if (info != null && !info.hasComponent(AapComponent.HUB)) {
+            return """{"error": "Hub is not available on this instance"}"""
+        }
+        val result = repository.getUsers(
+            page = args.page.coerceAtLeast(1),
+            pageSize = args.pageSize.coerceIn(1, 20)
+        ).getOrThrow()
+        return networkJson.encodeToString(mapOf(
+            "count" to result.totalCount.toString(),
+            "users" to networkJson.encodeToString(result.items)
+        ))
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/DataModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/DataModule.kt
@@ -37,4 +37,5 @@ val sharedRepositoryModule = module {
     single { ControllerReadOnlyRepository(get<IAapApiProvider>()) }
     single { EdaReadOnlyRepository(get<IAapApiProvider>()) }
     single { PlatformRepository(get<IAapApiProvider>()) }
+    single { HubRepository(get<IAapApiProvider>()) }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/HubRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/HubRepository.kt
@@ -1,0 +1,98 @@
+package io.github.leogallego.ansiblejane.data
+
+import io.github.leogallego.ansiblejane.model.*
+import io.github.leogallego.ansiblejane.network.IAapApiProvider
+
+class HubRepository(private val apiProvider: IAapApiProvider) {
+
+    suspend fun getCollections(
+        page: Int = 1,
+        pageSize: Int = 20,
+        search: String? = null
+    ): Result<ListResult<HubCollection>> = runV3Paginated {
+        apiProvider.getHubApiService().getCollections(page, pageSize, search)
+    }
+
+    suspend fun getNamespaces(
+        page: Int = 1,
+        pageSize: Int = 20,
+        search: String? = null
+    ): Result<ListResult<HubNamespace>> = runV3Paginated {
+        apiProvider.getHubApiService().getNamespaces(page, pageSize, search)
+    }
+
+    suspend fun getCollectionVersions(
+        page: Int = 1,
+        pageSize: Int = 20,
+        status: String? = null
+    ): Result<ListResult<HubCollectionVersion>> = runV3Paginated {
+        apiProvider.getHubApiService().getCollectionVersions(page, pageSize, status)
+    }
+
+    suspend fun getEeRepositories(
+        page: Int = 1,
+        pageSize: Int = 20,
+        search: String? = null
+    ): Result<ListResult<HubEeRepository>> = runV3Paginated {
+        apiProvider.getHubApiService().getEeRepositories(page, pageSize, search)
+    }
+
+    suspend fun getEeRegistries(
+        page: Int = 1,
+        pageSize: Int = 20,
+        search: String? = null
+    ): Result<ListResult<HubEeRegistry>> = runV3Paginated {
+        apiProvider.getHubApiService().getEeRegistries(page, pageSize, search)
+    }
+
+    suspend fun getUsers(
+        page: Int = 1,
+        pageSize: Int = 20
+    ): Result<ListResult<HubUser>> = runV3Paginated {
+        apiProvider.getHubApiService().getUsers(page, pageSize)
+    }
+
+    suspend fun getGroups(
+        page: Int = 1,
+        pageSize: Int = 20
+    ): Result<ListResult<HubGroup>> = runV3Paginated {
+        apiProvider.getHubApiService().getGroups(page, pageSize)
+    }
+
+    suspend fun getRoleDefinitions(
+        page: Int = 1,
+        pageSize: Int = 20
+    ): Result<ListResult<HubRoleDefinition>> = runPaginated {
+        apiProvider.getHubApiService().getRoleDefinitions(page, pageSize)
+    }
+
+    private inline fun <T> runPaginated(
+        block: () -> PaginatedResponse<T>
+    ): Result<ListResult<T>> = try {
+        val response = block()
+        Result.success(
+            ListResult(
+                items = response.results,
+                hasMore = response.next != null,
+                totalCount = response.count
+            )
+        )
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    private inline fun <T> runV3Paginated(
+        block: () -> GalaxyV3Response<T>
+    ): Result<ListResult<T>> = try {
+        val response = block()
+        Result.success(
+            ListResult(
+                items = response.data,
+                hasMore = response.links.next != null,
+                totalCount = response.meta.count
+            )
+        )
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/HubModels.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/HubModels.kt
@@ -1,0 +1,107 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GalaxyV3Response<T>(
+    val meta: GalaxyV3Meta = GalaxyV3Meta(),
+    val links: GalaxyV3Links = GalaxyV3Links(),
+    val data: List<T> = emptyList()
+)
+
+@Serializable
+data class GalaxyV3Meta(
+    val count: Int = 0
+)
+
+@Serializable
+data class GalaxyV3Links(
+    val first: String? = null,
+    val previous: String? = null,
+    val next: String? = null,
+    val last: String? = null
+)
+
+@Serializable
+data class HubCollection(
+    val href: String = "",
+    val namespace: String = "",
+    val name: String = "",
+    val description: String = "",
+    val deprecated: Boolean = false,
+    @SerialName("highest_version") val highestVersion: HubCollectionVersionSummary? = null,
+    @SerialName("created_at") val createdAt: String = "",
+    @SerialName("updated_at") val updatedAt: String = ""
+)
+
+@Serializable
+data class HubCollectionVersionSummary(
+    val version: String = "",
+    val href: String = ""
+)
+
+@Serializable
+data class HubNamespace(
+    val name: String = "",
+    val company: String = "",
+    val description: String = "",
+    @SerialName("avatar_url") val avatarUrl: String = ""
+)
+
+@Serializable
+data class HubCollectionVersion(
+    val namespace: String = "",
+    val name: String = "",
+    val version: String = "",
+    val status: String = "",
+    val repository: String = "",
+    @SerialName("created_at") val createdAt: String = "",
+    @SerialName("updated_at") val updatedAt: String = ""
+)
+
+@Serializable
+data class HubEeRepository(
+    val id: String = "",
+    val name: String = "",
+    val description: String? = null,
+    @SerialName("created_at") val createdAt: String = "",
+    @SerialName("updated_at") val updatedAt: String = ""
+)
+
+@Serializable
+data class HubEeRegistry(
+    val id: Int = 0,
+    val name: String = "",
+    val url: String = "",
+    @SerialName("download_concurrency") val downloadConcurrency: Int = 0,
+    @SerialName("rate_limit") val rateLimit: Int = 0,
+    val created: String = "",
+    val modified: String = ""
+)
+
+@Serializable
+data class HubUser(
+    val id: Int = 0,
+    val username: String = "",
+    val email: String = "",
+    @SerialName("first_name") val firstName: String = "",
+    @SerialName("last_name") val lastName: String = "",
+    @SerialName("is_superuser") val isSuperuser: Boolean = false
+)
+
+@Serializable
+data class HubGroup(
+    val id: Int = 0,
+    val name: String = ""
+)
+
+@Serializable
+data class HubRoleDefinition(
+    val id: Int = 0,
+    val name: String = "",
+    val description: String = "",
+    val permissions: List<String> = emptyList(),
+    @SerialName("content_type") val contentType: String? = null,
+    val managed: Boolean = false
+)

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/HttpClientFactory.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/HttpClientFactory.kt
@@ -20,6 +20,7 @@ private data class ClientGroup(
     val controller: AapApiClient,
     val eda: EdaApiClient? = null,
     val platform: PlatformApiClient? = null,
+    val hub: HubApiClient? = null,
     val httpClients: List<HttpClient> = emptyList()
 )
 
@@ -94,6 +95,32 @@ class HttpClientFactory(
             httpClients = existingClients + newClients
         )
         platformClient
+    }
+
+    override fun getHubApiService(): HubApiClient = synchronized(this) {
+        val instance = tokenManager.activeInstance.value
+            ?: throw IllegalStateException("No active AAP instance. Please log in first.")
+
+        val cached = clientCache[instance.id]
+        if (cached?.hub != null) return@synchronized cached.hub
+
+        val client = buildClient(instance.baseUrl, "/api/galaxy/", instance.trustSelfSigned, instance.id)
+        val hubClient = HubApiClient(client)
+
+        val existingClients = cached?.httpClients ?: emptyList()
+        val newClients = mutableListOf(client)
+        val controllerClient = cached?.controller ?: run {
+            val apiVersion = resolveApiVersion(instance.apiVersion)
+            val ctrlHttp = buildClient(instance.baseUrl, apiVersion.prefix, instance.trustSelfSigned, instance.id)
+            newClients.add(ctrlHttp)
+            AapApiClient(ctrlHttp)
+        }
+        val base = cached ?: ClientGroup(controller = controllerClient)
+        clientCache[instance.id] = base.copy(
+            hub = hubClient,
+            httpClients = existingClients + newClients
+        )
+        hubClient
     }
 
     override fun evictInstance(instanceId: String) {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/HubApiClient.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/HubApiClient.kt
@@ -1,0 +1,84 @@
+package io.github.leogallego.ansiblejane.network
+
+import io.github.leogallego.ansiblejane.model.*
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+
+class HubApiClient(private val client: HttpClient) {
+
+    suspend fun getCollections(
+        page: Int = 1,
+        pageSize: Int = 20,
+        search: String? = null
+    ): GalaxyV3Response<HubCollection> = client.get("v3/plugin/ansible/content/published/collections/index/") {
+        parameter("offset", (page - 1) * pageSize)
+        parameter("limit", pageSize)
+        search?.let { parameter("keywords", it) }
+    }.body()
+
+    suspend fun getNamespaces(
+        page: Int = 1,
+        pageSize: Int = 20,
+        search: String? = null
+    ): GalaxyV3Response<HubNamespace> = client.get("v3/namespaces/") {
+        parameter("offset", (page - 1) * pageSize)
+        parameter("limit", pageSize)
+        search?.let { parameter("keywords", it) }
+    }.body()
+
+    suspend fun getCollectionVersions(
+        page: Int = 1,
+        pageSize: Int = 20,
+        status: String? = null
+    ): GalaxyV3Response<HubCollectionVersion> = client.get("_ui/v1/collection-versions/") {
+        parameter("offset", (page - 1) * pageSize)
+        parameter("limit", pageSize)
+        status?.let { parameter("repository_label", it) }
+    }.body()
+
+    suspend fun getEeRepositories(
+        page: Int = 1,
+        pageSize: Int = 20,
+        search: String? = null
+    ): GalaxyV3Response<HubEeRepository> = client.get("v3/plugin/execution-environments/repositories/") {
+        parameter("offset", (page - 1) * pageSize)
+        parameter("limit", pageSize)
+        search?.let { parameter("name__icontains", it) }
+    }.body()
+
+    suspend fun getEeRegistries(
+        page: Int = 1,
+        pageSize: Int = 20,
+        search: String? = null
+    ): GalaxyV3Response<HubEeRegistry> = client.get("_ui/v1/execution-environments/registries/") {
+        parameter("offset", (page - 1) * pageSize)
+        parameter("limit", pageSize)
+        search?.let { parameter("name__icontains", it) }
+    }.body()
+
+    suspend fun getUsers(
+        page: Int = 1,
+        pageSize: Int = 20
+    ): GalaxyV3Response<HubUser> = client.get("_ui/v1/users/") {
+        parameter("offset", (page - 1) * pageSize)
+        parameter("limit", pageSize)
+    }.body()
+
+    suspend fun getGroups(
+        page: Int = 1,
+        pageSize: Int = 20
+    ): GalaxyV3Response<HubGroup> = client.get("_ui/v1/groups/") {
+        parameter("offset", (page - 1) * pageSize)
+        parameter("limit", pageSize)
+    }.body()
+
+    suspend fun getRoleDefinitions(
+        page: Int = 1,
+        pageSize: Int = 20
+    ): PaginatedResponse<HubRoleDefinition> = client.get("_ui/v2/role_definitions/") {
+        parameter("page", page)
+        parameter("limit", pageSize)
+    }.body()
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/IAapApiProvider.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/IAapApiProvider.kt
@@ -4,5 +4,6 @@ interface IAapApiProvider {
     fun getApiService(): AapApiClient
     fun getEdaApiService(): EdaApiClient
     fun getPlatformApiService(): PlatformApiClient
+    fun getHubApiService(): HubApiClient
     fun evictInstance(instanceId: String)
 }


### PR DESCRIPTION
## Summary

Closes #139

Adds `HubApiClient` (8 endpoints), `HubRepository`, data models, and 8 local tools for Private Automation Hub / Galaxy NG resources. All endpoints verified against live AAP 2.7 instance (#347).

**New tools:** `list_hub_collections`, `list_hub_namespaces`, `list_hub_approvals`, `list_hub_ee_repositories`, `list_hub_ee_registries`, `list_hub_users`, `list_hub_groups`, `list_hub_roles`

## Changes

- `HubApiClient.kt` — 8 endpoints (2 Galaxy v3, 5 `_ui/v1`, 1 `_ui/v2`), base path `/api/galaxy/`
- `HubModels.kt` — `GalaxyV3Response<T>` wrapper + 10 data classes
- `HubRepository.kt` — dual pagination helpers (`runV3Paginated` / `runPaginated`)
- `IAapApiProvider.kt` + `HttpClientFactory.kt` — Hub client support
- `ToolRouter.kt` — `HUB` category with keywords, overlap mappings, toolset mapping
- `AssistantDiModule.kt` + `DataModule.kt` — Koin registrations
- 3 test fakes updated for `getHubApiService()`

## Key decisions

- **GalaxyV3Response** — Hub uses `meta`/`links`/`data` format for all endpoints except `_ui/v2/role_definitions/` (standard DRF)
- **offset/limit pagination** — all Galaxy endpoints use offset/limit, converted from page number
- **Component gating** — all tools check `AapComponent.HUB` before calling APIs
- **Collections long-form path** — `v3/plugin/ansible/content/published/collections/index/` (short form 302 redirects)

## Review summary

Two review rounds + live API testing completed. Full findings documented in [PR #350 comment](https://github.com/leogallego/ansible-jane/pull/350#issuecomment-4747645772). PR #350 was merged prematurely and reverted (#354). This is the clean re-land.

## Deferred

- #346 — Migrate tool constructors from `TokenManager` to `ITokenManager`
- #347 — Remaining Hub API verification (search params, populated data)

## Test plan

- [x] `shared:compileKotlinJvm` passes
- [x] All 8 endpoints verified against AAP 2.7
- [x] CI `Build and test` passed (on prior PR #350)
- [ ] Full `assembleDebug` build
- [ ] Deploy to device, test each tool via chat

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>