### PR TITLE
refactor: migrate local tool constructors from TokenManager to ITokenManager

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListAuthenticatorsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListAuthenticatorsLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.PlatformRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListAuthenticatorsLocalTool(
     private val repository: PlatformRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListAuthenticatorsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_authenticators",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubApprovalsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubApprovalsLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.HubRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListHubApprovalsLocalTool(
     private val repository: HubRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubApprovalsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_hub_approvals",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubCollectionsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubCollectionsLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.HubRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListHubCollectionsLocalTool(
     private val repository: HubRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubCollectionsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_hub_collections",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRegistriesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRegistriesLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.HubRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListHubEeRegistriesLocalTool(
     private val repository: HubRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubEeRegistriesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_hub_ee_registries",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRepositoriesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRepositoriesLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.HubRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListHubEeRepositoriesLocalTool(
     private val repository: HubRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubEeRepositoriesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_hub_ee_repositories",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubGroupsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubGroupsLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.HubRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListHubGroupsLocalTool(
     private val repository: HubRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubGroupsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_hub_groups",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubNamespacesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubNamespacesLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.HubRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListHubNamespacesLocalTool(
     private val repository: HubRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubNamespacesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_hub_namespaces",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubRolesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubRolesLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.HubRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListHubRolesLocalTool(
     private val repository: HubRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubRolesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_hub_roles",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubUsersLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.HubRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListHubUsersLocalTool(
     private val repository: HubRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubUsersLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_hub_users",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformOrganizationsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformOrganizationsLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.PlatformRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListPlatformOrganizationsLocalTool(
     private val repository: PlatformRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListPlatformOrganizationsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_platform_organizations",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformRoleDefinitionsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformRoleDefinitionsLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.PlatformRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListPlatformRoleDefinitionsLocalTool(
     private val repository: PlatformRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListPlatformRoleDefinitionsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_platform_role_definitions",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformServicesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformServicesLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.PlatformRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListPlatformServicesLocalTool(
     private val repository: PlatformRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListPlatformServicesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_platform_services",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformTeamsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformTeamsLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.PlatformRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListPlatformTeamsLocalTool(
     private val repository: PlatformRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListPlatformTeamsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_platform_teams",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformUsersLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.PlatformRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListPlatformUsersLocalTool(
     private val repository: PlatformRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListPlatformUsersLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_platform_users",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListServiceClustersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListServiceClustersLocalTool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.data.PlatformRepository
-import io.github.leogallego.ansiblejane.data.TokenManager
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
@@ -13,7 +13,7 @@ import kotlinx.serialization.encodeToString
 
 class ListServiceClustersLocalTool(
     private val repository: PlatformRepository,
-    private val tokenManager: TokenManager
+    private val tokenManager: ITokenManager
 ) : AapLocalTool<ListServiceClustersLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_service_clusters",


### PR DESCRIPTION
## Summary

- Migrate 15 Platform + Hub local tools from concrete `TokenManager` to `ITokenManager` interface
- Import swap only — no logic changes, no DI changes
- Koin already binds `TokenManager` with `bind ITokenManager::class`

**Files changed:** 7 Platform tools + 8 Hub tools (2 lines each: import + constructor param)

Closes #346

## Test plan

- [ ] CI build passes (compile check is sufficient — only import/type changes)
- [ ] Verify `ITokenManager.activeInstance` provides the same `StateFlow` used by tools

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>