### PR TITLE
ci: fix Dependabot detection in lockfile regeneration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Regenerate lockfiles for Dependabot PRs
-        if: github.actor == 'dependabot[bot]'
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
         run: ./gradlew dependencies --write-locks
 
       - name: Build (Android + Desktop)


### PR DESCRIPTION
## Summary

- Fixes the lockfile regeneration step added in #420 — it used `github.actor` which is the user who triggered the event (e.g. whoever updated the branch), not the PR author
- Changes to `github.event.pull_request.user.login` which correctly identifies Dependabot PRs regardless of who triggers the CI run

## Context

When a Dependabot PR branch is updated via MCP `update_pull_request_branch` or manual rebase, `github.actor` is the human/bot who triggered it, not `dependabot[bot]`. The lockfile step was skipped, causing the same build failure #420 was meant to fix.

## Test plan

- [ ] Update a Dependabot PR branch (#397) after this merges — lockfile step should run and CI should pass

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>