### PR TITLE
refactor: make Tool a sealed interface (#364)

### DIFF
--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -99,11 +99,17 @@ for one-shot discovery of external endpoints would be over-engineering.
 
 ### Tool Contracts
 
+- `Tool` is a **sealed interface** (`shared/.../tools/ToolSpec.kt`). All direct subtypes
+  must live in the same package (`assistant.tools`) and module (`shared`). This enables
+  exhaustive `when` matching on tool types and catches missing branches at compile time.
 - Local tools implement the `LocalTool` interface (which extends `Tool`).
 - MCP tools are instances of the `McpTool` concrete class, constructed from MCP server
   discovery data at runtime. You do not subclass `McpTool`.
-- Both satisfy the `Tool` interface defined in `shared/.../tools/ToolSpec.kt`.
+- `CachedMcpTool` is a lazy-connection variant of `McpTool` that also directly extends `Tool`.
 - New local tools must be registered in `AssistantDiModule` with `bind LocalTool::class`.
+- Test-only tool stubs use the `@TestOnly` `ToolStub` open class
+  (`shared/.../tools/ToolStub.kt`) — a direct subtype of `Tool` in the same package,
+  satisfying the sealed constraint while keeping test support out of production paths.
 
 ---
 
@@ -287,3 +293,4 @@ rationale for the change. The PR review skill checks against the version in `mai
 | Version | Date | Change |
 |---------|------|--------|
 | 1.0.0 | 2026-06-18 | Initial contracts derived from codebase audit |
+| 1.1.0 | 2026-06-20 | Tool interface sealed (#364), test helpers documented |

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/TestOnly.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/TestOnly.kt
@@ -5,5 +5,5 @@ package io.github.leogallego.ansiblejane
     level = RequiresOptIn.Level.ERROR
 )
 @Retention(AnnotationRetention.BINARY)
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
 annotation class TestOnly

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolSpec.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolSpec.kt
@@ -8,7 +8,7 @@ data class ToolSpec(
     val parametersSchema: JsonObject
 )
 
-interface Tool {
+sealed interface Tool {
     val spec: ToolSpec
     val isDestructive: Boolean
         get() = false

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolStub.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolStub.kt
@@ -1,0 +1,20 @@
+package io.github.leogallego.ansiblejane.assistant.tools
+
+import io.github.leogallego.ansiblejane.TestOnly
+import kotlinx.serialization.json.JsonObject
+
+@TestOnly
+open class ToolStub(
+    name: String,
+    private val result: ToolResult = ToolResult(success = true),
+    description: String = "Stub tool",
+    override val serverLabel: String? = null,
+    override val toolset: String? = null,
+    private val onExecute: ((JsonObject) -> Unit)? = null
+) : Tool {
+    override val spec = ToolSpec(name, description, JsonObject(emptyMap()))
+    override suspend fun execute(args: JsonObject): ToolResult {
+        onExecute?.invoke(args)
+        return result
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineStreamingTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineStreamingTest.kt
@@ -6,17 +6,18 @@ import ai.koog.prompt.streaming.StreamFrame
 import app.cash.turbine.test
 import io.github.leogallego.ansiblejane.assistant.llm.LlmProvider
 import io.github.leogallego.ansiblejane.assistant.llm.ModelInfo
+import io.github.leogallego.ansiblejane.TestOnly
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
-import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.assistant.tools.ToolStub
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+@OptIn(TestOnly::class)
 class ChatEngineStreamingTest {
 
     @Test
@@ -30,7 +31,7 @@ class ChatEngineStreamingTest {
                 StreamFrame.End(finishReason = "stop")
             )
         ))
-        val tool = FakeStreamTool("list_hosts", """[{"id":1,"name":"host1"}]""")
+        val tool = ToolStub("list_hosts", ToolResult(success = true, data = """[{"id":1,"name":"host1"}]"""))
         val engine = ChatEngine(provider, ToolExecutor(listOf<Tool>(tool)))
 
         engine.processMessage("list hosts", emptyList(), emptyList()).test {
@@ -69,8 +70,8 @@ class ChatEngineStreamingTest {
             )
         ))
         val tools = listOf<Tool>(
-            FakeStreamTool("list_hosts", """[{"id":1}]"""),
-            FakeStreamTool("list_groups", """[{"id":2}]""")
+            ToolStub("list_hosts", ToolResult(success = true, data = """[{"id":1}]""")),
+            ToolStub("list_groups", ToolResult(success = true, data = """[{"id":2}]"""))
         )
         val engine = ChatEngine(provider, ToolExecutor(tools))
 
@@ -107,7 +108,7 @@ class ChatEngineStreamingTest {
                 StreamFrame.End(finishReason = "stop")
             )
         ))
-        val tool = FakeStreamTool("list_jobs", """[{"id":1},{"id":2},{"id":3}]""")
+        val tool = ToolStub("list_jobs", ToolResult(success = true, data = """[{"id":1},{"id":2},{"id":3}]"""))
         val engine = ChatEngine(provider, ToolExecutor(listOf<Tool>(tool)))
 
         engine.processMessage("show failed jobs", emptyList(), emptyList()).test {
@@ -142,7 +143,7 @@ class ChatEngineStreamingTest {
                 StreamFrame.End(finishReason = "stop")
             )
         ))
-        val tool = FakeStreamTool("ping", """{"status":"ok"}""")
+        val tool = ToolStub("ping", ToolResult(success = true, data = """{"status":"ok"}"""))
         val engine = ChatEngine(provider, ToolExecutor(listOf<Tool>(tool)))
 
         engine.processMessage("ping", emptyList(), emptyList()).test {
@@ -173,7 +174,7 @@ class ChatEngineStreamingTest {
                 StreamFrame.End(finishReason = "stop")
             )
         ))
-        val tool = FakeStreamTool("ping", """{"status":"ok"}""")
+        val tool = ToolStub("ping", ToolResult(success = true, data = """{"status":"ok"}"""))
         val engine = ChatEngine(provider, ToolExecutor(listOf<Tool>(tool)))
 
         engine.processMessage("check status", emptyList(), emptyList()).test {
@@ -213,13 +214,4 @@ private class StreamingFakeProvider(
     override fun isAvailable(): Boolean = true
     override fun modelInfo(): ModelInfo = ModelInfo("test-streaming")
     override fun close() {}
-}
-
-private class FakeStreamTool(
-    name: String,
-    private val responseData: String
-) : Tool {
-    override val spec = ToolSpec(name, "Test tool", JsonObject(emptyMap()))
-    override suspend fun execute(args: JsonObject): ToolResult =
-        ToolResult(success = true, data = responseData)
 }

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineTest.kt
@@ -6,9 +6,10 @@ import ai.koog.prompt.streaming.StreamFrame
 import app.cash.turbine.test
 import io.github.leogallego.ansiblejane.assistant.llm.LlmProvider
 import io.github.leogallego.ansiblejane.assistant.llm.ModelInfo
+import io.github.leogallego.ansiblejane.TestOnly
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
-import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.assistant.tools.ToolStub
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
@@ -17,6 +18,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+@OptIn(TestOnly::class)
 class ChatEngineTest {
 
     @Test
@@ -51,9 +53,10 @@ class ChatEngineTest {
             )),
             FakeResponse(text = "Found 3 failed jobs.")
         ))
-        val fakeTool = FakeTool(
-            spec = ToolSpec("list_jobs", "List jobs", JsonObject(emptyMap())),
-            result = ToolResult(success = true, data = "[{\"id\":1},{\"id\":2},{\"id\":3}]")
+        val fakeTool = ToolStub(
+            "list_jobs",
+            ToolResult(success = true, data = "[{\"id\":1},{\"id\":2},{\"id\":3}]"),
+            "List jobs"
         )
         val executor = ToolExecutor(listOf<Tool>(fakeTool))
         val engine = ChatEngine(provider, executor)
@@ -90,9 +93,10 @@ class ChatEngineTest {
                 ))
             }
         )
-        val fakeTool = FakeTool(
-            spec = ToolSpec("loop_tool", "Loops", JsonObject(emptyMap())),
-            result = ToolResult(success = true, data = "ok")
+        val fakeTool = ToolStub(
+            "loop_tool",
+            ToolResult(success = true, data = "ok"),
+            "Loops"
         )
         val executor = ToolExecutor(listOf<Tool>(fakeTool))
         val engine = ChatEngine(provider, executor, maxIterations = 3)
@@ -167,11 +171,4 @@ private class FakeLlmProvider(
     override fun isAvailable(): Boolean = true
     override fun modelInfo(): ModelInfo = ModelInfo("fake-model")
     override fun close() {}
-}
-
-private class FakeTool(
-    override val spec: ToolSpec,
-    private val result: ToolResult
-) : Tool {
-    override suspend fun execute(args: JsonObject): ToolResult = result
 }

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutorTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolExecutorTest.kt
@@ -1,10 +1,11 @@
 package io.github.leogallego.ansiblejane.assistant.engine
 
 import ai.koog.prompt.message.MessagePart
+import io.github.leogallego.ansiblejane.TestOnly
 import io.github.leogallego.ansiblejane.assistant.tools.ErrorType
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
-import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.assistant.tools.ToolStub
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean
@@ -17,6 +18,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@OptIn(TestOnly::class)
 class ToolExecutorTest {
 
     private fun toolCall(name: String, args: String = "{}"): MessagePart.Tool.Call =
@@ -24,8 +26,8 @@ class ToolExecutorTest {
 
     @Test
     fun `execute dispatches to correct tool by name`() = runTest {
-        val tool1 = StubTool("tool_a", ToolResult(success = true, data = "result_a"))
-        val tool2 = StubTool("tool_b", ToolResult(success = true, data = "result_b"))
+        val tool1 = ToolStub("tool_a", ToolResult(success = true, data = "result_a"))
+        val tool2 = ToolStub("tool_b", ToolResult(success = true, data = "result_b"))
         val executor = ToolExecutor(listOf<Tool>(tool1, tool2))
 
         val result = executor.execute(toolCall("tool_b"))
@@ -48,7 +50,7 @@ class ToolExecutorTest {
     @Test
     fun `execute truncates result exceeding maxResultChars`() = runTest {
         val longData = "x".repeat(30_000)
-        val tool = StubTool("big_tool", ToolResult(success = true, data = longData))
+        val tool = ToolStub("big_tool", ToolResult(success = true, data = longData))
         val executor = ToolExecutor(listOf<Tool>(tool), maxResultChars = 20_000)
 
         val result = executor.execute(toolCall("big_tool"))
@@ -61,7 +63,7 @@ class ToolExecutorTest {
     @Test
     fun `execute does not truncate result within limit`() = runTest {
         val data = "short result"
-        val tool = StubTool("small_tool", ToolResult(success = true, data = data))
+        val tool = ToolStub("small_tool", ToolResult(success = true, data = data))
         val executor = ToolExecutor(listOf<Tool>(tool))
 
         val result = executor.execute(toolCall("small_tool"))
@@ -89,12 +91,8 @@ class ToolExecutorTest {
     @Test
     fun `execute passes arguments to tool`() = runTest {
         var capturedArgs: JsonObject? = null
-        val tool = object : Tool {
-            override val spec = ToolSpec("arg_tool", "desc", JsonObject(emptyMap()))
-            override suspend fun execute(args: JsonObject): ToolResult {
-                capturedArgs = args
-                return ToolResult(success = true, data = "ok")
-            }
+        val tool = ToolStub("arg_tool", ToolResult(success = true, data = "ok")) { args ->
+            capturedArgs = args
         }
         val executor = ToolExecutor(listOf<Tool>(tool))
 
@@ -109,12 +107,4 @@ class ToolExecutorTest {
         assertEquals(42, capturedArgs!!["count"]!!.jsonPrimitive.int)
         assertEquals(true, capturedArgs!!["enabled"]!!.jsonPrimitive.boolean)
     }
-}
-
-private class StubTool(
-    name: String,
-    private val result: ToolResult
-) : Tool {
-    override val spec = ToolSpec(name, "Fake tool", JsonObject(emptyMap()))
-    override suspend fun execute(args: JsonObject): ToolResult = result
 }

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -1,8 +1,8 @@
 package io.github.leogallego.ansiblejane.assistant.engine
 
 import io.github.leogallego.ansiblejane.TestOnly
+import io.github.leogallego.ansiblejane.assistant.tools.ToolStub
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
@@ -48,12 +48,9 @@ class ToolRouterTest {
 
     private lateinit var router: ToolRouter
 
-    private fun mcpTool(name: String, serverLabel: String = "aap", toolset: String? = null) = object : Tool {
-        override val serverLabel: String = serverLabel
-        override val toolset: String? = toolset
-        override val spec = ToolSpec(name, "[$serverLabel] description of $name", JsonObject(emptyMap()))
-        override suspend fun execute(args: JsonObject) = ToolResult(success = true)
-    }
+    private fun mcpTool(name: String, serverLabel: String = "aap", toolset: String? = null) =
+        ToolStub(name, serverLabel = serverLabel, toolset = toolset,
+            description = "[$serverLabel] description of $name")
 
     private fun localTool(name: String, destructive: Boolean = false) = object : LocalTool {
         override val spec = ToolSpec(name, "Local: $name", JsonObject(emptyMap()))


### PR DESCRIPTION
## Summary

- Make `Tool` a sealed interface in `ToolSpec.kt`, closing the type hierarchy to `LocalTool`, `McpTool`, `CachedMcpTool`, and `ToolStub`
- Add `@TestOnly` `ToolStub` open class in `commonMain` as the canonical test helper — KMP treats `commonTest` as a separate module for sealed constraints, so test stubs must extend a production-side direct subtype
- Remove 4 private test tool classes (`FakeTool`, `FakeStreamTool`, `StubTool`, anonymous `object : Tool`) from test files, replaced by shared `ToolStub`
- Extend `@TestOnly` annotation `@Target` to include `CLASS`
- Update `service-contracts.md` to document sealed Tool hierarchy and ToolStub pattern

## Test plan

- [x] `shared:jvmTest` — all 4 affected test files pass (ToolRouterTest, ToolExecutorTest, ChatEngineTest, ChatEngineStreamingTest)
- [x] `app:testDebugUnitTest` — full app test suite passes (SettingsViewModelTest uses `LocalTool` which is unaffected)
- [x] Verified all direct `Tool` subtypes are in the `assistant.tools` package
- [x] Rebased on latest main (includes #380)

Closes #364

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>