### PR TITLE
test: remove unnecessary Robolectric from 5 ViewModel tests

### DIFF
--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/jobs/JobStatusViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/jobs/JobStatusViewModelTest.kt
@@ -13,10 +13,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class JobStatusViewModelTest {
 
     @get:Rule

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/jobs/RecentJobsViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/jobs/RecentJobsViewModelTest.kt
@@ -14,10 +14,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class RecentJobsViewModelTest {
 
     @get:Rule

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/templates/TemplatesViewModelTest.kt
@@ -17,10 +17,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class TemplatesViewModelTest {
 
     @get:Rule

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowJobStatusViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowJobStatusViewModelTest.kt
@@ -16,10 +16,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class WorkflowJobStatusViewModelTest {
 
     @get:Rule

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowTemplatesViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowTemplatesViewModelTest.kt
@@ -16,10 +16,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class WorkflowTemplatesViewModelTest {
 
     @get:Rule


### PR DESCRIPTION
## Summary

- Remove `@RunWith(RobolectricTestRunner::class)` and its imports from 5 ViewModel tests that don't use any Android framework APIs
- These tests use only fake repositories, `MainDispatcherRule`, `SavedStateHandle`, and Turbine — Robolectric was dead weight
- Makes them immediately eligible for `commonTest` migration

## Files changed

| File | Change |
|------|--------|
| `JobStatusViewModelTest.kt` | -3 lines (RunWith + imports) |
| `RecentJobsViewModelTest.kt` | -3 lines |
| `TemplatesViewModelTest.kt` | -3 lines |
| `WorkflowJobStatusViewModelTest.kt` | -3 lines |
| `WorkflowTemplatesViewModelTest.kt` | -3 lines |

## Test plan

- [x] All 5 modified tests pass: `./gradlew :app:testDebugUnitTest --tests "*.JobStatusViewModelTest" --tests "*.RecentJobsViewModelTest" --tests "*.TemplatesViewModelTest" --tests "*.WorkflowJobStatusViewModelTest" --tests "*.WorkflowTemplatesViewModelTest"`

Closes #378

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>