### PR TITLE
fix: add F-Droid metadata links

### DIFF
--- a/.github/workflows/fdroid-repo.yml
+++ b/.github/workflows/fdroid-repo.yml
@@ -72,6 +72,21 @@ jobs:
           mkdir -p fdroid/repo/icons
           cp fastlane/metadata/android/en-US/images/icon.png fdroid/repo/icons/icon.png
 
+      - name: Create app metadata
+        run: |
+          mkdir -p fdroid/metadata
+          cat > fdroid/metadata/io.github.leogallego.ansiblejane.yml <<'META'
+          Categories:
+            - System
+          License: GPL-3.0-only
+          AuthorName: Leonardo Gallego
+          WebSite: https://jane.ansible.ar
+          SourceCode: https://github.com/leogallego/ansible-jane
+          IssueTracker: https://github.com/leogallego/ansible-jane/issues
+          Changelog: https://github.com/leogallego/ansible-jane/releases
+          META
+          sed -i 's/^          //' fdroid/metadata/io.github.leogallego.ansiblejane.yml
+
       - name: Generate repo index
         working-directory: fdroid
         run: fdroid update --create-metadata


### PR DESCRIPTION
## Summary

- Add app metadata YAML to the F-Droid repo workflow with website, source code, issue tracker, and changelog links
- F-Droid clients will now show these links in the app details page

## Test plan

- [ ] Trigger F-Droid repo workflow after merge
- [ ] Check `index-v2.json` for `webSite`, `sourceCode`, `issueTracker` in package metadata
- [ ] Verify links appear in F-Droid client

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>