### PR TITLE
ci: add build_all option to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
         description: 'Tag to release (e.g. v0.8.4-alpha.7)'
         required: true
         type: string
+      build_all:
+        description: 'Build all platforms (macOS, Windows, Flatpak) even for pre-release tags'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -378,7 +383,7 @@ jobs:
 
   desktop-linux-flatpak:
     name: Build Flatpak
-    if: ${{ !contains(inputs.tag || github.ref_name, '-') }}
+    if: ${{ inputs.build_all || !contains(inputs.tag || github.ref_name, '-') }}
     needs: [desktop-linux-tar]
     runs-on: ubuntu-latest
     steps:
@@ -422,7 +427,7 @@ jobs:
 
   desktop-macos:
     name: Build Desktop macOS package
-    if: ${{ !contains(inputs.tag || github.ref_name, '-') }}
+    if: ${{ inputs.build_all || !contains(inputs.tag || github.ref_name, '-') }}
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -464,7 +469,7 @@ jobs:
 
   desktop-windows:
     name: Build Desktop Windows package
-    if: ${{ !contains(inputs.tag || github.ref_name, '-') }}
+    if: ${{ inputs.build_all || !contains(inputs.tag || github.ref_name, '-') }}
     runs-on: windows-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Adds a `build_all` boolean checkbox to the release workflow's `workflow_dispatch` inputs
- When checked, macOS (DMG), Windows (MSI), and Flatpak jobs run even for pre-release tags (e.g., `-alpha.2`)
- Tag-triggered runs and unchecked dispatches keep existing behavior (those platforms only build for GA releases)

## Test plan

- [ ] Dispatch release workflow with `build_all: false` on an alpha tag — macOS/Windows/Flatpak should be skipped
- [ ] Dispatch release workflow with `build_all: true` on an alpha tag — all platforms should build

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>