### PR TITLE
chore: bump version to v0.8.5-alpha.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.experimental.enableScreenshotTest=true
 kotlin.native.ignoreDisabledTargets=true
-appVersionName=0.8.4-alpha.9
-appVersionCode=26061809
+appVersionName=0.8.5-alpha.0
+appVersionCode=26061910


### PR DESCRIPTION
## Summary

- Bump `appVersionName` from `0.8.4-alpha.9` to `0.8.5-alpha.0`
- Bump `appVersionCode` from `26061809` to `26061910`

Auto-tag workflow will create `v0.8.5-alpha.0` tag and dispatch release on merge.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>