### PR TITLE
docs: add architecture service contracts and PR review skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Formal contracts are documented in `docs/architecture/service-contracts.md`. Key
 - **Interface requirement**: Every repository must have an `IXxxRepository` interface. Koin binds to interfaces, never concrete types.
 - **Module isolation**: `shared/` has zero dependencies on `app/` or `composeApp/`. `commonMain` never imports Android/JVM APIs.
 - **State exposure**: ViewModels expose `StateFlow<XxxUiState>`, never `MutableStateFlow`. UiState uses sealed classes with `Idle`/`Loading`/`Success`/`Error`.
-- **Tool contracts**: Local tools extend `LocalTool`. MCP tools implement `McpTool`. Both satisfy the `Tool` sealed interface.
+- **Tool contracts**: Local tools implement the `LocalTool` interface. MCP tools are instances of the `McpTool` class. Both satisfy the `Tool` interface.
 
 When reviewing PRs, load the `skills/pr-architecture-review/SKILL.md` skill to check changes against these contracts. It auto-loads relevant Kotlin/Android skills based on which files changed.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,18 @@ Rules:
 - **Presentation:** ViewModels with `StateFlow<UiState>` (Idle, Loading, Success, Error pattern) in `composeApp`.
 - **Platform abstractions (`shared/.../platform/`):** `expect`/`actual` classes for `SecureKeyStorage`, `DataStoreFactory`, `ConnectivityObserver`, `BackgroundWorker`, `PlatformUtils`, `NotificationManager`, `TlsTrustManager`, `HttpEngine`.
 
+## Kotlin Architecture Contracts
+
+Formal contracts are documented in `docs/architecture/service-contracts.md`. Key rules enforced during PR review:
+
+- **Layer discipline**: UI → Presentation → Engine → Repository → Network → Platform. No skipping.
+- **Interface requirement**: Every repository must have an `IXxxRepository` interface. Koin binds to interfaces, never concrete types.
+- **Module isolation**: `shared/` has zero dependencies on `app/` or `composeApp/`. `commonMain` never imports Android/JVM APIs.
+- **State exposure**: ViewModels expose `StateFlow<XxxUiState>`, never `MutableStateFlow`. UiState uses sealed classes with `Idle`/`Loading`/`Success`/`Error`.
+- **Tool contracts**: Local tools extend `LocalTool`. MCP tools implement `McpTool`. Both satisfy the `Tool` sealed interface.
+
+When reviewing PRs, load the `skills/pr-architecture-review/SKILL.md` skill to check changes against these contracts. It auto-loads relevant Kotlin/Android skills based on which files changed.
+
 ## AI Assistant Architecture
 
 The AI assistant (`assistant/` package in `app/` module, Android-only for now) provides natural-language interaction with AAP via tool-use LLMs. The engine, LLM providers, and tools have zero Android dependencies and are planned to move to `shared/commonMain` (#243). Full pipeline flow with component responsibilities is documented in `docs/reference/tool-pipeline-architecture.md`.

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -36,15 +36,17 @@ layers below it. No layer skipping is permitted.
 │ May depend on: Model, Platform                      │
 ├─────────────────────────────────────────────────────┤
 │ Layer 1: Platform & Models                          │
-│ Domain models, expect/actual, error types            │
+│ Domain models (accessible to all layers above)      │
+│ Platform expect/actual (restricted to Repository+)  │
 │ May depend on: Kotlin stdlib only                   │
 └─────────────────────────────────────────────────────┘
 ```
 
 ### Hard Rules
 
-- **No layer skipping.** UI must not import from Repository, Network, or Platform.
-  ViewModels must not import from Network. Repositories must not import from Presentation.
+- **No layer skipping.** UI must not import from Repository, Network, or Platform
+  (domain models in `model/` are accessible to all layers). ViewModels must not import
+  from Network. Repositories must not import from Presentation.
 - **No upward dependencies.** Network never imports from Presentation or UI.
   Repository never imports from Presentation or UI.
 - **Composables never call repository or network methods directly.** All data access
@@ -97,9 +99,10 @@ for one-shot discovery of external endpoints would be over-engineering.
 
 ### Tool Contracts
 
-- Local tools must extend `LocalTool` abstract class.
-- MCP tools implement `McpTool`.
-- Both satisfy the `Tool` sealed interface defined in `shared/.../tools/ToolSpec.kt`.
+- Local tools implement the `LocalTool` interface (which extends `Tool`).
+- MCP tools are instances of the `McpTool` concrete class, constructed from MCP server
+  discovery data at runtime. You do not subclass `McpTool`.
+- Both satisfy the `Tool` interface defined in `shared/.../tools/ToolSpec.kt`.
 - New local tools must be registered in `AssistantDiModule` with `bind LocalTool::class`.
 
 ---
@@ -205,8 +208,8 @@ for one-shot discovery of external endpoints would be over-engineering.
 ### Hard Rules
 
 - **Interfaces:** `IXxxRepository`, `IXxxManager` (prefix `I`)
-- **Internal variables:** `__prefix` double-underscore for non-public internal state
-  (follows Ansible convention for role variables)
+- **Backing fields:** `_prefix` single-underscore for private mutable backing fields
+  (standard Kotlin convention, e.g., `private val _uiState`)
 - **Files:** `snake_case` for Ansible content, `PascalCase` for Kotlin files
 - **Packages:** `lowercase` following Kotlin conventions
 

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -1,0 +1,286 @@
+# Ansible Jane — Architecture Service Contracts
+
+This document defines the enforceable architecture contracts for the Ansible Jane codebase.
+These contracts are checked during PR review (see `skills/pr-architecture-review/SKILL.md`).
+
+Violations of **hard rules** must be fixed before merge. **Soft guidelines** are advisory
+and flagged as recommendations.
+
+---
+
+## 1. Layer Architecture
+
+The codebase follows a strict 6-layer architecture. Each layer may only depend on the
+layers below it. No layer skipping is permitted.
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Layer 6: UI (Composables)                           │
+│ Renders state, captures user events                 │
+│ May depend on: Presentation, Model                  │
+├─────────────────────────────────────────────────────┤
+│ Layer 5: Presentation (ViewModels)                  │
+│ Manages UI state via StateFlow, orchestrates        │
+│ May depend on: Repository, Engine, Model            │
+├─────────────────────────────────────────────────────┤
+│ Layer 4: Engine (ChatEngine, ToolRouter)             │
+│ Business rules, tool orchestration, agentic loop    │
+│ May depend on: Repository, Tool definitions, Model  │
+├─────────────────────────────────────────────────────┤
+│ Layer 3: Repository (Data Access)                   │
+│ Data abstraction, caching, source coordination      │
+│ May depend on: Network, Platform, Model             │
+├─────────────────────────────────────────────────────┤
+│ Layer 2: Network (HTTP + MCP)                       │
+│ HTTP transport, MCP discovery, API facades          │
+│ May depend on: Model, Platform                      │
+├─────────────────────────────────────────────────────┤
+│ Layer 1: Platform & Models                          │
+│ Domain models, expect/actual, error types            │
+│ May depend on: Kotlin stdlib only                   │
+└─────────────────────────────────────────────────────┘
+```
+
+### Hard Rules
+
+- **No layer skipping.** UI must not import from Repository, Network, or Platform.
+  ViewModels must not import from Network. Repositories must not import from Presentation.
+- **No upward dependencies.** Network never imports from Presentation or UI.
+  Repository never imports from Presentation or UI.
+- **Composables never call repository or network methods directly.** All data access
+  goes through ViewModel state observation (`collectAsState`).
+- **ViewModels never instantiate HTTP clients.** Network access goes through
+  repositories, which use `IAapApiProvider`.
+
+### Permitted Exception
+
+`SettingsViewModel` may use `ModelFetcher` directly for dynamic LLM model discovery
+from user-provided URLs. This is documented and intentional — creating a repository
+for one-shot discovery of external endpoints would be over-engineering.
+
+---
+
+## 2. Interface Contracts
+
+### Hard Rules
+
+- **Every repository must have an interface.** The interface is named `IXxxRepository`
+  and lives in the same package as the implementation. The implementation is named
+  `XxxRepository`.
+
+  ```kotlin
+  // ✅ Correct
+  interface IJobRepository { ... }
+  class JobRepository(...) : IJobRepository { ... }
+
+  // ❌ Wrong: no interface
+  class JobRepository(...) { ... }
+  ```
+
+- **Koin binds to interfaces, never concrete types.** Use `bind IXxxRepository::class`.
+
+  ```kotlin
+  // ✅ Correct
+  single { JobRepository(get()) } bind IJobRepository::class
+
+  // ❌ Wrong: binds to concrete type
+  single { JobRepository(get()) }
+  ```
+
+- **API service interfaces are grouped by AAP component.** Three interfaces exist:
+  - `AapApiService` — Controller endpoints (`/api/v2/`)
+  - `EdaApiService` — EDA endpoints (`/api/eda/v1/`)
+  - `PlatformApiService` — Gateway endpoints (`/api/gateway/v1/`)
+
+  New API endpoints must be added to the appropriate existing interface. Do not create
+  new API service interfaces without an ADR.
+
+### Tool Contracts
+
+- Local tools must extend `LocalTool` abstract class.
+- MCP tools implement `McpTool`.
+- Both satisfy the `Tool` sealed interface defined in `shared/.../tools/ToolSpec.kt`.
+- New local tools must be registered in `AssistantDiModule` with `bind LocalTool::class`.
+
+---
+
+## 3. Module Boundaries
+
+### Hard Rules
+
+| Module | May depend on | Must not depend on |
+|--------|---------------|--------------------|
+| `app/` | `shared`, `composeApp` | — |
+| `composeApp/` | `shared` | `app/` |
+| `shared/` | — | `app/`, `composeApp/` |
+
+- **`commonMain` must never import Android or JVM APIs.** No `android.*`, `java.*`,
+  or `javax.*` imports in `commonMain` source sets.
+- **`expect`/`actual` requires both platforms.** Do not create `expect` declarations
+  unless you will implement `actual` in both `androidMain` and `jvmMain`. Android-only
+  features go in `app/` without ceremony.
+- **Shared logic must not live in `app/`.** If a tool, repository, or engine feature
+  is in `app/`, desktop can never reach it. Use `shared/commonMain` for reusable logic.
+
+### Source Set Rules
+
+| Source set | Purpose | Allowed imports |
+|------------|---------|-----------------|
+| `commonMain` | Cross-platform logic | Kotlin stdlib, Ktor, kotlinx.*, Koin |
+| `androidMain` | Android platform implementations | Android SDK, AndroidX |
+| `jvmMain` | Desktop platform implementations | JVM stdlib, java.* |
+| `desktopMain` | Desktop UI specifics | Compose Desktop APIs |
+
+---
+
+## 4. State Management Contracts
+
+### Hard Rules
+
+- **ViewModels expose `StateFlow<XxxUiState>`, never `MutableStateFlow`.** The mutable
+  backing field is private.
+
+  ```kotlin
+  // ✅ Correct
+  private val _uiState = MutableStateFlow<JobUiState>(JobUiState.Idle)
+  val uiState: StateFlow<JobUiState> = _uiState.asStateFlow()
+
+  // ❌ Wrong: exposes mutable state
+  val uiState = MutableStateFlow<JobUiState>(JobUiState.Idle)
+  ```
+
+- **UiState uses sealed classes/interfaces** with the standard variants:
+  - `Idle` — initial state before any action
+  - `Loading` — operation in progress
+  - `Success` — operation completed, holds result data
+  - `Error` — operation failed, holds error message/type
+
+  ```kotlin
+  sealed interface JobUiState {
+      data object Idle : JobUiState
+      data object Loading : JobUiState
+      data class Success(val jobs: List<Job>) : JobUiState
+      data class Error(val message: String) : JobUiState
+  }
+  ```
+
+- **One-time events are modeled separately from persistent UiState.** Use `Channel`
+  or `SharedFlow` for navigation events, snackbars, toasts — not as states in the
+  sealed class.
+
+### Soft Guidelines
+
+- Prefer `stateIn` with `SharingStarted.WhileSubscribed(5000)` for repository-backed
+  flows to avoid unnecessary upstream work.
+- Use `combine` for composing multiple state sources rather than nested `collect` blocks.
+
+---
+
+## 5. Dependency Injection Contracts
+
+### Hard Rules
+
+- **All DI uses Koin.** No Hilt, no Dagger, no manual service locators.
+- **DI modules are organized by layer:**
+  - `sharedNetworkModule` — HTTP, API discovery
+  - `sharedDataModule` + `sharedRepositoryModule` — Data access, repositories
+  - `sharedAssistantModule` — Engine, tools, MCP
+  - `presentationModule` — ViewModels
+- **ViewModels are injected via `koinViewModel()` in Composables** or `viewModelOf(::XxxViewModel)`
+  in module definitions.
+- **New repositories, tools, and services must be registered in the appropriate Koin module.**
+  Do not instantiate collaborators manually in constructors when Koin can provide them.
+
+### Soft Guidelines
+
+- Prefer constructor injection over field injection.
+- Use `single {}` for stateful services (repositories, managers).
+- Use `factory {}` for stateless utilities.
+- Use `named()` qualifier only when multiple instances of the same type are needed.
+
+---
+
+## 6. Naming Conventions
+
+### Hard Rules
+
+- **Interfaces:** `IXxxRepository`, `IXxxManager` (prefix `I`)
+- **Internal variables:** `__prefix` double-underscore for non-public internal state
+  (follows Ansible convention for role variables)
+- **Files:** `snake_case` for Ansible content, `PascalCase` for Kotlin files
+- **Packages:** `lowercase` following Kotlin conventions
+
+### Soft Guidelines
+
+- ViewModels: `XxxViewModel`
+- UiState: `XxxUiState`
+- Screens: `XxxScreen`
+- Composable components: descriptive name matching function purpose
+- Local tools: `XxxLocalTool` with tool name as `snake_case` (e.g., `list_job_templates`)
+
+---
+
+## 7. File Size and Complexity Guidelines
+
+### Soft Guidelines
+
+- **400 LOC warning threshold.** Files exceeding 400 lines should be examined for
+  single-responsibility violations. Not all large files are problems — some domains
+  are inherently complex.
+
+- **Documented exceptions** (currently acceptable):
+  - `ChatEngine.kt` (~509 LOC) — agentic loop orchestration is inherently complex
+  - `ToolRouter.kt` (~485 LOC) — category matching + scoring + MCP/local merging
+  - `AapApiClient.kt` (~413 LOC) — REST facade with 50+ endpoint wrappers
+  - `TokenManager.kt` (~422 LOC) — token lifecycle (candidate for future extraction)
+  - `McpServerManager.kt` (~357 LOC) — MCP connection lifecycle
+
+- **Extraction signals:** A file likely needs splitting when it has:
+  - More than 3 distinct responsibilities (e.g., networking + caching + validation + formatting)
+  - Multiple groups of private helper methods that don't interact
+  - Constructor with more than 6 dependencies
+
+---
+
+## 8. Error Handling Contract
+
+### Hard Rules
+
+- **Use `AppError` sealed class** for domain errors. Do not use raw strings or
+  platform exceptions as the error model.
+- **Transport errors are normalized at the repository boundary.** Ktor exceptions
+  become `AppError` variants before reaching ViewModels.
+- **User-facing error messages are derived in the Presentation layer.** Repositories
+  return structured errors; ViewModels format them for display.
+
+### Soft Guidelines
+
+- Distinguish retryable vs non-retryable errors where relevant.
+- Auth failures (401/403) should trigger token refresh or re-authentication flow,
+  not generic error display.
+
+---
+
+## 9. Security Contracts
+
+### Hard Rules
+
+- **No hardcoded URLs, tokens, or credentials.** All secrets go through
+  `TokenManager` → DataStore + cryptography-kotlin (AES-256-GCM).
+- **HTTPS only.** Enforced via `network_security_config.xml`. Self-signed certs
+  are supported via `TlsTrustManager` with explicit user opt-in per instance.
+- **Never use `EncryptedSharedPreferences`.** It is deprecated in this project.
+  Migration shims in `androidMain` are for legacy data only.
+- **Sensitive data stays in minimum layers.** Tokens live in `TokenManager` only.
+  ViewModels and UI never hold raw tokens.
+
+---
+
+## Versioning
+
+This document follows the project's semver scheme. Updates require a PR with
+rationale for the change. The PR review skill checks against the version in `main`.
+
+| Version | Date | Change |
+|---------|------|--------|
+| 1.0.0 | 2026-06-18 | Initial contracts derived from codebase audit |

--- a/docs/reference/skills-reference.md
+++ b/docs/reference/skills-reference.md
@@ -91,6 +91,7 @@ Bundled with this repo. Read with `Read` tool before relevant work.
 | **Edge-to-edge** | `android-official/edge-to-edge.md` |
 | **Gradle config** | `android-community/gradle-configuration.md` |
 | **Architecture review** | `kotlin-project-architecture-review/` |
+| **PR contract review** | `pr-architecture-review/` (project-specific, checks `docs/architecture/service-contracts.md`) |
 | **Feature implementation** | `kotlin-project-feature-implementation/` |
 | **Bug fixing** | `kotlin-project-bugfix/` |
 

--- a/docs/superpowers/specs/2026-06-18-pr-architecture-review-design.md
+++ b/docs/superpowers/specs/2026-06-18-pr-architecture-review-design.md
@@ -1,0 +1,90 @@
+# PR Architecture Review Skill — Design Spec
+
+**Date:** 2026-06-18
+**Status:** Approved
+
+## Problem
+
+The Ansible Jane codebase has a clean 6-layer architecture with 17 repository interfaces,
+consistent Koin DI, and proper module boundaries. However, these patterns are implicit —
+they exist in code but are not formally documented as enforceable contracts. Future Claude
+sessions reviewing PRs have no systematic way to verify new code adheres to these patterns.
+
+Additionally, the project has ~20 Kotlin/Android skills in `skills/` but no guidance on
+which to load for a given review. Reviewers either load none (missing relevant checks)
+or must manually decide (inconsistent coverage).
+
+## Solution
+
+Three deliverables:
+
+### 1. Architecture Service Contracts (`docs/architecture/service-contracts.md`)
+
+Formal documentation of the project's architecture rules, derived from a comprehensive
+codebase audit. Covers:
+
+- 6-layer architecture with dependency rules (hard rules, no exceptions)
+- Interface contracts (IXxxRepository pattern, Koin binding requirements)
+- Module boundaries (shared/composeApp/app isolation)
+- State management contracts (StateFlow exposure, UiState sealed classes)
+- DI contracts (Koin modules, registration patterns)
+- Naming conventions
+- File size guidelines with documented exceptions
+- Error handling and security contracts
+
+Rules are categorized as **hard rules** (must-fix violations) or **soft guidelines**
+(advisory recommendations).
+
+### 2. PR Review Skill (`skills/pr-architecture-review/SKILL.md`)
+
+A skill that Claude sessions invoke when reviewing PRs. The skill:
+
+1. Loads the service contracts as its source of truth
+2. Analyzes which files changed and categorizes them by layer/module
+3. Always loads a core skill set (coroutines, Flow, KMP expect/actual, Koin)
+4. Auto-detects additional skills from changed file patterns (Compose for UI changes,
+   data layer skill for repository changes, etc.)
+5. Runs hard rule checks against every changed file
+6. Runs soft guideline checks for pattern drift
+7. Produces structured findings with clear must-fix vs consider categorization
+
+### 3. CLAUDE.md Section
+
+A concise "Kotlin Architecture Contracts" section in the project CLAUDE.md that
+summarizes the key rules and points to the full contracts document. Ensures every
+Claude session is aware of the contracts without needing to discover them.
+
+## Architecture Decisions
+
+### Why not CI enforcement?
+
+The project's current size (~313 Kotlin files) doesn't justify custom lint rules or
+import-graph CI checks. The skill-based review approach is lighter, adapts as the
+architecture evolves, and catches semantic violations (not just syntactic ones) that
+static analysis would miss.
+
+### Why separate contracts doc instead of inline in CLAUDE.md?
+
+CLAUDE.md is already large. The contracts doc has detailed rationale, examples, and
+versioning that would bloat CLAUDE.md. The summary section in CLAUDE.md is sufficient
+for awareness; the full doc is loaded by the review skill when needed.
+
+### Why auto-detect skills instead of loading all?
+
+Loading all ~20 skills would overwhelm context. Auto-detection based on changed files
+ensures relevant expertise without noise. The core set (coroutines, Flow, KMP, Koin)
+covers patterns that affect every PR regardless of domain.
+
+## Audit Findings
+
+The codebase audit found the architecture is already in excellent shape:
+
+- **17 repository interfaces** with consistent IXxxRepository naming
+- **Clean 6-layer separation** with no layer skipping
+- **1 intentional violation** (SettingsViewModel ModelFetcher) — documented as exception
+- **5 files over 300 LOC** — all justified (ChatEngine, ToolRouter, AapApiClient,
+  TokenManager, McpServerManager)
+- **Consistent Koin DI** with 4 modules and interface bindings
+- **Perfect platform isolation** — no Android/JVM imports in commonMain
+
+The contracts codify this existing good state to prevent regression.

--- a/docs/superpowers/specs/2026-06-18-pr-architecture-review-design.md
+++ b/docs/superpowers/specs/2026-06-18-pr-architecture-review-design.md
@@ -82,7 +82,7 @@ The codebase audit found the architecture is already in excellent shape:
 - **17 repository interfaces** with consistent IXxxRepository naming
 - **Clean 6-layer separation** with no layer skipping
 - **1 intentional violation** (SettingsViewModel ModelFetcher) — documented as exception
-- **5 files over 300 LOC** — all justified (ChatEngine, ToolRouter, AapApiClient,
+- **5 files over 400 LOC** — all justified (ChatEngine, ToolRouter, AapApiClient,
   TokenManager, McpServerManager)
 - **Consistent Koin DI** with 4 modules and interface bindings
 - **Perfect platform isolation** — no Android/JVM imports in commonMain

--- a/skills/README.md
+++ b/skills/README.md
@@ -86,6 +86,10 @@ From [mmiani/kotlin-kmp-claude-agent-skills](https://github.com/mmiani/kotlin-km
 - **kotlin-kmp-refactor-safety** - 4-phase refactoring, parallel implementation prevention, rollback
 - **kotlin-kmp-code-review** - 24-priority architect-level review, escalation criteria
 
+### `pr-architecture-review/` - Project Architecture Contract Review
+Project-specific (Apache 2.0)
+- **pr-architecture-review** - PR review skill that checks changes against `docs/architecture/service-contracts.md`. Verifies layer discipline, interface contracts, module boundaries, state management, DI patterns. Auto-loads relevant Kotlin/Android skills based on changed files.
+
 ### `kotlin-kmp-abstraction-decision/` - KMP Abstraction Decision Framework
 From [vitorpamplona/amethyst](https://github.com/vitorpamplona/amethyst) (MIT)
 - **kotlin-kmp-abstraction-decision** - Decision tree for platform abstraction: what goes in commonMain vs expect/actual vs platform-specific. Abstraction tiers (always/sometimes/rarely/never), mechanism selection order, common pitfalls

--- a/skills/pr-architecture-review/SKILL.md
+++ b/skills/pr-architecture-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pr-architecture-review
 description: Use when reviewing PRs for architecture contract compliance in Ansible Jane. Checks layer discipline, interface contracts, module boundaries, state management, DI patterns, and naming conventions against docs/architecture/service-contracts.md. Auto-loads relevant Kotlin/Android skills based on changed files.
+license: Apache-2.0
 metadata:
   version: "1.0.0"
 ---
@@ -107,7 +108,7 @@ For any new or modified repository:
 - Verify the interface is in the same package as the implementation
 
 For any new tool:
-- Verify it extends `LocalTool` or implements `McpTool`
+- Verify it implements the `LocalTool` interface
 - Verify it is registered in `AssistantDiModule` with `bind LocalTool::class`
 
 #### 5c. Module boundaries
@@ -247,7 +248,7 @@ Examples:
 
 ## What this skill does NOT cover
 
-- **Line-level code quality** — use `kotlin-project-code-review` skill
+- **Line-level code quality** — use `kotlin-kmp-code-review` skill
 - **Compose recomposition performance** — use `compose-recomposition-performance` skill
 - **Ansible content quality** — use CLAUDE.md Ansible rules
 - **General PR correctness** — use the `code-review` superpowers skill

--- a/skills/pr-architecture-review/SKILL.md
+++ b/skills/pr-architecture-review/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: pr-architecture-review
+description: Use when reviewing PRs for architecture contract compliance in Ansible Jane. Checks layer discipline, interface contracts, module boundaries, state management, DI patterns, and naming conventions against docs/architecture/service-contracts.md. Auto-loads relevant Kotlin/Android skills based on changed files.
+metadata:
+  version: "1.0.0"
+---
+
+# PR Architecture Review
+
+Review pull requests against this project's architecture service contracts.
+
+This skill is **project-specific** — it checks changes against the enforceable rules
+in `docs/architecture/service-contracts.md`. It complements (does not replace) the
+generic `kotlin-project-architecture-review` and `kotlin-project-code-review` skills
+by grounding their dimensions in this project's actual contracts.
+
+---
+
+## When to use
+
+- Reviewing any PR to this repository
+- Reviewing a branch diff before creating a PR
+- Auditing code changes for architecture compliance
+- When asked to "check architecture" or "review for contracts"
+
+---
+
+## Review procedure
+
+Follow these steps in order. Do not skip steps.
+
+### Step 1: Load service contracts
+
+Read `docs/architecture/service-contracts.md` in full. This is the source of truth
+for all contract checks. If the file has been modified in the PR itself, review
+those modifications for correctness first.
+
+### Step 2: Identify changed files
+
+Get the full diff of the PR or branch. Categorize every changed file by layer
+and module:
+
+| Layer | Package patterns |
+|-------|-----------------|
+| UI | `ui/`, `screen/`, `component/`, Composable functions |
+| Presentation | `presentation/`, `*ViewModel.kt` |
+| Engine | `assistant/engine/`, `ChatEngine`, `ToolRouter`, `ToolExecutor` |
+| Repository | `data/`, `*Repository.kt`, `*Manager.kt` |
+| Network | `network/`, `*ApiClient.kt`, `*ApiService.kt`, `mcp/` |
+| Platform | `platform/`, `androidMain/`, `jvmMain/`, `desktopMain/` |
+| Model | `model/`, data classes, sealed classes |
+| DI | `di/`, `*Module.kt` |
+| Tools | `tools/`, `*LocalTool.kt`, `*McpTool.kt` |
+| Test | `*Test.kt`, `test/` |
+
+### Step 3: Load core skills
+
+Always read these skills before reviewing, regardless of which files changed:
+
+- `skills/kotlin-coroutines-structured-concurrency/SKILL.md`
+- `skills/kotlin-flow-state-event-modeling/SKILL.md`
+- `skills/kotlin-multiplatform-expect-actual/SKILL.md`
+- `skills/android-community/koin-editor.md`
+
+### Step 4: Auto-detect and load extra skills
+
+Based on which files changed, load additional skills:
+
+| Changed files match | Load skill |
+|--------------------|------------|
+| `ui/`, `presentation/`, `*Screen.kt` | `skills/compose-skill/SKILL.md` |
+| `ui/`, `*Screen.kt` with state hoisting | `skills/compose-state-hoisting/SKILL.md` |
+| `assistant/engine/`, module boundaries | `skills/kotlin-project-architecture-review/SKILL.md` |
+| `data/`, `*Repository.kt`, `network/` | `skills/kotlin-data-kmp-data-layer/SKILL.md` |
+| `platform/`, `expect`/`actual` | `skills/kotlin-kmp-abstraction-decision/SKILL.md` |
+| `*Test.kt`, test infrastructure | `skills/kotlin-testing-kmp/SKILL.md`, `skills/compose-ui-testing-patterns/SKILL.md` |
+| `*ViewModel.kt`, state management | `skills/kotlin-flow-state-event-modeling/SKILL.md` |
+| Navigation, routing | `skills/kotlin-navigation-compose-multiplatform/SKILL.md` |
+| Compose performance concerns | `skills/compose-recomposition-performance/SKILL.md` |
+
+Log which skills were loaded and why.
+
+### Step 5: Run contract checks
+
+For each changed file, check against the hard rules in the service contracts.
+These are **must-fix** findings — the PR should not merge with violations.
+
+#### 5a. Layer discipline
+
+For every import statement in changed files, verify:
+- UI files do not import from `data/`, `network/`, or `platform/`
+- Presentation files do not import from `network/`
+- Repository files do not import from `presentation/` or `ui/`
+- Network files do not import from `presentation/` or `ui/`
+- No layer skipping (UI calling Repository, ViewModel calling Network)
+
+**Check method:**
+```
+grep -n "^import" <changed-file> | check against layer rules
+```
+
+#### 5b. Interface contracts
+
+For any new or modified repository:
+- Verify a corresponding `IXxxRepository` interface exists
+- Verify Koin binding uses `bind IXxxRepository::class`
+- Verify the interface is in the same package as the implementation
+
+For any new tool:
+- Verify it extends `LocalTool` or implements `McpTool`
+- Verify it is registered in `AssistantDiModule` with `bind LocalTool::class`
+
+#### 5c. Module boundaries
+
+- Verify `shared/` files do not import from `app/` or `composeApp/`
+- Verify `composeApp/` files do not import from `app/`
+- Verify `commonMain` files have no `android.*`, `java.*`, or `javax.*` imports
+
+#### 5d. State management
+
+For new or modified ViewModels:
+- Verify `MutableStateFlow` is private
+- Verify public state is exposed as `StateFlow<XxxUiState>`
+- Verify UiState follows the sealed class pattern with `Idle`/`Loading`/`Success`/`Error`
+- Verify one-time events use `Channel` or `SharedFlow`, not UiState variants
+
+#### 5e. DI registration
+
+For any new class that should be injected:
+- Verify it is registered in the appropriate Koin module
+- Verify repository bindings use interface types
+- Verify ViewModel registration uses `viewModelOf()` or explicit `viewModel {}`
+
+#### 5f. Security
+
+- No hardcoded URLs, tokens, or API keys in changed files
+- No use of `EncryptedSharedPreferences` (deprecated)
+- Sensitive data does not leak into UI or logging
+
+### Step 6: Run soft checks
+
+These are **consider** findings — advisory, not blocking.
+
+#### 6a. File size
+
+Flag files exceeding 400 LOC unless they are in the documented exceptions list
+(ChatEngine, ToolRouter, AapApiClient, TokenManager, McpServerManager).
+
+#### 6b. Naming consistency
+
+- Interfaces should follow `IXxxRepository`/`IXxxManager` pattern
+- ViewModels should be named `XxxViewModel`
+- UiState should be named `XxxUiState`
+- Local tools should be named `XxxLocalTool`
+
+#### 6c. Extraction opportunities
+
+Flag when:
+- A class constructor takes more than 6 dependencies
+- A file has more than 3 groups of private helpers that don't interact
+- A ViewModel contains HTTP client instantiation (except documented SettingsViewModel exception)
+
+#### 6d. Pattern consistency
+
+Flag when a new screen or feature diverges from established patterns without justification:
+- Missing `Idle`/`Loading`/`Success`/`Error` in UiState
+- Manual DI instead of Koin injection
+- Direct API calls instead of repository pattern
+
+---
+
+## Output format
+
+Structure findings as follows:
+
+```markdown
+## Architecture Review: PR #NNN — <title>
+
+### Contract Violations (must-fix)
+
+- **[LAYER]** `FooViewModel.kt:42` — imports `network.AapApiClient` directly.
+  Must access data through a repository.
+- **[INTERFACE]** `BarRepository.kt` — no corresponding `IBarRepository` interface.
+  Add interface and update Koin binding.
+- **[MODULE]** `shared/.../Baz.kt:15` — imports `android.content.Context`.
+  Move to `androidMain` or use `expect`/`actual`.
+
+### Recommendations (consider)
+
+- **[SIZE]** `QuxViewModel.kt` is 520 LOC — consider extracting validation logic
+  into a dedicated `QuxValidator` class.
+- **[PATTERN]** `NewScreen` UiState uses `Boolean isLoading` instead of sealed class.
+  Consider migrating to `Idle`/`Loading`/`Success`/`Error` pattern for consistency.
+
+### Skills Loaded
+
+**Core (always):**
+- kotlin-coroutines-structured-concurrency
+- kotlin-flow-state-event-modeling
+- kotlin-multiplatform-expect-actual
+- koin-editor
+
+**Auto-detected:**
+- compose-skill (ui/ files changed)
+- kotlin-data-kmp-data-layer (data/ files changed)
+
+### Verdict
+
+One of:
+- **Clean** — no contract violations found
+- **Fixable** — N contract violations, M recommendations
+- **Needs architecture review** — structural changes detected, recommend also
+  running `kotlin-project-architecture-review` skill
+```
+
+---
+
+## Severity definitions
+
+### Must-fix (hard rule violation)
+
+The PR introduces a contract violation that will cause architectural drift.
+These map to the **hard rules** in `docs/architecture/service-contracts.md`.
+
+Examples:
+- ViewModel imports from `network/` package
+- New repository without `IXxxRepository` interface
+- Koin binding to concrete type instead of interface
+- `commonMain` file with Android imports
+- `MutableStateFlow` exposed publicly from ViewModel
+- New tool not registered in `AssistantDiModule`
+- Hardcoded credentials or tokens
+
+### Consider (soft recommendation)
+
+The code works but diverges from established patterns or guidelines.
+Not blocking, but worth addressing to prevent drift.
+
+Examples:
+- File exceeding 400 LOC (outside documented exceptions)
+- Naming inconsistency (e.g., `FooRepo` instead of `FooRepository`)
+- Missing test coverage for new repository or ViewModel
+- UiState not using sealed class pattern
+- Constructor with many dependencies suggesting extraction opportunity
+
+---
+
+## What this skill does NOT cover
+
+- **Line-level code quality** — use `kotlin-project-code-review` skill
+- **Compose recomposition performance** — use `compose-recomposition-performance` skill
+- **Ansible content quality** — use CLAUDE.md Ansible rules
+- **General PR correctness** — use the `code-review` superpowers skill
+- **Security audit** — use `security-review` skill for deep security analysis
+
+This skill focuses exclusively on **architecture contract compliance** for this
+specific project.
+
+---
+
+## Maintenance
+
+When the architecture evolves (new modules, new patterns, new exceptions):
+1. Update `docs/architecture/service-contracts.md` with the change
+2. Update the relevant check in this skill if needed
+3. Bump the version in both files
+4. The PR introducing the change should document why the contract changed


### PR DESCRIPTION
## Summary

- Add `docs/architecture/service-contracts.md` — formal architecture contracts documenting the project's 6-layer architecture, interface requirements (IXxxRepository pattern), module boundaries, state management patterns, DI conventions, and security rules. Rules are categorized as hard (must-fix) or soft (advisory).
- Add `skills/pr-architecture-review/SKILL.md` — a PR review skill that auto-loads relevant Kotlin/Android skills based on changed files and checks PRs against the service contracts. Produces structured findings with must-fix vs consider categorization.
- Update `CLAUDE.md` with a concise "Kotlin Architecture Contracts" section pointing to the full contracts document.
- Add design spec at `docs/superpowers/specs/2026-06-18-pr-architecture-review-design.md`.

All contracts were derived from a comprehensive codebase audit (313 Kotlin files, 17 repository interfaces, 4 Koin modules). The codebase is already in excellent shape — these contracts codify existing patterns to prevent regression.

## Test plan

- [ ] Verify `docs/architecture/service-contracts.md` rules match actual codebase patterns
- [ ] Verify all skill file references in `skills/pr-architecture-review/SKILL.md` resolve to existing files
- [ ] Verify CLAUDE.md section is correctly placed and concise
- [ ] Test the PR review skill by using it to review this PR itself

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>