### PR TITLE
fix: download-artifact glob + bump checkout to v7

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Read version, tag, and dispatch release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/fdroid-repo.yml
+++ b/.github/workflows/fdroid-repo.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install fdroidserver
         run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -27,7 +27,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Compute version code
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,14 +386,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           merge-multiple: true
-          pattern: "apk|desktop-linux-deb|desktop-linux-rpm|desktop-macos|desktop-windows|desktop-linux-flatpak"
+          pattern: "{apk,desktop-linux-deb,desktop-linux-rpm,desktop-macos,desktop-windows,desktop-linux-flatpak}"
 
       - name: Download optional artifacts
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           merge-multiple: true
-          pattern: "desktop-linux-tar|desktop-linux-appimage"
+          pattern: "{desktop-linux-tar,desktop-linux-appimage}"
 
       - name: Extract changelog
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
@@ -302,7 +302,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
@@ -344,7 +344,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
@@ -377,7 +377,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
           fetch-depth: 0


### PR DESCRIPTION
## Summary

Fixes #359.

1. **Fix download-artifact pattern** — Replace `|` (pipe) with `{a,b,c}` (brace expansion) in `download-artifact@v8` pattern parameters. Pipe is treated as a literal character by minimatch, causing zero artifacts to be downloaded. This is why releases from v0.8.4-alpha.4 through v0.8.5-alpha.0 have no attached files.

2. **Bump actions/checkout v6 → v7** across all 5 workflows (release, ci, auto-tag, prepare-release, fdroid-repo). v7 migrates to Node.js 24 and hardens `pull_request_target` defaults.

## Test plan

- [ ] Trigger a release build and verify artifacts appear on the GitHub release

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>