### PR TITLE
chore: bump version to v0.8.6-alpha.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.experimental.enableScreenshotTest=true
 kotlin.native.ignoreDisabledTargets=true
-appVersionName=0.8.6-alpha.1
-appVersionCode=26062002
+appVersionName=0.8.6-alpha.2
+appVersionCode=26062302


### PR DESCRIPTION
Automated version bump for release v0.8.6-alpha.2.