### PR TITLE
fix: eliminate double-serialized JSON in local tool responses

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
@@ -103,6 +103,7 @@ class ToolExecutor(
         fun capResultArray(data: String): String {
             val parsed = try { json.parseToJsonElement(data) } catch (_: Exception) { return data }
             if (parsed !is JsonObject) return data
+            if ("count" !in parsed) return data
             val (arrayKey, results) = parsed.entries
                 .firstOrNull { it.value is JsonArray } ?: return data
             val arrayValue = results as JsonArray

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutor.kt
@@ -103,16 +103,19 @@ class ToolExecutor(
         fun capResultArray(data: String): String {
             val parsed = try { json.parseToJsonElement(data) } catch (_: Exception) { return data }
             if (parsed !is JsonObject) return data
-            val results = parsed["results"]
-            if (results !is JsonArray || results.size <= MAX_ARRAY_ITEMS) return data
-            val total = parsed["count"]?.jsonPrimitive?.intOrNull ?: results.size
+            val (arrayKey, results) = parsed.entries
+                .firstOrNull { it.value is JsonArray } ?: return data
+            val arrayValue = results as JsonArray
+            if (arrayValue.size <= MAX_ARRAY_ITEMS) return data
+            val total = parsed["count"]?.jsonPrimitive?.intOrNull ?: arrayValue.size
             val capped = buildJsonObject {
                 parsed.forEach { (k, v) ->
-                    when (k) {
-                        "results" -> put("results", buildJsonArray {
-                            results.take(MAX_ARRAY_ITEMS).forEach { add(it) }
+                    if (k == arrayKey) {
+                        put(k, buildJsonArray {
+                            arrayValue.take(MAX_ARRAY_ITEMS).forEach { add(it) }
                         })
-                        else -> put(k, v)
+                    } else {
+                        put(k, v)
                     }
                 }
                 put("_showing", MAX_ARRAY_ITEMS)

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetHostJobSummariesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetHostJobSummariesLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.HostRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class GetHostJobSummariesLocalTool(
     private val repository: HostRepository
@@ -34,9 +36,9 @@ class GetHostJobSummariesLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "job_host_summaries" to networkJson.encodeToString(result.summaries)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("job_host_summaries", networkJson.encodeToJsonElement(result.summaries))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetWorkflowJobLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetWorkflowJobLocalTool.kt
@@ -7,7 +7,8 @@ import io.github.leogallego.ansiblejane.data.WorkflowRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
 
 class GetWorkflowJobLocalTool(
     private val repository: WorkflowRepository
@@ -25,9 +26,9 @@ class GetWorkflowJobLocalTool(
     override suspend fun execute(args: Args): String {
         val job = repository.getWorkflowJobStatus(args.workflowJobId).getOrThrow()
         val nodes = repository.getWorkflowNodes(args.workflowJobId).getOrElse { emptyList() }
-        return networkJson.encodeToString(mapOf(
-            "workflow_job" to networkJson.encodeToString(job),
-            "nodes" to networkJson.encodeToString(nodes)
-        ))
+        return buildJsonObject {
+            put("workflow_job", networkJson.encodeToJsonElement(job))
+            put("nodes", networkJson.encodeToJsonElement(nodes))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListApplicationsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListApplicationsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListApplicationsLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -34,9 +36,9 @@ class ListApplicationsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "applications" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("applications", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListAuthenticatorsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListAuthenticatorsLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListAuthenticatorsLocalTool(
     private val repository: PlatformRepository,
@@ -37,9 +39,9 @@ class ListAuthenticatorsLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 25)
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "authenticators" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("authenticators", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListCredentialTypesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListCredentialTypesLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListCredentialTypesLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -34,9 +36,9 @@ class ListCredentialTypesLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "credential_types" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("credential_types", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListCredentialsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListCredentialsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.CredentialRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListCredentialsLocalTool(
     private val repository: CredentialRepository
@@ -34,9 +36,9 @@ class ListCredentialsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "credentials" to networkJson.encodeToString(result.credentials)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("credentials", networkJson.encodeToJsonElement(result.credentials))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaActivationsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaActivationsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.EdaActivationRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListEdaActivationsLocalTool(
     private val repository: EdaActivationRepository
@@ -32,9 +34,9 @@ class ListEdaActivationsLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "activations" to networkJson.encodeToString(result.activations)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("activations", networkJson.encodeToJsonElement(result.activations))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaAuditRulesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaAuditRulesLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.EdaAuditRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListEdaAuditRulesLocalTool(
     private val repository: EdaAuditRepository
@@ -32,9 +34,9 @@ class ListEdaAuditRulesLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "audit_rules" to networkJson.encodeToString(result.auditRules)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("audit_rules", networkJson.encodeToJsonElement(result.auditRules))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialTypesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialTypesLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListEdaCredentialTypesLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -35,9 +37,9 @@ class ListEdaCredentialTypesLocalTool(
             pageSize = pageSize,
             name = args.name
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "credential_types" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("credential_types", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListEdaCredentialsLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -35,9 +37,9 @@ class ListEdaCredentialsLocalTool(
             pageSize = pageSize,
             name = args.name
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "credentials" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("credentials", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaDecisionEnvironmentsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaDecisionEnvironmentsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListEdaDecisionEnvironmentsLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -35,9 +37,9 @@ class ListEdaDecisionEnvironmentsLocalTool(
             pageSize = pageSize,
             name = args.name
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "decision_environments" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("decision_environments", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaEventStreamsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaEventStreamsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListEdaEventStreamsLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -35,9 +37,9 @@ class ListEdaEventStreamsLocalTool(
             pageSize = pageSize,
             name = args.name
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "event_streams" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("event_streams", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaProjectsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaProjectsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListEdaProjectsLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -35,9 +37,9 @@ class ListEdaProjectsLocalTool(
             pageSize = pageSize,
             name = args.name
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "projects" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("projects", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaRulebooksLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaRulebooksLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListEdaRulebooksLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -35,9 +37,9 @@ class ListEdaRulebooksLocalTool(
             pageSize = pageSize,
             name = args.name
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "rulebooks" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("rulebooks", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaUsersLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListEdaUsersLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -32,9 +34,9 @@ class ListEdaUsersLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "users" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("users", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListExecutionEnvironmentsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListExecutionEnvironmentsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ProjectRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListExecutionEnvironmentsLocalTool(
     private val repository: ProjectRepository
@@ -31,9 +33,9 @@ class ListExecutionEnvironmentsLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "execution_environments" to networkJson.encodeToString(result.executionEnvironments)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("execution_environments", networkJson.encodeToJsonElement(result.executionEnvironments))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListGroupsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListGroupsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListGroupsLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -34,9 +36,9 @@ class ListGroupsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "groups" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("groups", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHostsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHostsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.HostRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListHostsLocalTool(
     private val repository: HostRepository
@@ -45,9 +47,9 @@ class ListHostsLocalTool(
             )
         }.getOrThrow()
 
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "hosts" to networkJson.encodeToString(result.hosts)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("hosts", networkJson.encodeToJsonElement(result.hosts))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubApprovalsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubApprovalsLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListHubApprovalsLocalTool(
     private val repository: HubRepository,
@@ -40,9 +42,9 @@ class ListHubApprovalsLocalTool(
             pageSize = args.pageSize.coerceIn(1, 20),
             status = args.status
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "collection_versions" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("collection_versions", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubCollectionsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubCollectionsLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListHubCollectionsLocalTool(
     private val repository: HubRepository,
@@ -40,9 +42,9 @@ class ListHubCollectionsLocalTool(
             pageSize = args.pageSize.coerceIn(1, 20),
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "collections" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("collections", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRegistriesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRegistriesLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListHubEeRegistriesLocalTool(
     private val repository: HubRepository,
@@ -40,9 +42,9 @@ class ListHubEeRegistriesLocalTool(
             pageSize = args.pageSize.coerceIn(1, 20),
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "ee_registries" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("ee_registries", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRepositoriesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRepositoriesLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListHubEeRepositoriesLocalTool(
     private val repository: HubRepository,
@@ -40,9 +42,9 @@ class ListHubEeRepositoriesLocalTool(
             pageSize = args.pageSize.coerceIn(1, 20),
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "ee_repositories" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("ee_repositories", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubGroupsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubGroupsLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListHubGroupsLocalTool(
     private val repository: HubRepository,
@@ -37,9 +39,9 @@ class ListHubGroupsLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 20)
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "groups" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("groups", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubNamespacesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubNamespacesLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListHubNamespacesLocalTool(
     private val repository: HubRepository,
@@ -40,9 +42,9 @@ class ListHubNamespacesLocalTool(
             pageSize = args.pageSize.coerceIn(1, 20),
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "namespaces" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("namespaces", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubRolesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubRolesLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListHubRolesLocalTool(
     private val repository: HubRepository,
@@ -37,9 +39,9 @@ class ListHubRolesLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 20)
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "role_definitions" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("role_definitions", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubUsersLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListHubUsersLocalTool(
     private val repository: HubRepository,
@@ -37,9 +39,9 @@ class ListHubUsersLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 20)
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "users" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("users", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInstanceGroupsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInstanceGroupsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.InfrastructureRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListInstanceGroupsLocalTool(
     private val repository: InfrastructureRepository
@@ -31,9 +33,9 @@ class ListInstanceGroupsLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "instance_groups" to networkJson.encodeToString(result.instanceGroups)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("instance_groups", networkJson.encodeToJsonElement(result.instanceGroups))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInstancesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInstancesLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.InfrastructureRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListInstancesLocalTool(
     private val repository: InfrastructureRepository
@@ -31,9 +33,9 @@ class ListInstancesLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "instances" to networkJson.encodeToString(result.instances)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("instances", networkJson.encodeToJsonElement(result.instances))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInventoriesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInventoriesLocalTool.kt
@@ -6,7 +6,9 @@ import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.InventoryRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListInventoriesLocalTool(
     private val repository: InventoryRepository
@@ -28,9 +30,9 @@ class ListInventoriesLocalTool(
             page = args.page.coerceAtLeast(1),
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "inventories" to networkJson.encodeToString(result.inventories)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("inventories", networkJson.encodeToJsonElement(result.inventories))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInventorySourcesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInventorySourcesLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListInventorySourcesLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -34,9 +36,9 @@ class ListInventorySourcesLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "inventory_sources" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("inventory_sources", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListJobTemplatesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListJobTemplatesLocalTool.kt
@@ -6,7 +6,9 @@ import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.TemplateRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListJobTemplatesLocalTool(
     private val repository: TemplateRepository
@@ -32,9 +34,9 @@ class ListJobTemplatesLocalTool(
             search = args.search,
             labelFilter = args.labels
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "templates" to networkJson.encodeToString(result.templates)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("templates", networkJson.encodeToJsonElement(result.templates))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListJobsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListJobsLocalTool.kt
@@ -8,7 +8,9 @@ import io.github.leogallego.ansiblejane.model.JobStatus
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListJobsLocalTool(
     private val repository: JobRepository
@@ -39,9 +41,9 @@ class ListJobsLocalTool(
             pageSize = pageSize,
             statusFilters = statusFilter
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "jobs" to networkJson.encodeToString(result.jobs)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("jobs", networkJson.encodeToJsonElement(result.jobs))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListLabelsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListLabelsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListLabelsLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -34,9 +36,9 @@ class ListLabelsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "labels" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("labels", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListNotificationTemplatesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListNotificationTemplatesLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListNotificationTemplatesLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -34,9 +36,9 @@ class ListNotificationTemplatesLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "notification_templates" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("notification_templates", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListOrganizationsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListOrganizationsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListOrganizationsLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -34,9 +36,9 @@ class ListOrganizationsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "organizations" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("organizations", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformOrganizationsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformOrganizationsLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListPlatformOrganizationsLocalTool(
     private val repository: PlatformRepository,
@@ -40,9 +42,9 @@ class ListPlatformOrganizationsLocalTool(
             pageSize = args.pageSize.coerceIn(1, 25),
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "organizations" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("organizations", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformRoleDefinitionsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformRoleDefinitionsLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListPlatformRoleDefinitionsLocalTool(
     private val repository: PlatformRepository,
@@ -40,9 +42,9 @@ class ListPlatformRoleDefinitionsLocalTool(
             pageSize = args.pageSize.coerceIn(1, 25),
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "role_definitions" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("role_definitions", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformServicesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformServicesLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListPlatformServicesLocalTool(
     private val repository: PlatformRepository,
@@ -37,9 +39,9 @@ class ListPlatformServicesLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 25)
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "services" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("services", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformTeamsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformTeamsLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListPlatformTeamsLocalTool(
     private val repository: PlatformRepository,
@@ -40,9 +42,9 @@ class ListPlatformTeamsLocalTool(
             pageSize = args.pageSize.coerceIn(1, 25),
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "teams" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("teams", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformUsersLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListPlatformUsersLocalTool(
     private val repository: PlatformRepository,
@@ -40,9 +42,9 @@ class ListPlatformUsersLocalTool(
             pageSize = args.pageSize.coerceIn(1, 25),
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "users" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("users", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListProjectsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListProjectsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ProjectRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListProjectsLocalTool(
     private val repository: ProjectRepository
@@ -34,9 +36,9 @@ class ListProjectsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "projects" to networkJson.encodeToString(result.projects)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("projects", networkJson.encodeToJsonElement(result.projects))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRoleDefinitionsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRoleDefinitionsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListRoleDefinitionsLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -34,9 +36,9 @@ class ListRoleDefinitionsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "role_definitions" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("role_definitions", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRolesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRolesLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListRolesLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -34,9 +36,9 @@ class ListRolesLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "roles" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("roles", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListSchedulesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListSchedulesLocalTool.kt
@@ -6,7 +6,9 @@ import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.ScheduleRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListSchedulesLocalTool(
     private val repository: ScheduleRepository
@@ -26,9 +28,9 @@ class ListSchedulesLocalTool(
         val result = repository.getSchedules(
             page = args.page.coerceAtLeast(1)
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "schedules" to networkJson.encodeToString(result.schedules)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("schedules", networkJson.encodeToJsonElement(result.schedules))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListServiceClustersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListServiceClustersLocalTool.kt
@@ -9,7 +9,9 @@ import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListServiceClustersLocalTool(
     private val repository: PlatformRepository,
@@ -37,9 +39,9 @@ class ListServiceClustersLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 25)
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "service_clusters" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("service_clusters", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTeamsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTeamsLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListTeamsLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -34,9 +36,9 @@ class ListTeamsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "teams" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("teams", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTokensLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTokensLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListTokensLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -31,9 +33,9 @@ class ListTokensLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "tokens" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("tokens", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListUsersLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListUsersLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -34,9 +36,9 @@ class ListUsersLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "users" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("users", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListWorkflowNodesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListWorkflowNodesLocalTool.kt
@@ -7,7 +7,9 @@ import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListWorkflowNodesLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -35,9 +37,9 @@ class ListWorkflowNodesLocalTool(
             pageSize = pageSize,
             workflowJobTemplate = args.workflowJobTemplate
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "workflow_nodes" to networkJson.encodeToString(result.items)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("workflow_nodes", networkJson.encodeToJsonElement(result.items))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListWorkflowTemplatesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListWorkflowTemplatesLocalTool.kt
@@ -6,7 +6,9 @@ import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.WorkflowRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class ListWorkflowTemplatesLocalTool(
     private val repository: WorkflowRepository
@@ -32,9 +34,9 @@ class ListWorkflowTemplatesLocalTool(
             search = args.search,
             labelFilter = args.labels
         ).getOrThrow()
-        return networkJson.encodeToString(mapOf(
-            "count" to result.totalCount.toString(),
-            "templates" to networkJson.encodeToString(result.templates)
-        ))
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("templates", networkJson.encodeToJsonElement(result.templates))
+        }.toString()
     }
 }


### PR DESCRIPTION
## Summary

- Fix double-serialization in all 50 list tools — items list was JSON-encoded as a string inside the outer JSON, producing `\"` escape overhead
- Replace `mapOf("key" to encodeToString(items))` with `buildJsonObject` + `encodeToJsonElement` for properly nested JSON
- Serialize `count` as integer instead of string
- Update `capResultArray()` in ToolExecutor to find the first `JsonArray` in any key instead of hardcoded `"results"` — makes array capping work for all local tools

**Before:** `{"count":"5","collections":"[{\"name\":\"foo\",...}]"}`
**After:** `{"count":5,"collections":[{"name":"foo",...}]}`

Closes #357

## Test plan

- [x] `./gradlew :app:compileDebugKotlin --no-daemon` passes
- [x] ToolRouter + engine tests pass
- [ ] CI build passes

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>