### PR TITLE
ci: fix lockfile regeneration to cover all modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Regenerate lockfiles for Dependabot PRs
         if: github.event.pull_request.user.login == 'dependabot[bot]'
-        run: ./gradlew dependencies --write-locks
+        run: ./gradlew :app:dependencies :shared:dependencies :composeApp:dependencies --write-locks
 
       - name: Build (Android + Desktop)
         run: ./gradlew assembleDebug :composeApp:desktopJar --stacktrace

--- a/.github/workflows/lockfile-update.yml
+++ b/.github/workflows/lockfile-update.yml
@@ -48,7 +48,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Regenerate lockfiles
-        run: ./gradlew dependencies --write-locks
+        run: ./gradlew :app:dependencies :shared:dependencies :composeApp:dependencies --write-locks
 
       - name: Commit and push updated lockfiles
         run: |


### PR DESCRIPTION
## Summary

- Fixes lockfile regeneration in CI and lockfile-update workflows to resolve all three modules (`:app`, `:shared`, `:composeApp`) instead of just the root project
- The root `./gradlew dependencies --write-locks` only resolves root-level configurations, missing module-specific ones like `:app:debugRuntimeClasspath` that enforce locked versions
- Also uses `github.event.pull_request.user.login` instead of `github.actor` for Dependabot detection (#421 fix included)

## Context

Follow-up to #420 and #421. The lockfile step was running but not regenerating the per-module lockfiles, so builds still failed with "Cannot find a version that satisfies the version constraints" because the module lockfiles enforced old versions.

## Test plan

- [ ] After merge, update Dependabot PR #397 branch — CI should pass with the lockfile step resolving all modules

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>