### PR TITLE
feat: restructure Settings tabs (#310)

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
@@ -12,8 +12,9 @@ import io.github.leogallego.ansiblejane.ui.components.TimeFormat
 enum class SettingsTab(val label: String) {
     General("General"),
     Instances("Instances"),
-    Agent("Agent"),
-    Tools("Tools")
+    AiProvider("AI Provider"),
+    McpServers("MCP Servers"),
+    LocalTools("Local Tools")
 }
 
 sealed interface SettingsUiState {
@@ -34,17 +35,17 @@ sealed interface SettingsUiState {
         val themeMode: ThemeMode = ThemeMode.SYSTEM,
         val pollInterval: PollInterval = PollInterval.MINUTES_15,
         val approvalPollingEnabled: Boolean = true,
-        // Agent (LLM config)
+        // AI Provider (LLM config)
         val savedConfigs: Map<String, LlmProviderConfig> = emptyMap(),
         val activeConfig: LlmProviderConfig? = null,
         val activeProviderKey: String? = null,
         val fetchedModels: List<String> = emptyList(),
         val modelFetchState: ModelFetchState = ModelFetchState.Idle,
-        // Tools (MCP)
+        // MCP Servers
         val mcpEnabled: Boolean = false,
         val mcpServers: List<McpServerConfig> = emptyList(),
         val connections: Map<String, McpConnectionState> = emptyMap(),
-        // Tools (Local + expanded state)
+        // Local Tools + expanded state
         val localTools: List<LocalToolUiState> = emptyList(),
         val mcpServerTools: Map<String, List<McpToolUiState>> = emptyMap(),
         val expandedMcpServers: Set<String> = emptySet(),

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalToolsTab.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalToolsTab.kt
@@ -1,0 +1,30 @@
+package io.github.leogallego.ansiblejane.ui.settings
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.leogallego.ansiblejane.presentation.settings.LocalToolUiState
+
+@Composable
+fun LocalToolsTab(
+    tools: List<LocalToolUiState>,
+    expandedCategories: Set<String>,
+    onToggleCategory: (String) -> Unit,
+    onToggleTool: (String, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LocalToolsSection(
+        tools = tools,
+        expandedCategories = expandedCategories,
+        onToggleCategory = onToggleCategory,
+        onToggleTool = onToggleTool,
+        modifier = modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    )
+}

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
@@ -161,7 +161,7 @@ private fun SettingsContent(
                 onLogout = onLogout,
                 modifier = Modifier.weight(1f)
             )
-            SettingsTab.Agent -> AgentTab(
+            SettingsTab.AiProvider -> AgentTab(
                 activeProviderKey = state.activeProviderKey,
                 activeConfig = state.activeConfig,
                 savedConfigs = state.savedConfigs,
@@ -174,14 +174,12 @@ private fun SettingsContent(
                 onClearHistory = onClearHistory,
                 modifier = Modifier.weight(1f)
             )
-            SettingsTab.Tools -> ToolsTab(
+            SettingsTab.McpServers -> ToolsTab(
                 mcpEnabled = state.mcpEnabled,
                 mcpServers = state.mcpServers,
                 connections = state.connections,
                 mcpServerTools = state.mcpServerTools,
-                localTools = state.localTools,
                 expandedMcpServers = state.expandedMcpServers,
-                expandedCategories = state.expandedCategories,
                 onToggleMcp = onToggleMcp,
                 onAddMcpServer = onAddMcpServer,
                 onRemoveMcpServer = onRemoveMcpServer,
@@ -190,10 +188,18 @@ private fun SettingsContent(
                 onToggleServerEnabled = onToggleServerEnabled,
                 onToggleToolEnabled = onToggleToolEnabled,
                 onToggleExpandMcpServer = onToggleExpandMcpServer,
-                onToggleExpandCategory = onToggleExpandCategory,
                 onRefreshMcpServer = onRefreshMcpServer,
                 isRefreshingTools = state.isRefreshingTools,
                 onRefreshAllTools = onRefreshAllTools,
+                modifier = Modifier.weight(1f)
+            )
+            SettingsTab.LocalTools -> LocalToolsTab(
+                tools = state.localTools,
+                expandedCategories = state.expandedCategories,
+                onToggleCategory = onToggleExpandCategory,
+                onToggleTool = { name, enabled ->
+                    onToggleToolEnabled(name, ToolSource.LOCAL, null, enabled)
+                },
                 modifier = Modifier.weight(1f)
             )
         }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolsTab.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolsTab.kt
@@ -3,9 +3,7 @@ package io.github.leogallego.ansiblejane.ui.settings
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -14,7 +12,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -34,7 +31,6 @@ import aapremotecontrol.composeapp.generated.resources.*
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.model.McpServerConfig
 import io.github.leogallego.ansiblejane.network.mcp.McpConnectionState
-import io.github.leogallego.ansiblejane.presentation.settings.LocalToolUiState
 import io.github.leogallego.ansiblejane.presentation.settings.McpToolUiState
 
 @Composable
@@ -43,9 +39,7 @@ fun ToolsTab(
     mcpServers: List<McpServerConfig>,
     connections: Map<String, McpConnectionState>,
     mcpServerTools: Map<String, List<McpToolUiState>>,
-    localTools: List<LocalToolUiState>,
     expandedMcpServers: Set<String>,
-    expandedCategories: Set<String>,
     onToggleMcp: (Boolean) -> Unit,
     onAddMcpServer: (url: String, label: String, toolset: String?, headers: Map<String, String>, useInstanceAuth: Boolean) -> Unit,
     onRemoveMcpServer: (url: String) -> Unit,
@@ -54,7 +48,6 @@ fun ToolsTab(
     onToggleServerEnabled: (url: String, enabled: Boolean) -> Unit,
     onToggleToolEnabled: (name: String, source: ToolSource, serverLabel: String?, enabled: Boolean) -> Unit,
     onToggleExpandMcpServer: (label: String) -> Unit,
-    onToggleExpandCategory: (category: String) -> Unit,
     onRefreshMcpServer: (label: String) -> Unit,
     isRefreshingTools: Boolean = false,
     onRefreshAllTools: () -> Unit = {},
@@ -153,17 +146,6 @@ fun ToolsTab(
             }
         }
 
-        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-
-        // Local tools section
-        LocalToolsSection(
-            tools = localTools,
-            expandedCategories = expandedCategories,
-            onToggleCategory = onToggleExpandCategory,
-            onToggleTool = { name, enabled ->
-                onToggleToolEnabled(name, ToolSource.LOCAL, null, enabled)
-            }
-        )
     }
 
     if (showAddServerSheet) {

--- a/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
@@ -183,46 +183,47 @@ class SettingsScreenTest {
     }
 
     @Test
-    fun tab_selector_shows_all_four_tabs() = runComposeUiTest {
+    fun tab_selector_shows_all_five_tabs() = runComposeUiTest {
         fakeTokenManager.setInstances(listOf(instance1))
         setUpScreen()
 
         onNodeWithText("General").assertIsDisplayed()
         onNodeWithText("Instances").assertIsDisplayed()
-        onNodeWithText("Agent").assertIsDisplayed()
-        onNodeWithText("Tools").assertIsDisplayed()
+        onNodeWithText("AI Provider").assertIsDisplayed()
+        onNodeWithText("MCP Servers").assertIsDisplayed()
+        onNodeWithText("Local Tools").assertIsDisplayed()
     }
 
     @Test
-    fun Agent_tab_shows_LLM_Provider_section() = runComposeUiTest {
+    fun AI_Provider_tab_shows_LLM_Provider_section() = runComposeUiTest {
         fakeTokenManager.setInstances(listOf(instance1))
         setUpScreen()
 
-        onNodeWithText("Agent").performClick()
+        onNodeWithText("AI Provider").performClick()
         waitForIdle()
 
         onNodeWithText("LLM Provider").assertIsDisplayed()
     }
 
     @Test
-    fun Tools_tab_shows_MCP_Servers_section() = runComposeUiTest {
+    fun MCP_Servers_tab_shows_MCP_section() = runComposeUiTest {
         fakeTokenManager.setInstances(listOf(instance1))
         setUpScreen()
 
-        onNodeWithText("Tools").performClick()
+        onNodeWithText("MCP Servers").performClick()
         waitForIdle()
 
-        onNodeWithText("MCP Servers").assertIsDisplayed()
+        onNodeWithText("Enable AAP MCP").assertIsDisplayed()
     }
 
     @Test
-    fun Tools_tab_shows_Local_Tools_section() = runComposeUiTest {
+    fun Local_Tools_tab_shows_tools_section() = runComposeUiTest {
         fakeTokenManager.setInstances(listOf(instance1))
         setUpScreen()
 
-        onNodeWithText("Tools").performClick()
+        onNodeWithText("Local Tools").performClick()
         waitForIdle()
 
-        onNodeWithText("Local Tools").performScrollTo().assertIsDisplayed()
+        onNodeWithText("Local Tools", substring = true).assertIsDisplayed()
     }
 }

--- a/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
@@ -224,6 +224,6 @@ class SettingsScreenTest {
         onNodeWithText("Local Tools").performClick()
         waitForIdle()
 
-        onNodeWithText("Local Tools", substring = true).assertIsDisplayed()
+        onNodeWithText("tools across", substring = true).assertIsDisplayed()
     }
 }


### PR DESCRIPTION
## Summary

- Rename "Agent" tab to "AI Provider" to accurately describe its purpose (LLM provider configuration)
- Rename "Tools" tab to "MCP Servers" to clarify it manages MCP server connections
- Extract Local Tools into a dedicated tab for category-based browsing of 61 built-in AAP API tools

Closes #310

## Changes

### `SettingsUiState.kt`
- Rename `SettingsTab.Agent` → `SettingsTab.AiProvider` with label "AI Provider"
- Rename `SettingsTab.Tools` → `SettingsTab.McpServers` with label "MCP Servers"
- Add `SettingsTab.LocalTools` with label "Local Tools"

### `SettingsScreen.kt`
- Update `when` block to route `AiProvider` → `AgentTab`, `McpServers` → `ToolsTab`, `LocalTools` → `LocalToolsTab`
- Remove local tools params from `ToolsTab` call (they now route to `LocalToolsTab`)

### `ToolsTab.kt`
- Remove `localTools`, `expandedCategories`, `onToggleExpandCategory` params
- Remove `LocalToolsSection` call and `HorizontalDivider` — now MCP-only
- Remove unused imports

### New: `LocalToolsTab.kt`
- Wrapper composable that delegates to existing `LocalToolsSection` with scroll and padding

## Test plan

- [ ] Desktop compilation passes (verified locally)
- [ ] CI passes (Android + Desktop build + tests)
- [ ] Tabs display as: General | Instances | AI Provider | MCP Servers | Local Tools
- [ ] Local tools appear in their own tab with category-based browsing
- [ ] MCP Servers tab no longer shows local tools section

## Review findings addressed

- **Plan review (Phase 4)**: No critical findings. TestTag auto-generated via `tab_${tab.name.lowercase()}`. Verified only SettingsScreen.kt calls ToolsTab.
- **Implementation review (Phase 6)**: No findings from architecture or code-quality reviewers.

## Acknowledged debt

- `AgentTab` composable function not renamed to `AiProviderTab` — intentional to minimize noise in this PR. The tab label communicates the purpose to users.

## Stack position

- **Base**: `main`
- **Next**: end (standalone issue)

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>