### PR TITLE
fix(site): default desktop screenshots to dark, match Android order

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -85,24 +85,24 @@
     <p class="subtitle">Native desktop builds for Linux, macOS, and Windows. No emulation, no Electron.</p>
     <div class="showcase-track showcase-track-desktop">
       <div class="showcase-item showcase-item-desktop">
-        <img src="img/screens/desktop-dashboard-light.png" data-dark="img/screens/desktop-dashboard-dark.png" data-light="img/screens/desktop-dashboard-light.png" alt="Desktop Dashboard">
+        <img src="img/screens/desktop-jane-dark.png" data-dark="img/screens/desktop-jane-dark.png" data-light="img/screens/desktop-jane-light.png" alt="Desktop Jane AI">
+        <div class="label">Jane</div>
+      </div>
+      <div class="showcase-item showcase-item-desktop">
+        <img src="img/screens/desktop-dashboard-dark.png" data-dark="img/screens/desktop-dashboard-dark.png" data-light="img/screens/desktop-dashboard-light.png" alt="Desktop Dashboard">
         <div class="label">Dashboard</div>
       </div>
       <div class="showcase-item showcase-item-desktop">
-        <img src="img/screens/desktop-templates-light.png" data-dark="img/screens/desktop-templates-dark.png" data-light="img/screens/desktop-templates-light.png" alt="Desktop Templates">
+        <img src="img/screens/desktop-templates-dark.png" data-dark="img/screens/desktop-templates-dark.png" data-light="img/screens/desktop-templates-light.png" alt="Desktop Templates">
         <div class="label">Templates</div>
       </div>
       <div class="showcase-item showcase-item-desktop">
-        <img src="img/screens/desktop-infrastructure-light.png" data-dark="img/screens/desktop-infrastructure-dark.png" data-light="img/screens/desktop-infrastructure-light.png" alt="Desktop Infrastructure">
-        <div class="label">Infrastructure</div>
-      </div>
-      <div class="showcase-item showcase-item-desktop">
-        <img src="img/screens/desktop-activity-light.png" data-dark="img/screens/desktop-activity-dark.png" data-light="img/screens/desktop-activity-light.png" alt="Desktop Activity">
+        <img src="img/screens/desktop-activity-dark.png" data-dark="img/screens/desktop-activity-dark.png" data-light="img/screens/desktop-activity-light.png" alt="Desktop Activity">
         <div class="label">Activity</div>
       </div>
       <div class="showcase-item showcase-item-desktop">
-        <img src="img/screens/desktop-jane-light.png" data-dark="img/screens/desktop-jane-dark.png" data-light="img/screens/desktop-jane-light.png" alt="Desktop Jane AI">
-        <div class="label">Jane</div>
+        <img src="img/screens/desktop-infrastructure-dark.png" data-dark="img/screens/desktop-infrastructure-dark.png" data-light="img/screens/desktop-infrastructure-light.png" alt="Desktop Infrastructure">
+        <div class="label">Infrastructure</div>
       </div>
     </div>
     <p class="desktop-platforms">Linux &middot; macOS &middot; Windows</p>


### PR DESCRIPTION
Default src was light but page starts in dark mode. Reorder to match Android showcase: Jane, Dashboard, Templates, Activity, Infrastructure.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>