### PR TITLE
fix: rename bottom nav tab from Jane to Jane AI

### DIFF
--- a/.github/workflows/fdroid-repo.yml
+++ b/.github/workflows/fdroid-repo.yml
@@ -84,6 +84,31 @@ jobs:
           SourceCode: https://github.com/leogallego/ansible-jane
           IssueTracker: https://github.com/leogallego/ansible-jane/issues
           Changelog: https://github.com/leogallego/ansible-jane/releases
+          Summary: AI-powered remote control for Ansible Automation Platform
+          Description: |-
+            Ansible Jane is a lightweight Android app for managing your Ansible
+            Automation Platform (AAP) instances on the go.
+
+            Jane is an AI assistant that works with the models you choose: local
+            models as small as qwen2.5:7b running on Ollama, or frontier providers
+            like OpenAI-compatible APIs, Google Gemini, and OpenRouter. Jane uses
+            tool-use and MCP to query your AAP instance in natural language.
+
+            Features:
+            * Browse and launch job templates and workflow templates
+            * Monitor job status and workflow execution in real-time
+            * Manage inventories and hosts
+            * View schedules and EDA audit logs
+            * AI assistant (Jane) for natural-language interaction with your AAP instance
+            * Bring your own model: local (Ollama, llama.cpp) or cloud (OpenAI-compatible, Gemini, OpenRouter)
+            * Multi-instance support with secure token storage
+            * Material You (Material 3) design with dark mode support
+
+            Requirements:
+            * Ansible Automation Platform 2.5+ with Gateway
+            * Android 12 (API 31) or higher
+
+            Ansible Jane is free and open source software.
           META
           sed -i 's/^          //' fdroid/metadata/io.github.leogallego.ansiblejane.yml
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="tab_templates">Templates</string>
     <string name="tab_infrastructure">Infrastructure</string>
     <string name="tab_activity">Activity</string>
-    <string name="tab_assistant">Jane</string>
+    <string name="tab_assistant">Jane AI</string>
 
     <!-- Tab segments -->
     <string name="segment_overview">Overview</string>

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/main/TabDefinitions.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/main/TabDefinitions.kt
@@ -72,7 +72,7 @@ sealed class TopLevelTab(
 
     data object Assistant : TopLevelTab(
         route = "main/assistant",
-        label = "Jane",
+        label = "Jane AI",
         icon = Icons.Outlined.Assistant,
         selectedIcon = Icons.Filled.Assistant,
         segments = listOf(


### PR DESCRIPTION
## Summary

- Rename bottom navigation tab label from "Jane" to "Jane AI" so users understand it's the AI assistant
- Updated in both `TabDefinitions.kt` (KMP) and `strings.xml` (Android)

## Test plan

- [ ] Verify bottom nav shows "Jane AI" label
- [ ] Check label doesn't overflow on smaller screens

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>