### PR TITLE
fix: rethrow CancellationException in repository and tool catch blocks

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
@@ -7,6 +7,7 @@ import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.platform.DataStoreFactory
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -180,6 +181,8 @@ class AssistantRepository(
                 val apiKey = tokenManager.loadLlmApiKey(key)
                 DebugLog.d(TAG, "ACTIVE_FLOW: provider=$key, apiKeyPresent=${apiKey != null}")
                 if (apiKey != null) mergeApiKeyValue(config, apiKey) else config
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 DebugLog.w(TAG, "Failed to deserialize active config from flow: ${e.message}")
                 null
@@ -199,6 +202,8 @@ class AssistantRepository(
                     val apiKey = keys[providerKey]
                     if (apiKey != null) mergeApiKeyValue(config, apiKey) else config
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 DebugLog.w(TAG, "Failed to deserialize saved configs from flow: ${e.message}")
                 emptyMap()

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/ModelFetcher.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/ModelFetcher.kt
@@ -5,6 +5,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -28,6 +29,8 @@ class ModelFetcher(
                     header(HttpHeaders.Authorization, "Bearer $apiKey")
                 }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             return Result.Error("Could not reach server: ${e.message}")
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
@@ -14,7 +14,7 @@ import io.github.leogallego.ansiblejane.assistant.llm.LlmTimeoutException
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
 import io.github.leogallego.ansiblejane.assistant.tools.toToolDescriptor
-import kotlinx.coroutines.CancellationException
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/AapLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/AapLocalTool.kt
@@ -5,6 +5,7 @@ import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.serialization.TypeToken
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.Serializable
@@ -41,6 +42,8 @@ abstract class AapLocalTool<TArgs : Any>(
             data = "$fields required but missing",
             errorType = ErrorType.NOT_FOUND
         )
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         ToolResult(
             success = false,

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/CachedMcpTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/CachedMcpTool.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.assistant.tools
 
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
+import kotlin.coroutines.cancellation.CancellationException
 import io.github.leogallego.ansiblejane.network.mcp.McpToolDefinition
 import kotlinx.serialization.json.JsonObject
 
@@ -40,6 +41,8 @@ class CachedMcpTool(
             } else {
                 ToolResult(success = true, data = text)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             ToolResult(
                 success = false,

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import io.ktor.client.network.sockets.SocketTimeoutException
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.io.IOException
 
 class McpTool(
@@ -58,6 +59,8 @@ class McpTool(
                 data = "Connection error: ${e.message}",
                 errorType = ErrorType.CONNECTION_ERROR
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             ToolResult(
                 success = false,

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
@@ -51,6 +51,8 @@ class McpTool(
             } else {
                 ToolResult(success = true, data = text)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: SocketTimeoutException) {
             ToolResult(success = false, data = "Tool call timed out", errorType = ErrorType.TIMEOUT)
         } catch (e: IOException) {
@@ -59,8 +61,6 @@ class McpTool(
                 data = "Connection error: ${e.message}",
                 errorType = ErrorType.CONNECTION_ERROR
             )
-        } catch (e: CancellationException) {
-            throw e
         } catch (e: Exception) {
             ToolResult(
                 success = false,

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/AuthRepository.kt
@@ -52,6 +52,8 @@ class AuthRepository(
             launchDiscovery(instanceId, baseUrl, token, apiVersion, trustSelfSigned)
 
             Result.success(user)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -85,6 +87,8 @@ class AuthRepository(
             launchDiscovery(instanceId, instance.baseUrl, newToken, apiVersion, trustSelfSigned)
 
             Result.success(user)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -110,6 +114,8 @@ class AuthRepository(
                 Exception("No user data returned")
             )
             CredentialStatus.Valid(user)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             CredentialStatus.ValidationFailed(e)
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/AuthRepository.kt
@@ -14,7 +14,7 @@ import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.coroutines.CancellationException
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ControllerReadOnlyRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ControllerReadOnlyRepository.kt
@@ -3,6 +3,7 @@ package io.github.leogallego.ansiblejane.data
 import io.github.leogallego.ansiblejane.model.*
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import kotlinx.serialization.json.JsonElement
+import kotlin.coroutines.cancellation.CancellationException
 
 class ControllerReadOnlyRepository(private val apiProvider: IAapApiProvider) {
 
@@ -103,12 +104,16 @@ class ControllerReadOnlyRepository(private val apiProvider: IAapApiProvider) {
 
     suspend fun getSettings(): Result<JsonElement> = try {
         Result.success(apiProvider.getApiService().getSettings())
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Result.failure(e)
     }
 
     suspend fun getConfig(): Result<JsonElement> = try {
         Result.success(apiProvider.getApiService().getConfig())
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Result.failure(e)
     }
@@ -123,6 +128,8 @@ class ControllerReadOnlyRepository(private val apiProvider: IAapApiProvider) {
 
     suspend fun getSurveySpec(id: Int): Result<SurveySpec> = try {
         Result.success(apiProvider.getApiService().getSurveySpec(id))
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Result.failure(e)
     }
@@ -138,6 +145,8 @@ class ControllerReadOnlyRepository(private val apiProvider: IAapApiProvider) {
                 totalCount = response.count
             )
         )
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Result.failure(e)
     }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/CredentialRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/CredentialRepository.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.data
 
 import io.github.leogallego.ansiblejane.model.Credential
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import kotlin.coroutines.cancellation.CancellationException
 
 class CredentialRepository(private val apiProvider: IAapApiProvider) : ICredentialRepository {
 
@@ -23,6 +24,8 @@ class CredentialRepository(private val apiProvider: IAapApiProvider) : ICredenti
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -31,6 +34,8 @@ class CredentialRepository(private val apiProvider: IAapApiProvider) : ICredenti
     override suspend fun getCredential(id: Int): Result<Credential> {
         return try {
             Result.success(apiProvider.getApiService().getCredential(id))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/EdaActivationRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/EdaActivationRepository.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.data
 
 import io.github.leogallego.ansiblejane.model.EdaActivation
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import kotlin.coroutines.cancellation.CancellationException
 
 class EdaActivationRepository(private val apiProvider: IAapApiProvider) : IEdaActivationRepository {
 
@@ -21,6 +22,8 @@ class EdaActivationRepository(private val apiProvider: IAapApiProvider) : IEdaAc
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -29,6 +32,8 @@ class EdaActivationRepository(private val apiProvider: IAapApiProvider) : IEdaAc
     override suspend fun getActivation(id: Int): Result<EdaActivation> {
         return try {
             Result.success(apiProvider.getEdaApiService().getActivation(id))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/EdaAuditRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/EdaAuditRepository.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.data
 
 import io.github.leogallego.ansiblejane.model.EdaRuleAudit
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import kotlin.coroutines.cancellation.CancellationException
 
 class EdaAuditRepository(private val apiProvider: IAapApiProvider) : IEdaAuditRepository {
 
@@ -19,6 +20,8 @@ class EdaAuditRepository(private val apiProvider: IAapApiProvider) : IEdaAuditRe
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/EdaReadOnlyRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/EdaReadOnlyRepository.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.data
 
 import io.github.leogallego.ansiblejane.model.*
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import kotlin.coroutines.cancellation.CancellationException
 
 class EdaReadOnlyRepository(private val apiProvider: IAapApiProvider) {
 
@@ -71,6 +72,8 @@ class EdaReadOnlyRepository(private val apiProvider: IAapApiProvider) {
                 totalCount = response.count
             )
         )
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Result.failure(e)
     }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/HostRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/HostRepository.kt
@@ -3,6 +3,7 @@ package io.github.leogallego.ansiblejane.data
 import io.github.leogallego.ansiblejane.model.Host
 import io.github.leogallego.ansiblejane.model.JobHostSummary
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.json.JsonElement
 
 class HostRepository(private val apiProvider: IAapApiProvider) : IHostRepository {
@@ -25,6 +26,8 @@ class HostRepository(private val apiProvider: IAapApiProvider) : IHostRepository
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -50,6 +53,8 @@ class HostRepository(private val apiProvider: IAapApiProvider) : IHostRepository
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -58,6 +63,8 @@ class HostRepository(private val apiProvider: IAapApiProvider) : IHostRepository
     override suspend fun getHostFacts(hostId: Int): Result<Map<String, JsonElement>> {
         return try {
             Result.success(apiProvider.getApiService().getHostFacts(hostId))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -81,6 +88,8 @@ class HostRepository(private val apiProvider: IAapApiProvider) : IHostRepository
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/InfrastructureRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/InfrastructureRepository.kt
@@ -4,6 +4,7 @@ import io.github.leogallego.ansiblejane.model.Instance
 import io.github.leogallego.ansiblejane.model.InstanceGroup
 import io.github.leogallego.ansiblejane.model.PingResponse
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.json.JsonElement
 
 class InfrastructureRepository(private val apiProvider: IAapApiProvider) : IInfrastructureRepository {
@@ -24,6 +25,8 @@ class InfrastructureRepository(private val apiProvider: IAapApiProvider) : IInfr
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -32,6 +35,8 @@ class InfrastructureRepository(private val apiProvider: IAapApiProvider) : IInfr
     override suspend fun getInstance(id: Int): Result<Instance> {
         return try {
             Result.success(apiProvider.getApiService().getInstance(id))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -53,6 +58,8 @@ class InfrastructureRepository(private val apiProvider: IAapApiProvider) : IInfr
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -61,6 +68,8 @@ class InfrastructureRepository(private val apiProvider: IAapApiProvider) : IInfr
     override suspend fun ping(): Result<PingResponse> {
         return try {
             Result.success(apiProvider.getApiService().ping())
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -69,6 +78,8 @@ class InfrastructureRepository(private val apiProvider: IAapApiProvider) : IInfr
     override suspend fun getMeshTopology(): Result<JsonElement> {
         return try {
             Result.success(apiProvider.getApiService().getMeshTopology())
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/InventoryRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/InventoryRepository.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.data
 
 import io.github.leogallego.ansiblejane.model.Inventory
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import kotlin.coroutines.cancellation.CancellationException
 
 class InventoryRepository(private val apiProvider: IAapApiProvider) : IInventoryRepository {
 
@@ -23,6 +24,8 @@ class InventoryRepository(private val apiProvider: IAapApiProvider) : IInventory
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -31,6 +34,8 @@ class InventoryRepository(private val apiProvider: IAapApiProvider) : IInventory
     override suspend fun getInventory(id: Int): Result<Inventory> {
         return try {
             Result.success(apiProvider.getApiService().getInventory(id))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/JobRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/JobRepository.kt
@@ -3,6 +3,7 @@ package io.github.leogallego.ansiblejane.data
 import io.github.leogallego.ansiblejane.model.Job
 import io.github.leogallego.ansiblejane.model.JobStatus
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -12,6 +13,8 @@ class JobRepository(private val apiProvider: IAapApiProvider) : IJobRepository {
     override suspend fun getJobStatus(jobId: Int): Result<Job> {
         return try {
             Result.success(apiProvider.getApiService().getJob(jobId))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -34,6 +37,8 @@ class JobRepository(private val apiProvider: IAapApiProvider) : IJobRepository {
         return try {
             val response = apiProvider.getApiService().getJobStdout(jobId)
             Result.success(response)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -73,6 +78,8 @@ class JobRepository(private val apiProvider: IAapApiProvider) : IJobRepository {
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/PlatformRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/PlatformRepository.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.data
 
 import io.github.leogallego.ansiblejane.model.*
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import kotlin.coroutines.cancellation.CancellationException
 
 class PlatformRepository(private val apiProvider: IAapApiProvider) {
 
@@ -69,6 +70,8 @@ class PlatformRepository(private val apiProvider: IAapApiProvider) {
                 totalCount = response.count
             )
         )
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Result.failure(e)
     }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ProjectRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ProjectRepository.kt
@@ -3,6 +3,7 @@ package io.github.leogallego.ansiblejane.data
 import io.github.leogallego.ansiblejane.model.ExecutionEnvironment
 import io.github.leogallego.ansiblejane.model.Project
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import kotlin.coroutines.cancellation.CancellationException
 
 class ProjectRepository(private val apiProvider: IAapApiProvider) : IProjectRepository {
 
@@ -24,6 +25,8 @@ class ProjectRepository(private val apiProvider: IAapApiProvider) : IProjectRepo
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -32,6 +35,8 @@ class ProjectRepository(private val apiProvider: IAapApiProvider) : IProjectRepo
     override suspend fun getProject(id: Int): Result<Project> {
         return try {
             Result.success(apiProvider.getApiService().getProject(id))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -53,6 +58,8 @@ class ProjectRepository(private val apiProvider: IAapApiProvider) : IProjectRepo
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ScheduleRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ScheduleRepository.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.data
 
 import io.github.leogallego.ansiblejane.model.Schedule
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import kotlin.coroutines.cancellation.CancellationException
 
 class ScheduleRepository(private val apiProvider: IAapApiProvider) : IScheduleRepository {
 
@@ -18,6 +19,8 @@ class ScheduleRepository(private val apiProvider: IAapApiProvider) : IScheduleRe
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -27,6 +30,8 @@ class ScheduleRepository(private val apiProvider: IAapApiProvider) : IScheduleRe
         return try {
             val updated = apiProvider.getApiService().toggleSchedule(id, mapOf("enabled" to enabled))
             Result.success(updated)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/TemplateRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/TemplateRepository.kt
@@ -3,6 +3,7 @@ package io.github.leogallego.ansiblejane.data
 import io.github.leogallego.ansiblejane.model.JobTemplate
 import io.github.leogallego.ansiblejane.model.LaunchRequest
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import kotlin.coroutines.cancellation.CancellationException
 
 class TemplateRepository(private val apiProvider: IAapApiProvider) : ITemplateRepository {
 
@@ -24,6 +25,8 @@ class TemplateRepository(private val apiProvider: IAapApiProvider) : ITemplateRe
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -34,6 +37,8 @@ class TemplateRepository(private val apiProvider: IAapApiProvider) : ITemplateRe
             val request = LaunchRequest(extraVars = extraVars)
             val response = apiProvider.getApiService().launchJob(templateId, request)
             Result.success(response.job)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ToolManifestRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ToolManifestRepository.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import io.github.leogallego.ansiblejane.model.ToolManifest
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlin.time.Clock
 import kotlinx.serialization.encodeToString
@@ -48,6 +49,8 @@ class ToolManifestRepository(
                 }
                 else -> manifest
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.w(TAG, "Failed to deserialize manifest for $instanceId: ${e.message}")
             deleteManifest(instanceId)

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/WorkflowRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/WorkflowRepository.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.data
 
 import io.github.leogallego.ansiblejane.model.LaunchRequest
 import io.github.leogallego.ansiblejane.model.WorkflowApproval
+import kotlin.coroutines.cancellation.CancellationException
 import io.github.leogallego.ansiblejane.model.WorkflowJob
 import io.github.leogallego.ansiblejane.model.WorkflowJobTemplate
 import io.github.leogallego.ansiblejane.model.WorkflowJobTemplateNode
@@ -31,6 +32,8 @@ class WorkflowRepository(private val apiProvider: IAapApiProvider) : IWorkflowRe
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -41,6 +44,8 @@ class WorkflowRepository(private val apiProvider: IAapApiProvider) : IWorkflowRe
             val request = LaunchRequest(extraVars = extraVars)
             val response = apiProvider.getApiService().launchWorkflowJob(templateId, request)
             Result.success(response.workflowJob)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -49,6 +54,8 @@ class WorkflowRepository(private val apiProvider: IAapApiProvider) : IWorkflowRe
     override suspend fun getWorkflowJobStatus(workflowJobId: Int): Result<WorkflowJob> {
         return try {
             Result.success(apiProvider.getApiService().getWorkflowJob(workflowJobId))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -73,6 +80,8 @@ class WorkflowRepository(private val apiProvider: IAapApiProvider) : IWorkflowRe
                 page++
             } while (response.next != null)
             Result.success(all)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -92,6 +101,8 @@ class WorkflowRepository(private val apiProvider: IAapApiProvider) : IWorkflowRe
                 page++
             } while (response.next != null)
             Result.success(all)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -100,6 +111,8 @@ class WorkflowRepository(private val apiProvider: IAapApiProvider) : IWorkflowRe
     override suspend fun getWorkflowApproval(approvalId: Int): Result<WorkflowApproval> {
         return try {
             Result.success(apiProvider.getApiService().getWorkflowApproval(approvalId))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -119,6 +132,8 @@ class WorkflowRepository(private val apiProvider: IAapApiProvider) : IWorkflowRe
                     totalCount = response.count
                 )
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -128,6 +143,8 @@ class WorkflowRepository(private val apiProvider: IAapApiProvider) : IWorkflowRe
         return try {
             apiProvider.getApiService().approveWorkflow(approvalId)
             Result.success(Unit)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -137,6 +154,8 @@ class WorkflowRepository(private val apiProvider: IAapApiProvider) : IWorkflowRe
         return try {
             apiProvider.getApiService().denyWorkflow(approvalId)
             Result.success(Unit)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/backup/BackupManager.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/backup/BackupManager.kt
@@ -8,6 +8,7 @@ import dev.whyoleg.cryptography.algorithms.SHA256
 import dev.whyoleg.cryptography.random.CryptographyRandom
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.model.AapInstance
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 
@@ -39,6 +40,8 @@ class BackupManager {
     suspend fun importBackup(data: ByteArray, password: String): BackupEnvelope {
         val plaintext = try {
             decrypt(data, password)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             throw BackupDecryptionException("Incorrect password or corrupted backup")
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/InstanceDiscovery.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/InstanceDiscovery.kt
@@ -6,6 +6,7 @@ import io.github.leogallego.ansiblejane.model.InstanceInfo
 import io.github.leogallego.ansiblejane.model.PlatformType
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import kotlin.coroutines.cancellation.CancellationException
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
@@ -144,6 +145,8 @@ class InstanceDiscovery(private val json: Json) {
         } else {
             null
         }
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Log.d(TAG, "Version probe $url failed: ${e.message}")
         null
@@ -173,6 +176,8 @@ class InstanceDiscovery(private val json: Json) {
         } else {
             null
         }
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Log.d(TAG, "Config probe failed: ${e.message}")
         null
@@ -184,6 +189,8 @@ class InstanceDiscovery(private val json: Json) {
     ): Boolean = try {
         val response = client.get(url)
         response.status.isSuccess()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Log.d(TAG, "Probe $url failed: ${e.message}")
         false

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManager.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManager.kt
@@ -14,7 +14,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import kotlin.concurrent.Volatile
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
-import kotlinx.coroutines.CancellationException
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -128,6 +128,8 @@ class McpServerManager(
                 val state = connectAndDiscover(config.url, ktorClient)
                 registerServer(config.label, state, config.toolset)
                 state.client
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _connections.update {
                     it + (serverLabel to McpConnectionState.Error(

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManager.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManager.kt
@@ -74,6 +74,8 @@ class McpServerManager(
             val state = connectAndDiscover(config.url, ktorClient)
             Log.d(TAG, "Connected '${config.label}': ${state.toolDefs.size} tools, server=${state.serverInfo.name}/${state.serverInfo.version}")
             registerServer(config.label, state, config.toolset)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.w(TAG, "Failed to connect '${config.label}': ${e.message}")
             _connections.update {
@@ -212,6 +214,9 @@ class McpServerManager(
                                 SdkClientState(sdkClient, ktorClient, serverInfo, toolDefs),
                                 config.toolset
                             )
+                        } catch (e: CancellationException) {
+                            closeSafely(sdkClient, ktorClient)
+                            throw e
                         } catch (e: Exception) {
                             closeSafely(sdkClient, ktorClient)
                             _connections.update {


### PR DESCRIPTION
## Summary

Closes #356.

All repository classes, tool classes, and infrastructure code caught broad `Exception` around suspend calls without rethrowing `CancellationException`, breaking structured concurrency cancellation propagation. When a coroutine was cancelled (user navigates away, ViewModel scope cleared), the exception was wrapped in `Result.failure()` instead of propagating, causing the agentic loop to waste an extra iteration (~30s timeout) before detecting the cancellation.

Added `catch (e: CancellationException) { throw e }` before every `catch (e: Exception)` that wraps a suspend call across **27 files** (144 lines added).

### Files changed

**Shared helpers (highest impact — used by ~20+ methods):**
- `ControllerReadOnlyRepository.runPaginated` + 3 direct methods
- `PlatformRepository.runPaginated`
- `EdaReadOnlyRepository.runEdaPaginated`

**Repositories (15 files):**
WorkflowRepository (9 blocks), HostRepository (4), JobRepository (3), InfrastructureRepository (5), AuthRepository (3), ProjectRepository (3), TemplateRepository (2), ScheduleRepository (2), InventoryRepository (2), CredentialRepository (2), EdaActivationRepository (2), EdaAuditRepository (1)

**Tools and engine (6 files):**
AapLocalTool, McpTool, CachedMcpTool, McpServerManager (3 blocks), ModelFetcher, ToolManifestRepository

**Additional sites found during review (6 files):**
- InstanceDiscovery (3 blocks — suspend `httpClient.get()`)
- AssistantRepository (2 blocks — suspend `tokenManager.loadLlmApiKey()` in Flow.map)
- BackupManager (1 block — suspend `decrypt()`)
- McpServerManager.ensureConnected (skip spurious Error state on cancellation)
- McpTool (reordered CE catch before SocketTimeout/IOException for consistency)
- Normalized all imports to `kotlin.coroutines.cancellation.CancellationException`

## Test plan

- [x] `shared:compileKotlinJvm` — compiles cleanly
- [x] `shared:jvmTest` — all tests pass
- [x] `app:compileDebugKotlin` — compiles cleanly
- [x] `app:testDebugUnitTest --tests "assistant.*"` — all assistant tests pass

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>