### PR TITLE
refactor: extract listToolJson helper for list tool JSON serialization

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolJsonHelpers.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolJsonHelpers.kt
@@ -1,0 +1,12 @@
+package io.github.leogallego.ansiblejane.assistant.tools
+
+import io.github.leogallego.ansiblejane.network.networkJson
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.put
+
+inline fun <reified T> listToolJson(key: String, count: Int, items: List<T>): String =
+    buildJsonObject {
+        put("count", count)
+        put(key, networkJson.encodeToJsonElement(items))
+    }.toString()

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetHostJobSummariesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetHostJobSummariesLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.HostRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class GetHostJobSummariesLocalTool(
     private val repository: HostRepository
@@ -36,9 +33,6 @@ class GetHostJobSummariesLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("job_host_summaries", networkJson.encodeToJsonElement(result.summaries))
-        }.toString()
+        return listToolJson("job_host_summaries", result.totalCount, result.summaries)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListApplicationsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListApplicationsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListApplicationsLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -36,9 +33,6 @@ class ListApplicationsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("applications", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("applications", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListAuthenticatorsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListAuthenticatorsLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.data.PlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListAuthenticatorsLocalTool(
     private val repository: PlatformRepository,
@@ -39,9 +36,6 @@ class ListAuthenticatorsLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 25)
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("authenticators", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("authenticators", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListCredentialTypesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListCredentialTypesLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListCredentialTypesLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -36,9 +33,6 @@ class ListCredentialTypesLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("credential_types", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("credential_types", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListCredentialsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListCredentialsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.CredentialRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListCredentialsLocalTool(
     private val repository: CredentialRepository
@@ -36,9 +33,6 @@ class ListCredentialsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("credentials", networkJson.encodeToJsonElement(result.credentials))
-        }.toString()
+        return listToolJson("credentials", result.totalCount, result.credentials)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaActivationsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaActivationsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.EdaActivationRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListEdaActivationsLocalTool(
     private val repository: EdaActivationRepository
@@ -34,9 +31,6 @@ class ListEdaActivationsLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("activations", networkJson.encodeToJsonElement(result.activations))
-        }.toString()
+        return listToolJson("activations", result.totalCount, result.activations)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaAuditRulesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaAuditRulesLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.EdaAuditRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListEdaAuditRulesLocalTool(
     private val repository: EdaAuditRepository
@@ -34,9 +31,6 @@ class ListEdaAuditRulesLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("audit_rules", networkJson.encodeToJsonElement(result.auditRules))
-        }.toString()
+        return listToolJson("audit_rules", result.totalCount, result.auditRules)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialTypesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialTypesLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListEdaCredentialTypesLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -37,9 +34,6 @@ class ListEdaCredentialTypesLocalTool(
             pageSize = pageSize,
             name = args.name
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("credential_types", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("credential_types", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListEdaCredentialsLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -37,9 +34,6 @@ class ListEdaCredentialsLocalTool(
             pageSize = pageSize,
             name = args.name
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("credentials", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("credentials", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaDecisionEnvironmentsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaDecisionEnvironmentsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListEdaDecisionEnvironmentsLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -37,9 +34,6 @@ class ListEdaDecisionEnvironmentsLocalTool(
             pageSize = pageSize,
             name = args.name
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("decision_environments", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("decision_environments", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaEventStreamsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaEventStreamsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListEdaEventStreamsLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -37,9 +34,6 @@ class ListEdaEventStreamsLocalTool(
             pageSize = pageSize,
             name = args.name
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("event_streams", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("event_streams", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaProjectsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaProjectsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListEdaProjectsLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -37,9 +34,6 @@ class ListEdaProjectsLocalTool(
             pageSize = pageSize,
             name = args.name
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("projects", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("projects", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaRulebooksLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaRulebooksLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListEdaRulebooksLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -37,9 +34,6 @@ class ListEdaRulebooksLocalTool(
             pageSize = pageSize,
             name = args.name
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("rulebooks", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("rulebooks", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaUsersLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListEdaUsersLocalTool(
     private val repository: EdaReadOnlyRepository
@@ -34,9 +31,6 @@ class ListEdaUsersLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("users", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("users", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListExecutionEnvironmentsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListExecutionEnvironmentsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ProjectRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListExecutionEnvironmentsLocalTool(
     private val repository: ProjectRepository
@@ -33,9 +30,6 @@ class ListExecutionEnvironmentsLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("execution_environments", networkJson.encodeToJsonElement(result.executionEnvironments))
-        }.toString()
+        return listToolJson("execution_environments", result.totalCount, result.executionEnvironments)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListGroupsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListGroupsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListGroupsLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -36,9 +33,6 @@ class ListGroupsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("groups", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("groups", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHostsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHostsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.HostRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListHostsLocalTool(
     private val repository: HostRepository
@@ -47,9 +44,6 @@ class ListHostsLocalTool(
             )
         }.getOrThrow()
 
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("hosts", networkJson.encodeToJsonElement(result.hosts))
-        }.toString()
+        return listToolJson("hosts", result.totalCount, result.hosts)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubApprovalsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubApprovalsLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.HubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListHubApprovalsLocalTool(
     private val repository: HubRepository,
@@ -42,9 +39,6 @@ class ListHubApprovalsLocalTool(
             pageSize = args.pageSize.coerceIn(1, 20),
             status = args.status
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("collection_versions", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("collection_versions", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubCollectionsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubCollectionsLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.HubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListHubCollectionsLocalTool(
     private val repository: HubRepository,
@@ -42,9 +39,6 @@ class ListHubCollectionsLocalTool(
             pageSize = args.pageSize.coerceIn(1, 20),
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("collections", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("collections", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRegistriesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRegistriesLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.HubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListHubEeRegistriesLocalTool(
     private val repository: HubRepository,
@@ -42,9 +39,6 @@ class ListHubEeRegistriesLocalTool(
             pageSize = args.pageSize.coerceIn(1, 20),
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("ee_registries", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("ee_registries", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRepositoriesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRepositoriesLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.HubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListHubEeRepositoriesLocalTool(
     private val repository: HubRepository,
@@ -42,9 +39,6 @@ class ListHubEeRepositoriesLocalTool(
             pageSize = args.pageSize.coerceIn(1, 20),
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("ee_repositories", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("ee_repositories", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubGroupsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubGroupsLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.HubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListHubGroupsLocalTool(
     private val repository: HubRepository,
@@ -39,9 +36,6 @@ class ListHubGroupsLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 20)
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("groups", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("groups", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubNamespacesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubNamespacesLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.HubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListHubNamespacesLocalTool(
     private val repository: HubRepository,
@@ -42,9 +39,6 @@ class ListHubNamespacesLocalTool(
             pageSize = args.pageSize.coerceIn(1, 20),
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("namespaces", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("namespaces", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubRolesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubRolesLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.HubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListHubRolesLocalTool(
     private val repository: HubRepository,
@@ -39,9 +36,6 @@ class ListHubRolesLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 20)
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("role_definitions", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("role_definitions", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubUsersLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.HubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListHubUsersLocalTool(
     private val repository: HubRepository,
@@ -39,9 +36,6 @@ class ListHubUsersLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 20)
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("users", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("users", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInstanceGroupsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInstanceGroupsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.InfrastructureRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListInstanceGroupsLocalTool(
     private val repository: InfrastructureRepository
@@ -33,9 +30,6 @@ class ListInstanceGroupsLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("instance_groups", networkJson.encodeToJsonElement(result.instanceGroups))
-        }.toString()
+        return listToolJson("instance_groups", result.totalCount, result.instanceGroups)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInstancesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInstancesLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.InfrastructureRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListInstancesLocalTool(
     private val repository: InfrastructureRepository
@@ -33,9 +30,6 @@ class ListInstancesLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("instances", networkJson.encodeToJsonElement(result.instances))
-        }.toString()
+        return listToolJson("instances", result.totalCount, result.instances)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInventoriesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInventoriesLocalTool.kt
@@ -3,12 +3,9 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.InventoryRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListInventoriesLocalTool(
     private val repository: InventoryRepository
@@ -30,9 +27,6 @@ class ListInventoriesLocalTool(
             page = args.page.coerceAtLeast(1),
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("inventories", networkJson.encodeToJsonElement(result.inventories))
-        }.toString()
+        return listToolJson("inventories", result.totalCount, result.inventories)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInventorySourcesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInventorySourcesLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListInventorySourcesLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -36,9 +33,6 @@ class ListInventorySourcesLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("inventory_sources", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("inventory_sources", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListJobTemplatesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListJobTemplatesLocalTool.kt
@@ -3,12 +3,9 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.TemplateRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListJobTemplatesLocalTool(
     private val repository: TemplateRepository
@@ -34,9 +31,6 @@ class ListJobTemplatesLocalTool(
             search = args.search,
             labelFilter = args.labels
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("templates", networkJson.encodeToJsonElement(result.templates))
-        }.toString()
+        return listToolJson("templates", result.totalCount, result.templates)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListJobsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListJobsLocalTool.kt
@@ -3,14 +3,11 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.JobRepository
 import io.github.leogallego.ansiblejane.model.JobStatus
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListJobsLocalTool(
     private val repository: JobRepository
@@ -41,9 +38,6 @@ class ListJobsLocalTool(
             pageSize = pageSize,
             statusFilters = statusFilter
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("jobs", networkJson.encodeToJsonElement(result.jobs))
-        }.toString()
+        return listToolJson("jobs", result.totalCount, result.jobs)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListLabelsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListLabelsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListLabelsLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -36,9 +33,6 @@ class ListLabelsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("labels", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("labels", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListNotificationTemplatesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListNotificationTemplatesLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListNotificationTemplatesLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -36,9 +33,6 @@ class ListNotificationTemplatesLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("notification_templates", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("notification_templates", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListOrganizationsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListOrganizationsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListOrganizationsLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -36,9 +33,6 @@ class ListOrganizationsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("organizations", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("organizations", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPendingApprovalsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPendingApprovalsLocalTool.kt
@@ -7,10 +7,9 @@ import io.github.leogallego.ansiblejane.data.IWorkflowRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.put
 
 class ListPendingApprovalsLocalTool(
     private val repository: IWorkflowRepository
@@ -33,14 +32,10 @@ class ListPendingApprovalsLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 100)
         ).getOrThrow()
-        val resultsArray = networkJson.encodeToJsonElement(
-            kotlinx.serialization.builtins.ListSerializer(io.github.leogallego.ansiblejane.model.WorkflowApproval.serializer()),
-            result.approvals
-        )
-        return JsonObject(mapOf(
-            "count" to JsonPrimitive(result.totalCount),
-            "has_more" to JsonPrimitive(result.hasMore),
-            "results" to resultsArray
-        )).toString()
+        return buildJsonObject {
+            put("count", result.totalCount)
+            put("has_more", result.hasMore)
+            put("results", networkJson.encodeToJsonElement(result.approvals))
+        }.toString()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformOrganizationsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformOrganizationsLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.data.PlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListPlatformOrganizationsLocalTool(
     private val repository: PlatformRepository,
@@ -42,9 +39,6 @@ class ListPlatformOrganizationsLocalTool(
             pageSize = args.pageSize.coerceIn(1, 25),
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("organizations", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("organizations", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformRoleDefinitionsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformRoleDefinitionsLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.data.PlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListPlatformRoleDefinitionsLocalTool(
     private val repository: PlatformRepository,
@@ -42,9 +39,6 @@ class ListPlatformRoleDefinitionsLocalTool(
             pageSize = args.pageSize.coerceIn(1, 25),
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("role_definitions", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("role_definitions", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformServicesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformServicesLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.data.PlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListPlatformServicesLocalTool(
     private val repository: PlatformRepository,
@@ -39,9 +36,6 @@ class ListPlatformServicesLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 25)
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("services", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("services", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformTeamsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformTeamsLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.data.PlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListPlatformTeamsLocalTool(
     private val repository: PlatformRepository,
@@ -42,9 +39,6 @@ class ListPlatformTeamsLocalTool(
             pageSize = args.pageSize.coerceIn(1, 25),
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("teams", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("teams", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformUsersLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.data.PlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListPlatformUsersLocalTool(
     private val repository: PlatformRepository,
@@ -42,9 +39,6 @@ class ListPlatformUsersLocalTool(
             pageSize = args.pageSize.coerceIn(1, 25),
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("users", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("users", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListProjectsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListProjectsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ProjectRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListProjectsLocalTool(
     private val repository: ProjectRepository
@@ -36,9 +33,6 @@ class ListProjectsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("projects", networkJson.encodeToJsonElement(result.projects))
-        }.toString()
+        return listToolJson("projects", result.totalCount, result.projects)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRoleDefinitionsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRoleDefinitionsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListRoleDefinitionsLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -36,9 +33,6 @@ class ListRoleDefinitionsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("role_definitions", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("role_definitions", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRolesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRolesLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListRolesLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -36,9 +33,6 @@ class ListRolesLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("roles", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("roles", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListSchedulesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListSchedulesLocalTool.kt
@@ -3,12 +3,9 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ScheduleRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListSchedulesLocalTool(
     private val repository: ScheduleRepository
@@ -28,9 +25,6 @@ class ListSchedulesLocalTool(
         val result = repository.getSchedules(
             page = args.page.coerceAtLeast(1)
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("schedules", networkJson.encodeToJsonElement(result.schedules))
-        }.toString()
+        return listToolJson("schedules", result.totalCount, result.schedules)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListServiceClustersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListServiceClustersLocalTool.kt
@@ -3,15 +3,12 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.data.PlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListServiceClustersLocalTool(
     private val repository: PlatformRepository,
@@ -39,9 +36,6 @@ class ListServiceClustersLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = args.pageSize.coerceIn(1, 25)
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("service_clusters", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("service_clusters", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTeamsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTeamsLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListTeamsLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -36,9 +33,6 @@ class ListTeamsLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("teams", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("teams", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTokensLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTokensLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListTokensLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -33,9 +30,6 @@ class ListTokensLocalTool(
             page = args.page.coerceAtLeast(1),
             pageSize = pageSize
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("tokens", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("tokens", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListUsersLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListUsersLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -36,9 +33,6 @@ class ListUsersLocalTool(
             pageSize = pageSize,
             search = args.search
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("users", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("users", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListWorkflowNodesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListWorkflowNodesLocalTool.kt
@@ -3,13 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListWorkflowNodesLocalTool(
     private val repository: ControllerReadOnlyRepository
@@ -37,9 +34,6 @@ class ListWorkflowNodesLocalTool(
             pageSize = pageSize,
             workflowJobTemplate = args.workflowJobTemplate
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("workflow_nodes", networkJson.encodeToJsonElement(result.items))
-        }.toString()
+        return listToolJson("workflow_nodes", result.totalCount, result.items)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListWorkflowTemplatesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListWorkflowTemplatesLocalTool.kt
@@ -3,12 +3,9 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.WorkflowRepository
-import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ListWorkflowTemplatesLocalTool(
     private val repository: WorkflowRepository
@@ -34,9 +31,6 @@ class ListWorkflowTemplatesLocalTool(
             search = args.search,
             labelFilter = args.labels
         ).getOrThrow()
-        return buildJsonObject {
-            put("count", result.totalCount)
-            put("templates", networkJson.encodeToJsonElement(result.templates))
-        }.toString()
+        return listToolJson("templates", result.totalCount, result.templates)
     }
 }


### PR DESCRIPTION
## Summary

- Extract shared `listToolJson()` helper that replaces the 4-line `buildJsonObject` block repeated across 49 list tools
- Each tool reduces from 4 lines + 3 imports to 1 line + 1 import
- Migrate `ListPendingApprovalsLocalTool` from `JsonObject(mapOf())` with explicit serializers to standard `buildJsonObject` style

## Details

**New helper** (`ToolJsonHelpers.kt`):
```kotlin
inline fun <reified T> listToolJson(key: String, count: Int, items: List<T>): String =
    buildJsonObject {
        put("count", count)
        put(key, networkJson.encodeToJsonElement(items))
    }.toString()
```

**Before** (49 tools):
```kotlin
import io.github.leogallego.ansiblejane.network.networkJson
import kotlinx.serialization.json.encodeToJsonElement
import kotlinx.serialization.json.buildJsonObject
import kotlinx.serialization.json.put

return buildJsonObject {
    put("count", result.totalCount)
    put("templates", networkJson.encodeToJsonElement(result.templates))
}.toString()
```

**After**:
```kotlin
import io.github.leogallego.ansiblejane.assistant.tools.listToolJson

return listToolJson("templates", result.totalCount, result.templates)
```

**Impact**: 51 files changed, +125 / -412 lines (net -287)

Closes #370

## Test plan

- [x] `shared:compileKotlinJvm` — builds clean
- [x] `shared:jvmTest` — all tests pass
- [x] Rebased on latest main — no conflicts

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>