### PR TITLE
perf: consolidate CI Gradle invocations (#365)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,20 +42,11 @@ jobs:
       - name: Set execution flag for gradlew
         run: chmod +x gradlew
 
-      - name: Build debug APK
-        run: ./gradlew assembleDebug --stacktrace
+      - name: Build (Android + Desktop)
+        run: ./gradlew assembleDebug :composeApp:desktopJar --stacktrace
 
-      - name: Build Desktop JAR
-        run: ./gradlew :composeApp:desktopJar --stacktrace
-
-      - name: Run unit tests
-        run: ./gradlew testDebugUnitTest --stacktrace
-
-      - name: Run shared JVM tests
-        run: ./gradlew :shared:jvmTest --stacktrace
-
-      - name: Run Desktop UI tests
-        run: ./gradlew :composeApp:desktopTest --stacktrace
+      - name: Test (all targets)
+        run: ./gradlew testDebugUnitTest :shared:jvmTest :composeApp:desktopTest --stacktrace --continue
 
       - name: Check for lifecycle artifact version drift
         run: |


### PR DESCRIPTION
## Summary

- Consolidate 5 separate CI Gradle invocations into 2 (build + test) to eliminate 3 JVM startup + configuration overhead cycles (~30-40s each)
- Add `--continue` flag to the test step so all test suites run even if one fails, improving CI diagnostics

Closes #365

## Changes

### `.github/workflows/ci.yml`

**Before** (5 steps, 5 JVM startups):
- Build debug APK (`assembleDebug`)
- Build Desktop JAR (`:composeApp:desktopJar`)
- Run unit tests (`testDebugUnitTest`)
- Run shared JVM tests (`:shared:jvmTest`)
- Run Desktop UI tests (`:composeApp:desktopTest`)

**After** (2 steps, 2 JVM startups):
- Build (Android + Desktop): `assembleDebug :composeApp:desktopJar`
- Test (all targets): `testDebugUnitTest :shared:jvmTest :composeApp:desktopTest --continue`

All 5 original Gradle tasks are preserved. The lifecycle version drift check step is untouched.

## Test plan

- [ ] CI passes on this PR (the CI workflow itself is the test)
- [ ] All 5 Gradle tasks complete successfully in the consolidated steps
- [ ] Compare CI run time with recent runs on main (~7-8 min baseline)

## Review findings addressed

- **Plan review (Phase 4)**: Warning about failure isolation addressed by adding `--continue` flag
- **Implementation review (Phase 6)**: No findings (architecture + code-quality clean)

## Acknowledged debt

None

## Stack position

- **Base**: `main`
- **Next**: end (standalone issue)

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>