### PR TITLE
chore: bump version to v0.8.6-alpha.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.experimental.enableScreenshotTest=true
 kotlin.native.ignoreDisabledTargets=true
-appVersionName=0.8.5-alpha.0
-appVersionCode=26061910
+appVersionName=0.8.6-alpha.0
+appVersionCode=26062001


### PR DESCRIPTION
## Summary

- Bump versionName to `0.8.6-alpha.0` and versionCode to `26062001`

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>