### PR TITLE
fix(site): make hero buttons clickable, add desktop showcase

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -79,6 +79,27 @@
     </div>
   </section>
 
+  <!-- Desktop Showcase -->
+  <section class="showcase showcase-desktop fade-in">
+    <h2>Same app, bigger screen</h2>
+    <p class="subtitle">Native desktop builds for Linux, macOS, and Windows. No emulation, no Electron.</p>
+    <div class="showcase-track showcase-track-desktop">
+      <div class="showcase-item showcase-item-desktop">
+        <img src="img/screens/desktop-dashboard-dark.png" data-dark="img/screens/desktop-dashboard-dark.png" data-light="img/screens/desktop-dashboard-light.png" alt="Desktop Dashboard">
+        <div class="label">Dashboard</div>
+      </div>
+      <div class="showcase-item showcase-item-desktop">
+        <img src="img/screens/desktop-jane-dark.png" data-dark="img/screens/desktop-jane-dark.png" data-light="img/screens/desktop-jane-light.png" alt="Desktop Jane AI">
+        <div class="label">Jane</div>
+      </div>
+      <div class="showcase-item showcase-item-desktop">
+        <img src="img/screens/desktop-templates-dark.png" data-dark="img/screens/desktop-templates-dark.png" data-light="img/screens/desktop-templates-light.png" alt="Desktop Templates">
+        <div class="label">Templates</div>
+      </div>
+    </div>
+    <p class="desktop-platforms">Linux &middot; macOS &middot; Windows</p>
+  </section>
+
   <!-- Network (Features) -->
   <section class="network" id="network">
     <h2 class="fade-in">The Network</h2>

--- a/site/styles.css
+++ b/site/styles.css
@@ -38,6 +38,7 @@ a:hover { text-decoration: underline; }
   position: fixed;
   inset: 0;
   z-index: 0;
+  pointer-events: none;
 }
 
 .stars1, .stars2 {
@@ -372,6 +373,27 @@ a:hover { text-decoration: underline; }
   text-align: center;
 }
 
+/* ---- Desktop Showcase ---- */
+.showcase-desktop {
+  border-top: 1px solid var(--glass-border);
+}
+
+.showcase-track-desktop {
+  padding: 0 max(24px, calc((100vw - 1100px) / 2));
+}
+
+.showcase-item-desktop {
+  flex: 0 0 340px;
+}
+
+.desktop-platforms {
+  margin-top: 24px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.5px;
+}
+
 /* ---- Install ---- */
 .install {
   padding: 80px 24px;
@@ -461,4 +483,5 @@ footer .epigraph {
   .network { padding: 0 16px 48px; }
   .install-options { grid-template-columns: 1fr; }
   .showcase-item { flex: 0 0 160px; }
+  .showcase-item-desktop { flex: 0 0 280px; }
 }


### PR DESCRIPTION
## Summary

- Fix starfield overlay blocking all button clicks (pointer-events: none)
- Add desktop showcase section below Android screenshots (Linux, macOS, Windows)
- Desktop screenshots use placeholder image paths — actual images to be added

## Test plan

- [x] Download and Source Code buttons now clickable (verified with Playwright)
- [x] Desktop section renders with correct layout and theme toggle support
- [ ] Add desktop screenshot images to `site/img/screens/desktop-*`

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>