### PR TITLE
fix: update F-Droid repo and site URLs to custom domain

### DIFF
--- a/.github/workflows/fdroid-repo.yml
+++ b/.github/workflows/fdroid-repo.yml
@@ -41,7 +41,7 @@ jobs:
           mkdir -p fdroid/repo
           echo "$FDROID_KEYSTORE_B64" | base64 -d > fdroid/keystore.p12
           cat > fdroid/config.yml <<'CONF'
-          repo_url: https://leogallego.github.io/ansible-jane/fdroid/repo
+          repo_url: https://jane.ansible.ar/fdroid/repo
           repo_name: Ansible Jane F-Droid Repo
           repo_description: Self-hosted F-Droid repository for Ansible Jane, a remote control app for Ansible Automation Platform.
           repo_icon: icon.png
@@ -50,7 +50,7 @@ jobs:
           echo "keystorepass: $FDROID_KEYSTORE_PASS" >> fdroid/config.yml
           echo "keypass: $FDROID_KEY_PASS" >> fdroid/config.yml
           echo "repo_keyalias: $FDROID_KEY_ALIAS" >> fdroid/config.yml
-          echo "keydname: CN=leogallego.github.io, OU=F-Droid Repo, O=Ansible Jane" >> fdroid/config.yml
+          echo "keydname: CN=jane.ansible.ar, OU=F-Droid Repo, O=Ansible Jane" >> fdroid/config.yml
           sed -i 's/^          //' fdroid/config.yml
           chmod 0600 fdroid/config.yml
         env:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A multiplatform app (Android and Desktop) for managing [Ansible Automation Platf
 
 ### Android
 
-- **F-Droid** - add this repo to your F-Droid client: `https://leogallego.github.io/ansible-jane/fdroid/repo`
+- **F-Droid** - add this repo to your F-Droid client: `https://jane.ansible.ar/fdroid/repo`
 - **GitHub Releases** - download the latest APK from [Releases](https://github.com/leogallego/ansible-jane/releases/latest)
 - **Obtainium** - point [Obtainium](https://github.com/ImranR98/Obtainium) to this repo for automatic updates
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.experimental.enableScreenshotTest=true
 kotlin.native.ignoreDisabledTargets=true
-appVersionName=0.8.6-alpha.0
-appVersionCode=26062001
+appVersionName=0.8.6-alpha.1
+appVersionCode=26062002

--- a/site/index.html
+++ b/site/index.html
@@ -8,8 +8,8 @@
   <meta name="theme-color" content="#090A0F">
   <meta property="og:title" content="Ansible Jane">
   <meta property="og:description" content="Manage Ansible Automation Platform from your phone or desktop. AI-powered, open source.">
-  <meta property="og:image" content="https://leogallego.github.io/ansible-jane/img/icon.png">
-  <meta property="og:url" content="https://leogallego.github.io/ansible-jane/">
+  <meta property="og:image" content="https://jane.ansible.ar/img/icon.png">
+  <meta property="og:url" content="https://jane.ansible.ar/">
   <meta property="og:type" content="website">
   <link rel="icon" href="img/icon.png" type="image/png">
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary

- Update F-Droid `repo_url` and certificate CN from `leogallego.github.io` to `jane.ansible.ar`
- Update `og:image` and `og:url` meta tags in site to use custom domain
- Update README F-Droid repo URL

GitHub Pages redirects all `github.io` requests to the custom domain with a 301, causing F-Droid clients to fail with `RedirectResponseException: Unhandled redirect`.

## Test plan

- [ ] Verify `https://jane.ansible.ar/fdroid/repo/entry.jar` returns 200
- [ ] Re-add F-Droid repo in client with new URL
- [ ] Trigger F-Droid repo rebuild after merge to regenerate index with new URL

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>