### PR TITLE
refactor: move McpServerManagerTest to shared/jvmTest (#375)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -139,7 +139,6 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.ktor.client.mock)
     testImplementation(libs.mockwebserver)
-    testImplementation(libs.mcp.sdk.client) // Workaround: needed until McpServerManagerTest moves to shared/jvmTest (#375)
     testImplementation(libs.turbine)
     testImplementation(libs.coroutines.test)
     testImplementation(libs.robolectric)

--- a/shared/src/jvmTest/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManagerTest.kt
+++ b/shared/src/jvmTest/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManagerTest.kt
@@ -13,26 +13,26 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
-import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
 import java.net.Proxy
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class McpServerManagerTest {
 
     private lateinit var server: MockWebServer
     private lateinit var manager: McpServerManager
 
-    @Before
+    @BeforeTest
     fun setup() {
         server = MockWebServer()
     }
 
-    @After
+    @AfterTest
     fun tearDown() {
         server.shutdown()
         runBlocking { manager.disconnectAll() }
@@ -173,12 +173,10 @@ class McpServerManagerTest {
         manager.connectAll(instance)
         manager.disconnectAll()
 
-        // Re-set instance so ensureConnected can find config
         manager.connectAll(
             instance.copy(mcpServerUrls = instance.mcpServerUrls)
         )
 
-        // Tools should be available after connectAll
         assertEquals(1, manager.mcpTools.value.size)
     }
 
@@ -196,7 +194,6 @@ class McpServerManagerTest {
         manager.connectAll(instance)
         assertEquals(1, manager.mcpTools.value.size)
 
-        // Reconnect — should still have tools
         manager.reconnectServer("test-server")
 
         val tools = manager.mcpTools.value
@@ -278,7 +275,6 @@ class McpServerManagerTest {
         )
         manager.connectAllWithCache(instance, manifest)
 
-        // Deferred — cached tools remain from setCachedTools
         val tools = manager.mcpTools.value
         assertEquals(1, tools.size)
         assertEquals("cached.tool", tools[0].spec.name)
@@ -347,7 +343,6 @@ class McpServerManagerTest {
 
         manager.connectAllWithCache(instance, manifest)
 
-        // No connections made — deferred to lazy ensureConnected
         assertTrue(manager.connections.value.isEmpty())
     }
 


### PR DESCRIPTION
## Summary

- Move `McpServerManagerTest` from `app/src/test/` to `shared/src/jvmTest/` where its production class (`McpServerManager`) already lives
- Convert JUnit 4 annotations to kotlin.test (`@Before`→`@BeforeTest`, `@After`→`@AfterTest`, `Assert.*`→`kotlin.test.*`)
- Remove `testImplementation(libs.mcp.sdk.client)` workaround from `app/build.gradle.kts` — no longer needed since `shared/commonMain` already declares this dependency

## Test plan

- [x] All 18 McpServerManagerTest tests pass in `shared:jvmTest`
- [x] `app:compileDebugUnitTestKotlin` succeeds without the removed workaround dep
- [x] No other `app/src/test/` file imports `io.modelcontextprotocol`
- [x] Architecture review: clean — no contract violations

Closes #375

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>