### PR TITLE
ci: fix Dependabot PR lockfile race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Set execution flag for gradlew
         run: chmod +x gradlew
 
+      - name: Regenerate lockfiles for Dependabot PRs
+        if: github.actor == 'dependabot[bot]'
+        run: ./gradlew dependencies --write-locks
+
       - name: Build (Android + Desktop)
         run: ./gradlew assembleDebug :composeApp:desktopJar --stacktrace
 


### PR DESCRIPTION
## Summary

- Adds a conditional step to CI that regenerates Gradle lockfiles in-place before building, only for Dependabot PRs
- Fixes race condition where CI and lockfile-update workflow trigger simultaneously — CI would fail on stale lockfiles before the lockfile commit landed
- Non-Dependabot PRs are unaffected (step is skipped)

## Test plan

- [ ] Merge this PR, then trigger `@dependabot rebase` on any open Dependabot PR (#397, #398, #395, #396) — CI should pass
- [ ] Verify non-Dependabot PRs skip the lockfile step (check CI logs)

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>