### PR TITLE
fix: Session 1 architecture hygiene (#433, #432, #434, #435)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Three separate Ktor API service interfaces: `AapApiService` (Controller), `EdaAp
 
 - **shared module (`shared/`):** KMP library -- platform abstractions (`platform/`), networking (Ktor `network/`), data layer (repositories, DataStore, encryption), AI tools and engine. Source sets: `commonMain`, `androidMain`, `jvmMain` (Desktop).
 - **composeApp module (`composeApp/`):** Compose Multiplatform UI -- navigation, screens (Dashboard, Templates, Activity, Infrastructure, EDA, Chat), themes, components. Source sets: `commonMain`, `androidMain`, `desktopMain`.
-- **app module (`app/`):** Android-only -- `MainActivity`, AI assistant (`assistant/` package with LLM providers, tool execution), Settings screens (General/Instances/Agent/Tools), Koin DI wiring. Depends on `:shared` and `:composeApp`.
+- **app module (`app/`):** Android shell -- `MainActivity`, notification channels, WorkManager (`ApprovalPollingWorker`), deep links, and Android Koin platform wiring. Depends on `:shared` and `:composeApp`. UI/settings live in `composeApp/`.
 
 ### Where to Put New Code (Android-first, Desktop stretch goal)
 
@@ -75,7 +75,7 @@ Rules:
 - **Network Layer:** Ktor `HttpClient` with engine abstraction (`HttpEngine` expect/actual), auth interceptor, self-signed cert support via `TlsTrustManager`. Instance discovery via `InstanceDiscovery` detects platform type (AAP/AWX/Jewel) and component versions.
 - **Data Layer:** `TokenManager` (DataStore + cryptography-kotlin encryption), repositories with `IRepository` interfaces in shared, `AssistantRepository` for LLM config persistence.
 - **Presentation:** ViewModels with `StateFlow<UiState>` (Idle, Loading, Success, Error pattern) in `composeApp`.
-- **Platform abstractions (`shared/.../platform/`):** `expect`/`actual` classes for `SecureKeyStorage`, `DataStoreFactory`, `ConnectivityObserver`, `BackgroundWorker`, `PlatformUtils`, `NotificationManager`, `TlsTrustManager`, `HttpEngine`.
+- **Platform abstractions (`shared/.../platform/`):** `expect`/`actual` classes for `SecureKeyStorage`, `DataStoreFactory`, `ConnectivityObserver`, `BackgroundWorker`, `PlatformUtils`, `NotificationManager`, `TlsTrustManager`, `HttpEngine`. Approval polling via `BackgroundWorker` is Android-only (WorkManager in `app/`); the desktop `actual` is an intentional no-op stub.
 
 ## Kotlin Architecture Contracts
 
@@ -91,16 +91,24 @@ When reviewing PRs, load the `skills/pr-architecture-review/SKILL.md` skill to c
 
 ## AI Assistant Architecture
 
-The AI assistant (`assistant/` package in `app/` module, Android-only for now) provides natural-language interaction with AAP via tool-use LLMs. The engine, LLM providers, and tools have zero Android dependencies and are planned to move to `shared/commonMain` (#243). Full pipeline flow with component responsibilities is documented in `docs/reference/tool-pipeline-architecture.md`.
+The AI assistant provides natural-language interaction with AAP via tool-use LLMs. Module placement after #243:
+
+| Concern | Module | Package |
+|---------|--------|---------|
+| Engine, LLM providers, tools, DI | `shared/` | `assistant/engine`, `assistant/llm`, `assistant/tools`, `assistant/di` |
+| UI + ViewModels | `composeApp/` | `assistant/ui`, `assistant/presentation` |
+| Android shell only | `app/` | notifications, WorkManager approval polling, deep links |
+
+Full pipeline flow with component responsibilities is documented in `docs/reference/tool-pipeline-architecture.md`.
 
 ### Tool System
 
 Two tool sources, unified via `Tool` interface (`shared/.../tools/ToolSpec.kt`):
 
-- **Local tools** (`tools/local/`) — 61 tools that call AAP APIs directly via Ktor. Zero latency, no MCP server required. Covers jobs, inventories, hosts, projects, credentials, EDA, schedules, workflow approvals, platform config, and more. Examples: `list_job_templates`, `launch_job`, `get_host_facts`, `approve_workflow`, `list_platform_services`, `ping`.
-- **MCP tools** (`tools/McpTool.kt`) — dynamically discovered from connected MCP servers. Each `McpTool` carries an optional `toolset` field for category-based routing. `McpServerConfig` supports per-toolset endpoints (e.g., `/job_management/mcp`) to reduce tool count per connection.
+- **Local tools** (`shared/.../tools/local/`) — 61 tools that call AAP APIs directly via Ktor. Zero latency, no MCP server required. Covers jobs, inventories, hosts, projects, credentials, EDA, schedules, workflow approvals, platform config, and more. Examples: `list_job_templates`, `launch_job`, `get_host_facts`, `approve_workflow`, `list_platform_services`, `ping`.
+- **MCP tools** (`shared/.../tools/McpTool.kt`) — dynamically discovered from connected MCP servers. Each `McpTool` carries an optional `toolset` field for category-based routing. `McpServerConfig` supports per-toolset endpoints (e.g., `/job_management/mcp`) to reduce tool count per connection.
 
-### ToolRouter (`app/.../engine/ToolRouter.kt`)
+### ToolRouter (`shared/.../engine/ToolRouter.kt`)
 
 Category-based query routing that selects relevant tools per user message:
 
@@ -112,7 +120,7 @@ Category-based query routing that selects relevant tools per user message:
 - **Read-only enforcement**: `McpServerConfig.readOnly` filters out write actions (`_create`, `_update`, `_delete`, `_launch`, etc.) from read-only MCP servers.
 - **Per-tool enable/disable**: `setToolEnabled()` / `isToolEnabled()` for user-facing tool management UI.
 
-### Engine Pipeline (`app/.../engine/`)
+### Engine Pipeline (`shared/.../engine/`)
 
 - **ChatEngine** — agentic loop: sends user message + tool schemas to LLM, executes tool calls, re-sends results until LLM produces a text response. Max 10 iterations.
 - **ToolExecutor** — executes tool calls with 30s timeout, 2-minute result cache, array capping (max 10 items), and smart truncation (8K char limit).

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/PresentationModule.kt
@@ -8,9 +8,11 @@ import io.github.leogallego.ansiblejane.presentation.settings.BackupViewModel
 import io.github.leogallego.ansiblejane.presentation.jobs.JobStatusViewModel
 import io.github.leogallego.ansiblejane.presentation.jobs.RecentJobsViewModel
 import io.github.leogallego.ansiblejane.presentation.eda.EdaAuditViewModel
+import io.github.leogallego.ansiblejane.presentation.hosts.HostDetailViewModel
 import io.github.leogallego.ansiblejane.presentation.hosts.HostsViewModel
 import io.github.leogallego.ansiblejane.presentation.hosts.InventoryHostsViewModel
 import io.github.leogallego.ansiblejane.presentation.inventory.InventoriesViewModel
+import io.github.leogallego.ansiblejane.presentation.main.MainViewModel
 import io.github.leogallego.ansiblejane.presentation.schedules.SchedulesViewModel
 import io.github.leogallego.ansiblejane.presentation.templates.TemplatesViewModel
 import io.github.leogallego.ansiblejane.presentation.workflows.WorkflowJobStatusViewModel
@@ -40,6 +42,13 @@ val presentationModule = module {
     viewModelOf(::InventoriesViewModel)
     viewModelOf(::InventoryHostsViewModel)
     viewModelOf(::HostsViewModel)
+    viewModel { params ->
+        HostDetailViewModel(
+            hostId = params.get(),
+            hostRepository = get(),
+        )
+    }
+    viewModelOf(::MainViewModel)
     viewModelOf(::BackupViewModel)
     viewModel {
         AssistantViewModel(

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostDetailViewModel.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.github.leogallego.ansiblejane.data.IHostRepository
 import io.github.leogallego.ansiblejane.model.JobHostSummary
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -32,11 +35,14 @@ class HostDetailViewModel(
     private val _uiState = MutableStateFlow<HostDetailUiState>(HostDetailUiState.Success())
     val uiState: StateFlow<HostDetailUiState> = _uiState.asStateFlow()
 
+    private var loadJob: Job? = null
+
     init {
         load()
     }
 
     fun load() {
+        loadJob?.cancel()
         if (hostId <= 0) {
             _uiState.update {
                 HostDetailUiState.Success(
@@ -47,36 +53,33 @@ class HostDetailViewModel(
             return
         }
         _uiState.update { HostDetailUiState.Success() }
-        viewModelScope.launch {
-            hostRepository.getHostFacts(hostId).fold(
-                onSuccess = { facts ->
-                    _uiState.update { state ->
-                        val success = state as? HostDetailUiState.Success ?: HostDetailUiState.Success()
-                        success.copy(factsLoading = false, facts = facts)
-                    }
-                },
-                onFailure = {
-                    _uiState.update { state ->
-                        val success = state as? HostDetailUiState.Success ?: HostDetailUiState.Success()
-                        success.copy(factsLoading = false, facts = emptyMap())
-                    }
+        loadJob = viewModelScope.launch {
+            coroutineScope {
+                val factsDeferred = async {
+                    hostRepository.getHostFacts(hostId).fold(
+                        onSuccess = { it },
+                        onFailure = { emptyMap() },
+                    )
                 }
-            )
+                val jobsDeferred = async {
+                    hostRepository.getHostJobSummaries(hostId).fold(
+                        onSuccess = { it.summaries },
+                        onFailure = { emptyList() },
+                    )
+                }
 
-            hostRepository.getHostJobSummaries(hostId).fold(
-                onSuccess = { result ->
-                    _uiState.update { state ->
-                        val success = state as? HostDetailUiState.Success ?: HostDetailUiState.Success()
-                        success.copy(jobsLoading = false, jobSummaries = result.summaries)
-                    }
-                },
-                onFailure = {
-                    _uiState.update { state ->
-                        val success = state as? HostDetailUiState.Success ?: HostDetailUiState.Success()
-                        success.copy(jobsLoading = false, jobSummaries = emptyList())
-                    }
+                val facts = factsDeferred.await()
+                _uiState.update { state ->
+                    val success = state as HostDetailUiState.Success
+                    success.copy(factsLoading = false, facts = facts)
                 }
-            )
+
+                val jobSummaries = jobsDeferred.await()
+                _uiState.update { state ->
+                    val success = state as HostDetailUiState.Success
+                    success.copy(jobsLoading = false, jobSummaries = jobSummaries)
+                }
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostDetailViewModel.kt
@@ -1,0 +1,86 @@
+package io.github.leogallego.ansiblejane.presentation.hosts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.github.leogallego.ansiblejane.data.IHostRepository
+import io.github.leogallego.ansiblejane.model.JobHostSummary
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonElement
+
+sealed interface HostDetailUiState {
+    /**
+     * Detail content with independent section loading flags.
+     * Repository failures surface as empty sections (same UX as the former UI-layer fetch).
+     */
+    data class Content(
+        val factsLoading: Boolean = true,
+        val facts: Map<String, JsonElement> = emptyMap(),
+        val jobsLoading: Boolean = true,
+        val jobSummaries: List<JobHostSummary> = emptyList(),
+    ) : HostDetailUiState
+}
+
+class HostDetailViewModel(
+    private val hostId: Int,
+    private val hostRepository: IHostRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<HostDetailUiState>(HostDetailUiState.Content())
+    val uiState: StateFlow<HostDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        if (hostId <= 0) {
+            _uiState.update {
+                HostDetailUiState.Content(
+                    factsLoading = false,
+                    jobsLoading = false,
+                )
+            }
+            return
+        }
+        _uiState.update { HostDetailUiState.Content() }
+        viewModelScope.launch {
+            hostRepository.getHostFacts(hostId).fold(
+                onSuccess = { facts ->
+                    _uiState.update { state ->
+                        val content = state as? HostDetailUiState.Content ?: HostDetailUiState.Content()
+                        content.copy(factsLoading = false, facts = facts)
+                    }
+                },
+                onFailure = {
+                    _uiState.update { state ->
+                        val content = state as? HostDetailUiState.Content ?: HostDetailUiState.Content()
+                        content.copy(factsLoading = false, facts = emptyMap())
+                    }
+                }
+            )
+
+            hostRepository.getHostJobSummaries(hostId).fold(
+                onSuccess = { result ->
+                    _uiState.update { state ->
+                        val content = state as? HostDetailUiState.Content ?: HostDetailUiState.Content()
+                        content.copy(jobsLoading = false, jobSummaries = result.summaries)
+                    }
+                },
+                onFailure = {
+                    _uiState.update { state ->
+                        val content = state as? HostDetailUiState.Content ?: HostDetailUiState.Content()
+                        content.copy(jobsLoading = false, jobSummaries = emptyList())
+                    }
+                }
+            )
+        }
+    }
+
+    fun retry() {
+        load()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostDetailViewModel.kt
@@ -16,7 +16,7 @@ sealed interface HostDetailUiState {
      * Detail content with independent section loading flags.
      * Repository failures surface as empty sections (same UX as the former UI-layer fetch).
      */
-    data class Content(
+    data class Success(
         val factsLoading: Boolean = true,
         val facts: Map<String, JsonElement> = emptyMap(),
         val jobsLoading: Boolean = true,
@@ -29,7 +29,7 @@ class HostDetailViewModel(
     private val hostRepository: IHostRepository,
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow<HostDetailUiState>(HostDetailUiState.Content())
+    private val _uiState = MutableStateFlow<HostDetailUiState>(HostDetailUiState.Success())
     val uiState: StateFlow<HostDetailUiState> = _uiState.asStateFlow()
 
     init {
@@ -39,26 +39,26 @@ class HostDetailViewModel(
     fun load() {
         if (hostId <= 0) {
             _uiState.update {
-                HostDetailUiState.Content(
+                HostDetailUiState.Success(
                     factsLoading = false,
                     jobsLoading = false,
                 )
             }
             return
         }
-        _uiState.update { HostDetailUiState.Content() }
+        _uiState.update { HostDetailUiState.Success() }
         viewModelScope.launch {
             hostRepository.getHostFacts(hostId).fold(
                 onSuccess = { facts ->
                     _uiState.update { state ->
-                        val content = state as? HostDetailUiState.Content ?: HostDetailUiState.Content()
-                        content.copy(factsLoading = false, facts = facts)
+                        val success = state as? HostDetailUiState.Success ?: HostDetailUiState.Success()
+                        success.copy(factsLoading = false, facts = facts)
                     }
                 },
                 onFailure = {
                     _uiState.update { state ->
-                        val content = state as? HostDetailUiState.Content ?: HostDetailUiState.Content()
-                        content.copy(factsLoading = false, facts = emptyMap())
+                        val success = state as? HostDetailUiState.Success ?: HostDetailUiState.Success()
+                        success.copy(factsLoading = false, facts = emptyMap())
                     }
                 }
             )
@@ -66,14 +66,14 @@ class HostDetailViewModel(
             hostRepository.getHostJobSummaries(hostId).fold(
                 onSuccess = { result ->
                     _uiState.update { state ->
-                        val content = state as? HostDetailUiState.Content ?: HostDetailUiState.Content()
-                        content.copy(jobsLoading = false, jobSummaries = result.summaries)
+                        val success = state as? HostDetailUiState.Success ?: HostDetailUiState.Success()
+                        success.copy(jobsLoading = false, jobSummaries = result.summaries)
                     }
                 },
                 onFailure = {
                     _uiState.update { state ->
-                        val content = state as? HostDetailUiState.Content ?: HostDetailUiState.Content()
-                        content.copy(jobsLoading = false, jobSummaries = emptyList())
+                        val success = state as? HostDetailUiState.Success ?: HostDetailUiState.Success()
+                        success.copy(jobsLoading = false, jobSummaries = emptyList())
                     }
                 }
             )

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/main/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/main/MainViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.github.leogallego.ansiblejane.assistant.data.IAssistantRepository
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
+import io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapInstance
 import kotlinx.coroutines.flow.SharingStarted
@@ -12,12 +13,17 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
+/**
+ * Always-ready shell/top-bar state (no Idle/Loading/Error lifecycle).
+ * Config types live in assistant.data as shared domain models.
+ */
 data class MainUiState(
     val activeInstance: AapInstance? = null,
     val activeConfig: LlmProviderConfig? = null,
     val savedConfigs: Map<String, LlmProviderConfig> = emptyMap(),
     val activeProviderKey: String? = null,
     val sessionTokens: Int = 0,
+    val sessionTokensFormatted: String = "0",
 )
 
 class MainViewModel(
@@ -38,6 +44,7 @@ class MainViewModel(
             savedConfigs = savedConfigs,
             activeProviderKey = activeProviderKey,
             sessionTokens = sessionTokens,
+            sessionTokensFormatted = TokenUsage.formatTokenCount(sessionTokens),
         )
     }.stateIn(
         scope = viewModelScope,

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/main/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/main/MainViewModel.kt
@@ -1,0 +1,57 @@
+package io.github.leogallego.ansiblejane.presentation.main
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.github.leogallego.ansiblejane.assistant.data.IAssistantRepository
+import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
+import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.model.AapInstance
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+data class MainUiState(
+    val activeInstance: AapInstance? = null,
+    val activeConfig: LlmProviderConfig? = null,
+    val savedConfigs: Map<String, LlmProviderConfig> = emptyMap(),
+    val activeProviderKey: String? = null,
+    val sessionTokens: Int = 0,
+)
+
+class MainViewModel(
+    tokenManager: ITokenManager,
+    private val assistantRepository: IAssistantRepository,
+) : ViewModel() {
+
+    val uiState: StateFlow<MainUiState> = combine(
+        tokenManager.activeInstance,
+        assistantRepository.activeConfigFlow,
+        assistantRepository.savedConfigsFlow,
+        assistantRepository.activeProviderKeyFlow,
+        assistantRepository.sessionTokensFlow,
+    ) { activeInstance, activeConfig, savedConfigs, activeProviderKey, sessionTokens ->
+        MainUiState(
+            activeInstance = activeInstance,
+            activeConfig = activeConfig,
+            savedConfigs = savedConfigs,
+            activeProviderKey = activeProviderKey,
+            sessionTokens = sessionTokens,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = MainUiState(activeInstance = tokenManager.activeInstance.value),
+    )
+
+    fun switchActiveProvider(key: String) {
+        viewModelScope.launch {
+            assistantRepository.switchActiveProvider(key)
+        }
+    }
+
+    fun clearHistory() {
+        assistantRepository.clearHistory()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/hosts/HostDetailSheet.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/hosts/HostDetailSheet.kt
@@ -36,7 +36,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,15 +47,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
-import io.github.leogallego.ansiblejane.data.IHostRepository
 import io.github.leogallego.ansiblejane.model.Host
 import io.github.leogallego.ansiblejane.model.JobHostSummary
+import io.github.leogallego.ansiblejane.presentation.hosts.HostDetailUiState
+import io.github.leogallego.ansiblejane.presentation.hosts.HostDetailViewModel
 import io.github.leogallego.ansiblejane.ui.components.DetailRow
 import io.github.leogallego.ansiblejane.ui.components.DetailSheetHeader
-import kotlinx.serialization.json.JsonElement
 import org.jetbrains.compose.resources.stringResource
 import aapremotecontrol.composeapp.generated.resources.*
-import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.parameter.parametersOf
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -140,25 +141,16 @@ private fun HostDetailFullScreen(
     host: Host,
     onClose: () -> Unit
 ) {
-    val hostRepository: IHostRepository = koinInject()
-    var facts by remember { mutableStateOf<Map<String, JsonElement>?>(null) }
-    var factsLoading by remember { mutableStateOf(true) }
-    var jobSummaries by remember { mutableStateOf<List<JobHostSummary>>(emptyList()) }
-    var jobsLoading by remember { mutableStateOf(true) }
-
-    LaunchedEffect(host.id) {
-        hostRepository.getHostFacts(host.id).fold(
-            onSuccess = { facts = it },
-            onFailure = { facts = emptyMap() }
-        )
-        factsLoading = false
-
-        hostRepository.getHostJobSummaries(host.id).fold(
-            onSuccess = { jobSummaries = it.summaries },
-            onFailure = { jobSummaries = emptyList() }
-        )
-        jobsLoading = false
-    }
+    val viewModel: HostDetailViewModel = koinViewModel(
+        key = "host-detail-${host.id}",
+        parameters = { parametersOf(host.id) },
+    )
+    val uiState by viewModel.uiState.collectAsState()
+    val content = uiState as? HostDetailUiState.Content ?: HostDetailUiState.Content()
+    val facts = content.facts
+    val factsLoading = content.factsLoading
+    val jobSummaries = content.jobSummaries
+    val jobsLoading = content.jobsLoading
 
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
@@ -251,7 +243,7 @@ private fun HostDetailFullScreen(
                     }
                 }
             } else {
-                val factEntries = facts?.entries?.toList().orEmpty()
+                val factEntries = facts.entries.toList()
                 if (factEntries.isEmpty()) {
                     item {
                         Text(

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/hosts/HostDetailSheet.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/hosts/HostDetailSheet.kt
@@ -146,7 +146,7 @@ private fun HostDetailFullScreen(
         parameters = { parametersOf(host.id) },
     )
     val uiState by viewModel.uiState.collectAsState()
-    val content = uiState as? HostDetailUiState.Content ?: HostDetailUiState.Content()
+    val content = uiState as? HostDetailUiState.Success ?: HostDetailUiState.Success()
     val facts = content.facts
     val factsLoading = content.factsLoading
     val jobSummaries = content.jobSummaries

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
@@ -53,7 +53,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -65,18 +64,15 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.collectAsState
-import io.github.leogallego.ansiblejane.assistant.data.IAssistantRepository
 import io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
 import io.github.leogallego.ansiblejane.assistant.data.KnownProvider
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
-import io.github.leogallego.ansiblejane.data.ITokenManager
+import io.github.leogallego.ansiblejane.presentation.main.MainViewModel
 import io.github.leogallego.ansiblejane.presentation.notifications.NotificationsViewModel
 import io.github.leogallego.ansiblejane.presentation.settings.SettingsTab
 import io.github.leogallego.ansiblejane.ui.notifications.NotificationsSheet
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import aapremotecontrol.composeapp.generated.resources.*
-import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -86,13 +82,13 @@ fun MainScreen(
     onNavigateToApproval: (Int) -> Unit = {},
     content: @Composable (TopLevelTab, Segment) -> Unit
 ) {
-    val tokenManager: ITokenManager = koinInject()
-    val assistantRepository: IAssistantRepository = koinInject()
-    val activeInstance by tokenManager.activeInstance.collectAsState()
-    val activeConfig by assistantRepository.activeConfigFlow.collectAsState(null)
-    val savedConfigs by assistantRepository.savedConfigsFlow.collectAsState(emptyMap())
-    val activeProviderKey by assistantRepository.activeProviderKeyFlow.collectAsState(null)
-    val sessionTokens by assistantRepository.sessionTokensFlow.collectAsState()
+    val mainViewModel: MainViewModel = koinViewModel()
+    val mainUiState by mainViewModel.uiState.collectAsState()
+    val activeInstance = mainUiState.activeInstance
+    val activeConfig = mainUiState.activeConfig
+    val savedConfigs = mainUiState.savedConfigs
+    val activeProviderKey = mainUiState.activeProviderKey
+    val sessionTokens = mainUiState.sessionTokens
 
     val tabs = TopLevelTab.entries
     val dashboardTabIndex = tabs.indexOfFirst { it is TopLevelTab.Dashboard }.coerceAtLeast(0)
@@ -111,7 +107,6 @@ fun MainScreen(
     var showNotificationsSheet by remember { mutableStateOf(false) }
 
     val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
     var showClearChatConfirm by remember { mutableStateOf(false) }
     var showProviderMenu by remember(selectedTabIndex) { mutableStateOf(false) }
 
@@ -123,7 +118,7 @@ fun MainScreen(
             confirmButton = {
                 TextButton(onClick = {
                     showClearChatConfirm = false
-                    assistantRepository.clearHistory()
+                    mainViewModel.clearHistory()
                 }) { Text(stringResource(Res.string.btn_clear)) }
             },
             dismissButton = {
@@ -199,9 +194,7 @@ fun MainScreen(
                                 sessionTokens = sessionTokens,
                                 onSwitchProvider = { key ->
                                     showProviderMenu = false
-                                    scope.launch {
-                                        assistantRepository.switchActiveProvider(key)
-                                    }
+                                    mainViewModel.switchActiveProvider(key)
                                 },
                                 onNavigateToSettings = {
                                     showProviderMenu = false

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
@@ -64,7 +64,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.collectAsState
-import io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
 import io.github.leogallego.ansiblejane.assistant.data.KnownProvider
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.presentation.main.MainViewModel
@@ -89,6 +88,7 @@ fun MainScreen(
     val savedConfigs = mainUiState.savedConfigs
     val activeProviderKey = mainUiState.activeProviderKey
     val sessionTokens = mainUiState.sessionTokens
+    val sessionTokensFormatted = mainUiState.sessionTokensFormatted
 
     val tabs = TopLevelTab.entries
     val dashboardTabIndex = tabs.indexOfFirst { it is TopLevelTab.Dashboard }.coerceAtLeast(0)
@@ -192,6 +192,7 @@ fun MainScreen(
                                 activeProviderKey = activeProviderKey,
                                 savedConfigs = savedConfigs,
                                 sessionTokens = sessionTokens,
+                                sessionTokensFormatted = sessionTokensFormatted,
                                 onSwitchProvider = { key ->
                                     showProviderMenu = false
                                     mainViewModel.switchActiveProvider(key)
@@ -332,6 +333,7 @@ private fun ProviderDropdownMenu(
     activeProviderKey: String?,
     savedConfigs: Map<String, LlmProviderConfig>,
     sessionTokens: Int,
+    sessionTokensFormatted: String,
     onSwitchProvider: (String) -> Unit,
     onNavigateToSettings: () -> Unit
 ) {
@@ -345,10 +347,9 @@ private fun ProviderDropdownMenu(
         shape = RoundedCornerShape(16.dp)
     ) {
         if (sessionTokens > 0) {
-            val formatted = TokenUsage.formatTokenCount(sessionTokens)
             val tokensCd = stringResource(Res.string.provider_tokens_session_cd, sessionTokens)
             Text(
-                text = stringResource(Res.string.provider_tokens, formatted),
+                text = stringResource(Res.string.provider_tokens, sessionTokensFormatted),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModelTest.kt
@@ -1,0 +1,164 @@
+package io.github.leogallego.ansiblejane.assistant.presentation
+
+import app.cash.turbine.test
+import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
+import io.github.leogallego.ansiblejane.assistant.data.TokenSavingMode
+import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
+import io.github.leogallego.ansiblejane.assistant.engine.Role
+import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
+import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.fakes.FakeAssistantRepository
+import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
+import io.github.leogallego.ansiblejane.fakes.FakeToolManifestRepository
+import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
+import io.github.leogallego.ansiblejane.setupMainDispatcher
+import io.github.leogallego.ansiblejane.tearDownMainDispatcher
+import io.github.leogallego.ansiblejane.testInstance
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AssistantViewModelTest {
+
+    private lateinit var fakeAssistantRepo: FakeAssistantRepository
+    private lateinit var fakeTokenManager: FakeTokenManager
+    private lateinit var mcpServerManager: McpServerManager
+
+    @BeforeTest
+    fun setup() {
+        setupMainDispatcher()
+        fakeAssistantRepo = FakeAssistantRepository()
+        fakeTokenManager = FakeTokenManager()
+        mcpServerManager = McpServerManager(
+            ktorClientFactory = { _, _ ->
+                HttpClient(MockEngine) { engine { addHandler { respond("") } } }
+            }
+        )
+    }
+
+    @AfterTest
+    fun cleanup() {
+        tearDownMainDispatcher()
+    }
+
+    private fun fakeLocalTool(name: String) = object : LocalTool {
+        override val spec = ToolSpec(name, "Description of $name", JsonObject(emptyMap()))
+        override val isDestructive = false
+        override suspend fun execute(args: JsonObject) = ToolResult(success = true)
+    }
+
+    private fun createViewModel(localTools: List<LocalTool> = emptyList()) = AssistantViewModel(
+        mcpServerManager = mcpServerManager,
+        repository = fakeAssistantRepo,
+        tokenManager = fakeTokenManager,
+        manifestRepository = FakeToolManifestRepository(),
+        toolRouter = ToolRouter(initialLocalTools = localTools, repository = fakeAssistantRepo),
+        localTools = localTools,
+    )
+
+    @Test
+    fun `init with no active instance emits Idle`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            assertEquals(AssistantUiState.Idle, awaitItem())
+        }
+    }
+
+    @Test
+    fun `init with active instance emits Active`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is AssistantUiState.Active)
+            assertTrue((state as AssistantUiState.Active).messages.isEmpty())
+        }
+    }
+
+    @Test
+    fun `sendMessage without LLM config adds guidance`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.sendMessage("list hosts")
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is AssistantUiState.Active)
+            val messages = (state as AssistantUiState.Active).messages
+            assertEquals(1, messages.size)
+            assertEquals(Role.ASSISTANT, messages[0].role)
+            assertTrue(messages[0].content.contains("configure an LLM provider"))
+        }
+    }
+
+    @Test
+    fun `TOOLS_ONLY general query short-circuits without tool execution`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        fakeAssistantRepo.saveLlmConfig(
+            LlmProviderConfig.OpenAiCompatible(
+                url = "https://api.openai.com/v1",
+                model = "gpt-4o",
+                apiKey = "sk-test",
+                tokenSavingMode = TokenSavingMode.TOOLS_ONLY,
+            )
+        )
+
+        val viewModel = createViewModel(localTools = listOf(fakeLocalTool("list_hosts")))
+        advanceUntilIdle()
+
+        viewModel.sendMessage("hello")
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is AssistantUiState.Active)
+            val active = state as AssistantUiState.Active
+            assertFalse(active.isGenerating)
+            assertTrue(active.messages.any { it.role == Role.USER && it.content == "hello" })
+            assertTrue(
+                active.messages.any {
+                    it.role == Role.ASSISTANT && it.content.contains("query your AAP instance")
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `clearHistory clears messages in Active state`() = runTest {
+        fakeTokenManager.setInstances(listOf(testInstance))
+        fakeAssistantRepo.addMessage(ChatMessage(role = Role.USER, content = "hi"))
+        fakeAssistantRepo.addMessage(ChatMessage(role = Role.ASSISTANT, content = "hello"))
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.clearHistory()
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is AssistantUiState.Active)
+            assertTrue((state as AssistantUiState.Active).messages.isEmpty())
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeProjectRepository.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeProjectRepository.kt
@@ -1,0 +1,42 @@
+package io.github.leogallego.ansiblejane.fakes
+
+import io.github.leogallego.ansiblejane.data.ExecutionEnvironmentListResult
+import io.github.leogallego.ansiblejane.data.IProjectRepository
+import io.github.leogallego.ansiblejane.data.ProjectListResult
+import io.github.leogallego.ansiblejane.model.Project
+
+class FakeProjectRepository : IProjectRepository {
+    var projects = listOf<Project>()
+    var projectCount: Int? = null
+    var shouldFail = false
+    var failureException: Exception = RuntimeException("Test error")
+
+    override suspend fun getProjects(
+        page: Int,
+        pageSize: Int,
+        search: String?,
+    ): Result<ProjectListResult> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(
+            ProjectListResult(
+                projects = projects,
+                hasMore = false,
+                totalCount = projectCount ?: projects.size,
+            )
+        )
+    }
+
+    override suspend fun getProject(id: Int): Result<Project> {
+        if (shouldFail) return Result.failure(failureException)
+        return projects.find { it.id == id }?.let { Result.success(it) }
+            ?: Result.failure(RuntimeException("Not found"))
+    }
+
+    override suspend fun getExecutionEnvironments(
+        page: Int,
+        pageSize: Int,
+    ): Result<ExecutionEnvironmentListResult> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(ExecutionEnvironmentListResult(emptyList(), hasMore = false, totalCount = 0))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/dashboard/DashboardViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/dashboard/DashboardViewModelTest.kt
@@ -1,0 +1,123 @@
+package io.github.leogallego.ansiblejane.presentation.dashboard
+
+import app.cash.turbine.test
+import io.github.leogallego.ansiblejane.TestData
+import io.github.leogallego.ansiblejane.fakes.FakeAapApiProvider
+import io.github.leogallego.ansiblejane.fakes.FakeHostRepository
+import io.github.leogallego.ansiblejane.fakes.FakeInventoryRepository
+import io.github.leogallego.ansiblejane.fakes.FakeJobRepository
+import io.github.leogallego.ansiblejane.fakes.FakeProjectRepository
+import io.github.leogallego.ansiblejane.fakes.FakeScheduleRepository
+import io.github.leogallego.ansiblejane.fakes.FakeTemplateRepository
+import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
+import io.github.leogallego.ansiblejane.model.AppError
+import io.github.leogallego.ansiblejane.model.JobTemplate
+import io.github.leogallego.ansiblejane.setupMainDispatcher
+import io.github.leogallego.ansiblejane.tearDownMainDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DashboardViewModelTest {
+
+    private lateinit var fakeJobRepo: FakeJobRepository
+    private lateinit var fakeTemplateRepo: FakeTemplateRepository
+    private lateinit var fakeInventoryRepo: FakeInventoryRepository
+    private lateinit var fakeHostRepo: FakeHostRepository
+    private lateinit var fakeProjectRepo: FakeProjectRepository
+    private lateinit var fakeScheduleRepo: FakeScheduleRepository
+    private lateinit var fakeApiProvider: FakeAapApiProvider
+    private lateinit var fakeTokenManager: FakeTokenManager
+
+    @BeforeTest
+    fun setup() {
+        setupMainDispatcher()
+        fakeJobRepo = FakeJobRepository()
+        fakeTemplateRepo = FakeTemplateRepository()
+        fakeInventoryRepo = FakeInventoryRepository()
+        fakeHostRepo = FakeHostRepository()
+        fakeProjectRepo = FakeProjectRepository()
+        fakeScheduleRepo = FakeScheduleRepository()
+        fakeApiProvider = FakeAapApiProvider()
+        fakeTokenManager = FakeTokenManager()
+    }
+
+    @AfterTest
+    fun cleanup() {
+        tearDownMainDispatcher()
+    }
+
+    private fun createViewModel() = DashboardViewModel(
+        jobRepository = fakeJobRepo,
+        templateRepository = fakeTemplateRepo,
+        inventoryRepository = fakeInventoryRepo,
+        hostRepository = fakeHostRepo,
+        projectRepository = fakeProjectRepo,
+        scheduleRepository = fakeScheduleRepo,
+        apiProvider = fakeApiProvider,
+        tokenManager = fakeTokenManager,
+    )
+
+    @Test
+    fun `loads dashboard success when instance is active`() = runTest {
+        fakeJobRepo.jobs = emptyList()
+        fakeInventoryRepo.inventories = TestData.sampleInventories
+        fakeHostRepo.hosts = TestData.sampleHosts
+        fakeTemplateRepo.templates = listOf(JobTemplate(id = 1, name = "Deploy"))
+        fakeProjectRepo.projectCount = 2
+        fakeScheduleRepo.schedules = listOf(
+            TestData.createSchedule(1).copy(nextRun = "2026-08-06T00:00:00Z"),
+        )
+        fakeTokenManager.setInstances(listOf(TestData.testInstance.copy(alias = "Prod")))
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is DashboardUiState.Success)
+            val success = state as DashboardUiState.Success
+            assertEquals(HealthStatus.GREEN, success.healthStatus)
+            assertEquals(3, success.inventoryCount)
+            assertEquals(3, success.hostCount)
+            assertEquals(1, success.templateCount)
+            assertEquals(2, success.projectCount)
+            assertNull(success.edaActivationsCount)
+            assertEquals(1, success.upcomingSchedules.size)
+            assertEquals("Prod", success.instanceAlias)
+        }
+    }
+
+    @Test
+    fun `job repository failure yields error state`() = runTest {
+        fakeJobRepo.shouldFail = true
+        fakeJobRepo.failureException = RuntimeException("Connection refused")
+        fakeTokenManager.setInstances(listOf(TestData.testInstance))
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is DashboardUiState.Error)
+            assertTrue((state as DashboardUiState.Error).error is AppError.Unknown)
+        }
+    }
+
+    @Test
+    fun `stays loading when no active instance`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            assertEquals(DashboardUiState.Loading, awaitItem())
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostDetailViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostDetailViewModelTest.kt
@@ -1,0 +1,102 @@
+package io.github.leogallego.ansiblejane.presentation.hosts
+
+import app.cash.turbine.test
+import io.github.leogallego.ansiblejane.fakes.FakeHostRepository
+import io.github.leogallego.ansiblejane.model.JobHostSummary
+import io.github.leogallego.ansiblejane.model.JobHostSummaryFields
+import io.github.leogallego.ansiblejane.model.JobSummaryRef
+import io.github.leogallego.ansiblejane.setupMainDispatcher
+import io.github.leogallego.ansiblejane.tearDownMainDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HostDetailViewModelTest {
+
+    private lateinit var fakeRepo: FakeHostRepository
+
+    @BeforeTest
+    fun setup() {
+        setupMainDispatcher()
+        fakeRepo = FakeHostRepository()
+    }
+
+    @AfterTest
+    fun cleanup() {
+        tearDownMainDispatcher()
+    }
+
+    @Test
+    fun `loads facts and job summaries on init`() = runTest {
+        fakeRepo.hostFacts = mapOf("ansible_os" to JsonPrimitive("Linux"))
+        fakeRepo.jobSummaries = listOf(
+            JobHostSummary(
+                id = 10,
+                job = 100,
+                host = 1,
+                ok = 5,
+                created = "2026-01-01",
+                summaryFields = JobHostSummaryFields(
+                    job = JobSummaryRef(id = 100, name = "Deploy")
+                )
+            )
+        )
+
+        val viewModel = HostDetailViewModel(hostId = 1, hostRepository = fakeRepo)
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is HostDetailUiState.Content)
+            val content = state as HostDetailUiState.Content
+            assertFalse(content.factsLoading)
+            assertFalse(content.jobsLoading)
+            assertEquals("Linux", (content.facts["ansible_os"] as JsonPrimitive).content)
+            assertEquals(1, content.jobSummaries.size)
+            assertEquals("Deploy", content.jobSummaries[0].summaryFields.job?.name)
+        }
+    }
+
+    @Test
+    fun `repository failures yield empty sections`() = runTest {
+        fakeRepo.shouldFail = true
+
+        val viewModel = HostDetailViewModel(hostId = 1, hostRepository = fakeRepo)
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is HostDetailUiState.Content)
+            val content = state as HostDetailUiState.Content
+            assertFalse(content.factsLoading)
+            assertFalse(content.jobsLoading)
+            assertTrue(content.facts.isEmpty())
+            assertTrue(content.jobSummaries.isEmpty())
+        }
+    }
+
+    @Test
+    fun `invalid host id skips repository calls`() = runTest {
+        fakeRepo.hostFacts = mapOf("should_not_load" to JsonPrimitive("x"))
+
+        val viewModel = HostDetailViewModel(hostId = 0, hostRepository = fakeRepo)
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is HostDetailUiState.Content)
+            val content = state as HostDetailUiState.Content
+            assertFalse(content.factsLoading)
+            assertFalse(content.jobsLoading)
+            assertTrue(content.facts.isEmpty())
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostDetailViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/hosts/HostDetailViewModelTest.kt
@@ -55,8 +55,8 @@ class HostDetailViewModelTest {
 
         viewModel.uiState.test {
             val state = awaitItem()
-            assertTrue(state is HostDetailUiState.Content)
-            val content = state as HostDetailUiState.Content
+            assertTrue(state is HostDetailUiState.Success)
+            val content = state as HostDetailUiState.Success
             assertFalse(content.factsLoading)
             assertFalse(content.jobsLoading)
             assertEquals("Linux", (content.facts["ansible_os"] as JsonPrimitive).content)
@@ -74,8 +74,8 @@ class HostDetailViewModelTest {
 
         viewModel.uiState.test {
             val state = awaitItem()
-            assertTrue(state is HostDetailUiState.Content)
-            val content = state as HostDetailUiState.Content
+            assertTrue(state is HostDetailUiState.Success)
+            val content = state as HostDetailUiState.Success
             assertFalse(content.factsLoading)
             assertFalse(content.jobsLoading)
             assertTrue(content.facts.isEmpty())
@@ -92,8 +92,8 @@ class HostDetailViewModelTest {
 
         viewModel.uiState.test {
             val state = awaitItem()
-            assertTrue(state is HostDetailUiState.Content)
-            val content = state as HostDetailUiState.Content
+            assertTrue(state is HostDetailUiState.Success)
+            val content = state as HostDetailUiState.Success
             assertFalse(content.factsLoading)
             assertFalse(content.jobsLoading)
             assertTrue(content.facts.isEmpty())

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/main/MainViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/main/MainViewModelTest.kt
@@ -1,0 +1,105 @@
+package io.github.leogallego.ansiblejane.presentation.main
+
+import app.cash.turbine.test
+import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
+import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
+import io.github.leogallego.ansiblejane.assistant.engine.Role
+import io.github.leogallego.ansiblejane.fakes.FakeAssistantRepository
+import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
+import io.github.leogallego.ansiblejane.model.AapInstance
+import io.github.leogallego.ansiblejane.setupMainDispatcher
+import io.github.leogallego.ansiblejane.tearDownMainDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainViewModelTest {
+
+    private lateinit var fakeTokenManager: FakeTokenManager
+    private lateinit var fakeAssistantRepo: FakeAssistantRepository
+
+    private val instance = AapInstance(
+        id = "inst-1",
+        baseUrl = "https://aap.example.com",
+        token = "token-1",
+        alias = "Lab",
+    )
+
+    @BeforeTest
+    fun setup() {
+        setupMainDispatcher()
+        fakeTokenManager = FakeTokenManager()
+        fakeAssistantRepo = FakeAssistantRepository()
+    }
+
+    @AfterTest
+    fun cleanup() {
+        tearDownMainDispatcher()
+    }
+
+    private fun createViewModel() = MainViewModel(fakeTokenManager, fakeAssistantRepo)
+
+    @Test
+    fun `exposes active instance from token manager`() = runTest {
+        fakeTokenManager.setInstances(listOf(instance))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertEquals("Lab", state.activeInstance?.alias)
+            assertEquals("inst-1", state.activeInstance?.id)
+        }
+    }
+
+    @Test
+    fun `switchActiveProvider updates active provider key`() = runTest {
+        val config = LlmProviderConfig.OpenAiCompatible(
+            url = "https://api.openai.com/v1",
+            apiKey = "sk-test",
+            model = "gpt-4o",
+        )
+        fakeAssistantRepo.saveLlmConfig(config)
+        fakeAssistantRepo.saveAllLlmConfigs(mapOf("OPENAI" to config, "GEMINI" to config.copy(url = "https://generativelanguage.googleapis.com")))
+
+        val viewModel = createViewModel()
+        viewModel.switchActiveProvider("GEMINI")
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertEquals("GEMINI", state.activeProviderKey)
+        }
+    }
+
+    @Test
+    fun `clearHistory clears assistant history`() = runTest {
+        fakeAssistantRepo.addMessage(ChatMessage(role = Role.USER, content = "hello"))
+        assertTrue(fakeAssistantRepo.getHistory().isNotEmpty())
+
+        val viewModel = createViewModel()
+        viewModel.clearHistory()
+
+        assertTrue(fakeAssistantRepo.getHistory().isEmpty())
+        assertEquals(0, viewModel.uiState.value.sessionTokens)
+    }
+
+    @Test
+    fun `starts with null active instance when logged out`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertNull(state.activeInstance)
+            assertTrue(state.savedConfigs.isEmpty())
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/notifications/NotificationsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/notifications/NotificationsViewModelTest.kt
@@ -1,0 +1,84 @@
+package io.github.leogallego.ansiblejane.presentation.notifications
+
+import app.cash.turbine.test
+import io.github.leogallego.ansiblejane.fakes.FakeWorkflowRepository
+import io.github.leogallego.ansiblejane.model.WorkflowApproval
+import io.github.leogallego.ansiblejane.setupMainDispatcher
+import io.github.leogallego.ansiblejane.tearDownMainDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NotificationsViewModelTest {
+
+    private lateinit var fakeWorkflowRepo: FakeWorkflowRepository
+
+    @BeforeTest
+    fun setup() {
+        setupMainDispatcher()
+        fakeWorkflowRepo = FakeWorkflowRepository()
+    }
+
+    @AfterTest
+    fun cleanup() {
+        tearDownMainDispatcher()
+    }
+
+    @Test
+    fun `loads pending approvals on init`() = runTest {
+        fakeWorkflowRepo.approvals = listOf(
+            WorkflowApproval(id = 1, name = "Deploy to prod", status = "pending"),
+            WorkflowApproval(id = 2, name = "Scale web", status = "pending"),
+        )
+
+        val viewModel = NotificationsViewModel(fakeWorkflowRepo)
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertEquals(2, state.approvals.size)
+            assertEquals(2, state.pendingCount)
+            assertFalse(state.isLoading)
+            assertNull(state.error)
+        }
+    }
+
+    @Test
+    fun `empty approvals yield zero pending count`() = runTest {
+        fakeWorkflowRepo.approvals = emptyList()
+
+        val viewModel = NotificationsViewModel(fakeWorkflowRepo)
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state.approvals.isEmpty())
+            assertEquals(0, state.pendingCount)
+            assertFalse(state.isLoading)
+            assertNull(state.error)
+        }
+    }
+
+    @Test
+    fun `repository failure sets error message`() = runTest {
+        fakeWorkflowRepo.shouldFail = true
+        fakeWorkflowRepo.failureException = RuntimeException("Network error")
+
+        val viewModel = NotificationsViewModel(fakeWorkflowRepo)
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertFalse(state.isLoading)
+            assertEquals("Network error", state.error)
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowTemplateDetailViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/workflows/WorkflowTemplateDetailViewModelTest.kt
@@ -1,0 +1,134 @@
+package io.github.leogallego.ansiblejane.presentation.workflows
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import io.github.leogallego.ansiblejane.fakes.FakeWorkflowRepository
+import io.github.leogallego.ansiblejane.model.AppError
+import io.github.leogallego.ansiblejane.model.WorkflowJobTemplateNode
+import io.github.leogallego.ansiblejane.setupMainDispatcher
+import io.github.leogallego.ansiblejane.tearDownMainDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WorkflowTemplateDetailViewModelTest {
+
+    private lateinit var fakeWorkflowRepo: FakeWorkflowRepository
+
+    @BeforeTest
+    fun setup() {
+        setupMainDispatcher()
+        fakeWorkflowRepo = FakeWorkflowRepository()
+    }
+
+    @AfterTest
+    fun cleanup() {
+        tearDownMainDispatcher()
+    }
+
+    private fun createViewModel(
+        templateId: Int = 42,
+        templateName: String = "Full%20Deploy",
+    ): WorkflowTemplateDetailViewModel {
+        val savedStateHandle = SavedStateHandle(
+            mapOf(
+                "templateId" to templateId,
+                "templateName" to templateName,
+            )
+        )
+        return WorkflowTemplateDetailViewModel(savedStateHandle, fakeWorkflowRepo)
+    }
+
+    @Test
+    fun `loads template nodes on init`() = runTest {
+        fakeWorkflowRepo.templateNodes = listOf(
+            WorkflowJobTemplateNode(id = 1, identifier = "step-1"),
+            WorkflowJobTemplateNode(id = 2, identifier = "step-2"),
+        )
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertEquals("Full Deploy", viewModel.templateName)
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is WorkflowTemplateDetailUiState.Success)
+            val success = state as WorkflowTemplateDetailUiState.Success
+            assertEquals(2, success.nodes.size)
+            assertEquals("step-1", success.nodes[0].identifier)
+        }
+    }
+
+    @Test
+    fun `invalid template id yields error without repo success`() = runTest {
+        fakeWorkflowRepo.templateNodes = listOf(
+            WorkflowJobTemplateNode(id = 1, identifier = "should-not-load"),
+        )
+
+        val viewModel = createViewModel(templateId = -1)
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is WorkflowTemplateDetailUiState.Error)
+            val error = state as WorkflowTemplateDetailUiState.Error
+            assertTrue(error.error is AppError.Unknown)
+        }
+    }
+
+    @Test
+    fun `repository failure yields error state`() = runTest {
+        fakeWorkflowRepo.shouldFail = true
+        fakeWorkflowRepo.failureException = RuntimeException("Connection refused")
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is WorkflowTemplateDetailUiState.Error)
+        }
+    }
+
+    @Test
+    fun `launch emits Launched with workflow job id`() = runTest {
+        fakeWorkflowRepo.templateNodes = emptyList()
+        fakeWorkflowRepo.launchResult = 77
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.launch()
+        advanceUntilIdle()
+
+        viewModel.launchState.test {
+            val state = awaitItem()
+            assertTrue(state is LaunchFromDetailState.Launched)
+            assertEquals(77, (state as LaunchFromDetailState.Launched).workflowJobId)
+        }
+    }
+
+    @Test
+    fun `launch failure emits Failed`() = runTest {
+        fakeWorkflowRepo.templateNodes = emptyList()
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        fakeWorkflowRepo.shouldFail = true
+        fakeWorkflowRepo.failureException = RuntimeException("Launch denied")
+        viewModel.launch()
+        advanceUntilIdle()
+
+        viewModel.launchState.test {
+            val state = awaitItem()
+            assertTrue(state is LaunchFromDetailState.Failed)
+            assertEquals("Launch denied", (state as LaunchFromDetailState.Failed).message)
+        }
+    }
+}

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -130,6 +130,10 @@ for one-shot discovery of external endpoints would be over-engineering.
   features go in `app/` without ceremony.
 - **Shared logic must not live in `app/`.** If a tool, repository, or engine feature
   is in `app/`, desktop can never reach it. Use `shared/commonMain` for reusable logic.
+- **`BackgroundWorker` approval polling is Android-only.** Android schedules
+  `ApprovalPollingWorker` via WorkManager in `app/`. The JVM/`desktop` `actual` keeps
+  the `schedulePolling` / `cancelPolling` surface for expect/actual parity but is an
+  intentional no-op (no desktop polling parity planned).
 
 ### Source Set Rules
 

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -426,3 +426,4 @@ tombstones or "removed" markers.
 | 1.2.0 | 2026-06-21 | Add §10 Test Infrastructure contracts (#392) |
 | 1.2.1 | 2026-06-22 | Add lifecycle tags for transitional rules (#392) |
 | 1.3.0 | 2026-06-26 | Add §11 String Resources contract (#293) |
+| 1.3.1 | 2026-08-05 | Document Android-only BackgroundWorker approval polling (#433) |

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetConfigLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetConfigLocalTool.kt
@@ -3,10 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.EmptyArgs
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 
 class GetConfigLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<EmptyArgs>(
     typeToken<EmptyArgs>(), EmptyArgs.serializer(),
     "get_config", "Get AAP configuration including license info, version, and platform details"

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetSettingsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetSettingsLocalTool.kt
@@ -3,10 +3,10 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.EmptyArgs
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 
 class GetSettingsLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<EmptyArgs>(
     typeToken<EmptyArgs>(), EmptyArgs.serializer(),
     "get_settings", "Get AAP system settings categories and their endpoints"

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetSurveySpecLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/GetSurveySpecLocalTool.kt
@@ -3,13 +3,13 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import io.github.leogallego.ansiblejane.network.networkJson
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 
 class GetSurveySpecLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<GetSurveySpecLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     "get_survey_spec", "Get the survey specification for a job template (required variables and prompts)"

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListApplicationsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListApplicationsLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListApplicationsLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<ListApplicationsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_applications",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListAuthenticatorsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListAuthenticatorsLocalTool.kt
@@ -5,13 +5,13 @@ import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.data.IPlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListAuthenticatorsLocalTool(
-    private val repository: PlatformRepository,
+    private val repository: IPlatformRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListAuthenticatorsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListCredentialTypesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListCredentialTypesLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListCredentialTypesLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<ListCredentialTypesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_credential_types",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialTypesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialTypesLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IEdaReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListEdaCredentialTypesLocalTool(
-    private val repository: EdaReadOnlyRepository
+    private val repository: IEdaReadOnlyRepository
 ) : AapLocalTool<ListEdaCredentialTypesLocalTool.Args>(
     typeToken<Args>(),
     Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaCredentialsLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IEdaReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListEdaCredentialsLocalTool(
-    private val repository: EdaReadOnlyRepository
+    private val repository: IEdaReadOnlyRepository
 ) : AapLocalTool<ListEdaCredentialsLocalTool.Args>(
     typeToken<Args>(),
     Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaDecisionEnvironmentsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaDecisionEnvironmentsLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IEdaReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListEdaDecisionEnvironmentsLocalTool(
-    private val repository: EdaReadOnlyRepository
+    private val repository: IEdaReadOnlyRepository
 ) : AapLocalTool<ListEdaDecisionEnvironmentsLocalTool.Args>(
     typeToken<Args>(),
     Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaEventStreamsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaEventStreamsLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IEdaReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListEdaEventStreamsLocalTool(
-    private val repository: EdaReadOnlyRepository
+    private val repository: IEdaReadOnlyRepository
 ) : AapLocalTool<ListEdaEventStreamsLocalTool.Args>(
     typeToken<Args>(),
     Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaProjectsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaProjectsLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IEdaReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListEdaProjectsLocalTool(
-    private val repository: EdaReadOnlyRepository
+    private val repository: IEdaReadOnlyRepository
 ) : AapLocalTool<ListEdaProjectsLocalTool.Args>(
     typeToken<Args>(),
     Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaRulebooksLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaRulebooksLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IEdaReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListEdaRulebooksLocalTool(
-    private val repository: EdaReadOnlyRepository
+    private val repository: IEdaReadOnlyRepository
 ) : AapLocalTool<ListEdaRulebooksLocalTool.Args>(
     typeToken<Args>(),
     Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListEdaUsersLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.EdaReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IEdaReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListEdaUsersLocalTool(
-    private val repository: EdaReadOnlyRepository
+    private val repository: IEdaReadOnlyRepository
 ) : AapLocalTool<ListEdaUsersLocalTool.Args>(
     typeToken<Args>(),
     Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListGroupsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListGroupsLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListGroupsLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<ListGroupsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_groups",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubApprovalsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubApprovalsLocalTool.kt
@@ -4,14 +4,14 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.IHubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListHubApprovalsLocalTool(
-    private val repository: HubRepository,
+    private val repository: IHubRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubApprovalsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubCollectionsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubCollectionsLocalTool.kt
@@ -4,14 +4,14 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.IHubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListHubCollectionsLocalTool(
-    private val repository: HubRepository,
+    private val repository: IHubRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubCollectionsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRegistriesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRegistriesLocalTool.kt
@@ -4,14 +4,14 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.IHubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListHubEeRegistriesLocalTool(
-    private val repository: HubRepository,
+    private val repository: IHubRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubEeRegistriesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRepositoriesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubEeRepositoriesLocalTool.kt
@@ -4,14 +4,14 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.IHubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListHubEeRepositoriesLocalTool(
-    private val repository: HubRepository,
+    private val repository: IHubRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubEeRepositoriesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubGroupsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubGroupsLocalTool.kt
@@ -4,14 +4,14 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.IHubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListHubGroupsLocalTool(
-    private val repository: HubRepository,
+    private val repository: IHubRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubGroupsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubNamespacesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubNamespacesLocalTool.kt
@@ -4,14 +4,14 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.IHubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListHubNamespacesLocalTool(
-    private val repository: HubRepository,
+    private val repository: IHubRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubNamespacesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubRolesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubRolesLocalTool.kt
@@ -4,14 +4,14 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.IHubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListHubRolesLocalTool(
-    private val repository: HubRepository,
+    private val repository: IHubRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubRolesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListHubUsersLocalTool.kt
@@ -4,14 +4,14 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.HubRepository
+import io.github.leogallego.ansiblejane.data.IHubRepository
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListHubUsersLocalTool(
-    private val repository: HubRepository,
+    private val repository: IHubRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListHubUsersLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInventorySourcesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListInventorySourcesLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListInventorySourcesLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<ListInventorySourcesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_inventory_sources",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListLabelsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListLabelsLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListLabelsLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<ListLabelsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_labels",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListNotificationTemplatesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListNotificationTemplatesLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListNotificationTemplatesLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<ListNotificationTemplatesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_notification_templates",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListOrganizationsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListOrganizationsLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListOrganizationsLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<ListOrganizationsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_organizations",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformOrganizationsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformOrganizationsLocalTool.kt
@@ -5,13 +5,13 @@ import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.data.IPlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListPlatformOrganizationsLocalTool(
-    private val repository: PlatformRepository,
+    private val repository: IPlatformRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListPlatformOrganizationsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformRoleDefinitionsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformRoleDefinitionsLocalTool.kt
@@ -5,13 +5,13 @@ import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.data.IPlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListPlatformRoleDefinitionsLocalTool(
-    private val repository: PlatformRepository,
+    private val repository: IPlatformRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListPlatformRoleDefinitionsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformServicesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformServicesLocalTool.kt
@@ -5,13 +5,13 @@ import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.data.IPlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListPlatformServicesLocalTool(
-    private val repository: PlatformRepository,
+    private val repository: IPlatformRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListPlatformServicesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformTeamsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformTeamsLocalTool.kt
@@ -5,13 +5,13 @@ import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.data.IPlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListPlatformTeamsLocalTool(
-    private val repository: PlatformRepository,
+    private val repository: IPlatformRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListPlatformTeamsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListPlatformUsersLocalTool.kt
@@ -5,13 +5,13 @@ import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.data.IPlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListPlatformUsersLocalTool(
-    private val repository: PlatformRepository,
+    private val repository: IPlatformRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListPlatformUsersLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRoleDefinitionsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRoleDefinitionsLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListRoleDefinitionsLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<ListRoleDefinitionsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_role_definitions",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRolesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListRolesLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListRolesLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<ListRolesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_roles",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListServiceClustersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListServiceClustersLocalTool.kt
@@ -5,13 +5,13 @@ import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
 import io.github.leogallego.ansiblejane.data.ITokenManager
-import io.github.leogallego.ansiblejane.data.PlatformRepository
+import io.github.leogallego.ansiblejane.data.IPlatformRepository
 import io.github.leogallego.ansiblejane.model.AapComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListServiceClustersLocalTool(
-    private val repository: PlatformRepository,
+    private val repository: IPlatformRepository,
     private val tokenManager: ITokenManager
 ) : AapLocalTool<ListServiceClustersLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTeamsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTeamsLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListTeamsLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<ListTeamsLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_teams",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTokensLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListTokensLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListTokensLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<ListTokensLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_tokens",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListUsersLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListUsersLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListUsersLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<ListUsersLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_users",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListWorkflowNodesLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/ListWorkflowNodesLocalTool.kt
@@ -4,12 +4,12 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.listToolJson
-import io.github.leogallego.ansiblejane.data.ControllerReadOnlyRepository
+import io.github.leogallego.ansiblejane.data.IControllerReadOnlyRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class ListWorkflowNodesLocalTool(
-    private val repository: ControllerReadOnlyRepository
+    private val repository: IControllerReadOnlyRepository
 ) : AapLocalTool<ListWorkflowNodesLocalTool.Args>(
     typeToken<Args>(), Args.serializer(),
     name = "list_workflow_nodes",

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ControllerReadOnlyRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ControllerReadOnlyRepository.kt
@@ -5,104 +5,104 @@ import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import kotlinx.serialization.json.JsonElement
 import kotlin.coroutines.cancellation.CancellationException
 
-class ControllerReadOnlyRepository(private val apiProvider: IAapApiProvider) {
+class ControllerReadOnlyRepository(private val apiProvider: IAapApiProvider) : IControllerReadOnlyRepository {
 
-    suspend fun getOrganizations(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getOrganizations(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<Organization>> = runPaginated {
         apiProvider.getApiService().getOrganizations(page, pageSize, search)
     }
 
-    suspend fun getUsers(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getUsers(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<User>> = runPaginated {
         apiProvider.getApiService().getUsers(page, pageSize, search)
     }
 
-    suspend fun getTeams(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getTeams(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<Team>> = runPaginated {
         apiProvider.getApiService().getTeams(page, pageSize, search)
     }
 
-    suspend fun getRoles(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getRoles(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<Role>> = runPaginated {
         apiProvider.getApiService().getRoles(page, pageSize, search)
     }
 
-    suspend fun getRoleDefinitions(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getRoleDefinitions(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<RoleDefinition>> = runPaginated {
         apiProvider.getApiService().getRoleDefinitions(page, pageSize, search)
     }
 
-    suspend fun getGroups(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getGroups(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<Group>> = runPaginated {
         apiProvider.getApiService().getGroups(page, pageSize, search)
     }
 
-    suspend fun getInventorySources(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getInventorySources(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<InventorySource>> = runPaginated {
         apiProvider.getApiService().getInventorySources(page, pageSize, search)
     }
 
-    suspend fun getLabels(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getLabels(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<Label>> = runPaginated {
         apiProvider.getApiService().getLabels(page, pageSize, search)
     }
 
-    suspend fun getCredentialTypes(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getCredentialTypes(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<CredentialType>> = runPaginated {
         apiProvider.getApiService().getCredentialTypes(page, pageSize, search)
     }
 
-    suspend fun getNotificationTemplates(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getNotificationTemplates(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<NotificationTemplate>> = runPaginated {
         apiProvider.getApiService().getNotificationTemplates(page, pageSize, search)
     }
 
-    suspend fun getApplications(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getApplications(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<Application>> = runPaginated {
         apiProvider.getApiService().getApplications(page, pageSize, search)
     }
 
-    suspend fun getTokens(
-        page: Int = 1,
-        pageSize: Int = 25
+    override suspend fun getTokens(
+        page: Int,
+        pageSize: Int
     ): Result<ListResult<AapToken>> = runPaginated {
         apiProvider.getApiService().getTokens(page, pageSize)
     }
 
-    suspend fun getSettings(): Result<JsonElement> = try {
+    override suspend fun getSettings(): Result<JsonElement> = try {
         Result.success(apiProvider.getApiService().getSettings())
     } catch (e: CancellationException) {
         throw e
@@ -110,7 +110,7 @@ class ControllerReadOnlyRepository(private val apiProvider: IAapApiProvider) {
         Result.failure(e)
     }
 
-    suspend fun getConfig(): Result<JsonElement> = try {
+    override suspend fun getConfig(): Result<JsonElement> = try {
         Result.success(apiProvider.getApiService().getConfig())
     } catch (e: CancellationException) {
         throw e
@@ -118,15 +118,15 @@ class ControllerReadOnlyRepository(private val apiProvider: IAapApiProvider) {
         Result.failure(e)
     }
 
-    suspend fun getWorkflowJobTemplateNodes(
-        page: Int = 1,
-        pageSize: Int = 25,
-        workflowJobTemplate: Int? = null
+    override suspend fun getWorkflowJobTemplateNodes(
+        page: Int,
+        pageSize: Int,
+        workflowJobTemplate: Int?
     ): Result<ListResult<WorkflowJobTemplateNode>> = runPaginated {
         apiProvider.getApiService().getWorkflowJobTemplateNodes(page, pageSize, workflowJobTemplate)
     }
 
-    suspend fun getSurveySpec(id: Int): Result<SurveySpec> = try {
+    override suspend fun getSurveySpec(id: Int): Result<SurveySpec> = try {
         Result.success(apiProvider.getApiService().getSurveySpec(id))
     } catch (e: CancellationException) {
         throw e

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/DataModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/DataModule.kt
@@ -34,8 +34,8 @@ val sharedRepositoryModule = module {
     single { CredentialRepository(get<IAapApiProvider>()) } bind ICredentialRepository::class
     single { ProjectRepository(get<IAapApiProvider>()) } bind IProjectRepository::class
     single { EdaActivationRepository(get<IAapApiProvider>()) } bind IEdaActivationRepository::class
-    single { ControllerReadOnlyRepository(get<IAapApiProvider>()) }
-    single { EdaReadOnlyRepository(get<IAapApiProvider>()) }
-    single { PlatformRepository(get<IAapApiProvider>()) }
-    single { HubRepository(get<IAapApiProvider>()) }
+    single { ControllerReadOnlyRepository(get<IAapApiProvider>()) } bind IControllerReadOnlyRepository::class
+    single { EdaReadOnlyRepository(get<IAapApiProvider>()) } bind IEdaReadOnlyRepository::class
+    single { PlatformRepository(get<IAapApiProvider>()) } bind IPlatformRepository::class
+    single { HubRepository(get<IAapApiProvider>()) } bind IHubRepository::class
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/EdaReadOnlyRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/EdaReadOnlyRepository.kt
@@ -4,59 +4,59 @@ import io.github.leogallego.ansiblejane.model.*
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import kotlin.coroutines.cancellation.CancellationException
 
-class EdaReadOnlyRepository(private val apiProvider: IAapApiProvider) {
+class EdaReadOnlyRepository(private val apiProvider: IAapApiProvider) : IEdaReadOnlyRepository {
 
-    suspend fun getRulebooks(
-        page: Int = 1,
-        pageSize: Int = 20,
-        name: String? = null
+    override suspend fun getRulebooks(
+        page: Int,
+        pageSize: Int,
+        name: String?
     ): Result<ListResult<EdaRulebook>> = runEdaPaginated {
         apiProvider.getEdaApiService().getRulebooks(page, pageSize, name)
     }
 
-    suspend fun getDecisionEnvironments(
-        page: Int = 1,
-        pageSize: Int = 20,
-        name: String? = null
+    override suspend fun getDecisionEnvironments(
+        page: Int,
+        pageSize: Int,
+        name: String?
     ): Result<ListResult<EdaDecisionEnvironment>> = runEdaPaginated {
         apiProvider.getEdaApiService().getDecisionEnvironments(page, pageSize, name)
     }
 
-    suspend fun getProjects(
-        page: Int = 1,
-        pageSize: Int = 20,
-        name: String? = null
+    override suspend fun getProjects(
+        page: Int,
+        pageSize: Int,
+        name: String?
     ): Result<ListResult<EdaProject>> = runEdaPaginated {
         apiProvider.getEdaApiService().getProjects(page, pageSize, name)
     }
 
-    suspend fun getCredentials(
-        page: Int = 1,
-        pageSize: Int = 20,
-        name: String? = null
+    override suspend fun getCredentials(
+        page: Int,
+        pageSize: Int,
+        name: String?
     ): Result<ListResult<EdaCredential>> = runEdaPaginated {
         apiProvider.getEdaApiService().getCredentials(page, pageSize, name)
     }
 
-    suspend fun getCredentialTypes(
-        page: Int = 1,
-        pageSize: Int = 20,
-        name: String? = null
+    override suspend fun getCredentialTypes(
+        page: Int,
+        pageSize: Int,
+        name: String?
     ): Result<ListResult<EdaCredentialType>> = runEdaPaginated {
         apiProvider.getEdaApiService().getCredentialTypes(page, pageSize, name)
     }
 
-    suspend fun getEventStreams(
-        page: Int = 1,
-        pageSize: Int = 20,
-        name: String? = null
+    override suspend fun getEventStreams(
+        page: Int,
+        pageSize: Int,
+        name: String?
     ): Result<ListResult<EdaEventStream>> = runEdaPaginated {
         apiProvider.getEdaApiService().getEventStreams(page, pageSize, name)
     }
 
-    suspend fun getUsers(
-        page: Int = 1,
-        pageSize: Int = 20
+    override suspend fun getUsers(
+        page: Int,
+        pageSize: Int
     ): Result<ListResult<EdaUser>> = runEdaPaginated {
         apiProvider.getEdaApiService().getUsers(page, pageSize)
     }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/HubRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/HubRepository.kt
@@ -3,65 +3,65 @@ package io.github.leogallego.ansiblejane.data
 import io.github.leogallego.ansiblejane.model.*
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
 
-class HubRepository(private val apiProvider: IAapApiProvider) {
+class HubRepository(private val apiProvider: IAapApiProvider) : IHubRepository {
 
-    suspend fun getCollections(
-        page: Int = 1,
-        pageSize: Int = 20,
-        search: String? = null
+    override suspend fun getCollections(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<HubCollection>> = runV3Paginated {
         apiProvider.getHubApiService().getCollections(page, pageSize, search)
     }
 
-    suspend fun getNamespaces(
-        page: Int = 1,
-        pageSize: Int = 20,
-        search: String? = null
+    override suspend fun getNamespaces(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<HubNamespace>> = runV3Paginated {
         apiProvider.getHubApiService().getNamespaces(page, pageSize, search)
     }
 
-    suspend fun getCollectionVersions(
-        page: Int = 1,
-        pageSize: Int = 20,
-        status: String? = null
+    override suspend fun getCollectionVersions(
+        page: Int,
+        pageSize: Int,
+        status: String?
     ): Result<ListResult<HubCollectionVersion>> = runV3Paginated {
         apiProvider.getHubApiService().getCollectionVersions(page, pageSize, status)
     }
 
-    suspend fun getEeRepositories(
-        page: Int = 1,
-        pageSize: Int = 20,
-        search: String? = null
+    override suspend fun getEeRepositories(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<HubEeRepository>> = runV3Paginated {
         apiProvider.getHubApiService().getEeRepositories(page, pageSize, search)
     }
 
-    suspend fun getEeRegistries(
-        page: Int = 1,
-        pageSize: Int = 20,
-        search: String? = null
+    override suspend fun getEeRegistries(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<HubEeRegistry>> = runV3Paginated {
         apiProvider.getHubApiService().getEeRegistries(page, pageSize, search)
     }
 
-    suspend fun getUsers(
-        page: Int = 1,
-        pageSize: Int = 20
+    override suspend fun getUsers(
+        page: Int,
+        pageSize: Int
     ): Result<ListResult<HubUser>> = runV3Paginated {
         apiProvider.getHubApiService().getUsers(page, pageSize)
     }
 
-    suspend fun getGroups(
-        page: Int = 1,
-        pageSize: Int = 20
+    override suspend fun getGroups(
+        page: Int,
+        pageSize: Int
     ): Result<ListResult<HubGroup>> = runV3Paginated {
         apiProvider.getHubApiService().getGroups(page, pageSize)
     }
 
-    suspend fun getRoleDefinitions(
-        page: Int = 1,
-        pageSize: Int = 20
+    override suspend fun getRoleDefinitions(
+        page: Int,
+        pageSize: Int
     ): Result<ListResult<HubRoleDefinition>> = runPaginated {
         apiProvider.getHubApiService().getRoleDefinitions(page, pageSize)
     }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IControllerReadOnlyRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IControllerReadOnlyRepository.kt
@@ -1,0 +1,102 @@
+package io.github.leogallego.ansiblejane.data
+
+import io.github.leogallego.ansiblejane.model.AapToken
+import io.github.leogallego.ansiblejane.model.Application
+import io.github.leogallego.ansiblejane.model.CredentialType
+import io.github.leogallego.ansiblejane.model.Group
+import io.github.leogallego.ansiblejane.model.InventorySource
+import io.github.leogallego.ansiblejane.model.Label
+import io.github.leogallego.ansiblejane.model.NotificationTemplate
+import io.github.leogallego.ansiblejane.model.Organization
+import io.github.leogallego.ansiblejane.model.Role
+import io.github.leogallego.ansiblejane.model.RoleDefinition
+import io.github.leogallego.ansiblejane.model.SurveySpec
+import io.github.leogallego.ansiblejane.model.Team
+import io.github.leogallego.ansiblejane.model.User
+import io.github.leogallego.ansiblejane.model.WorkflowJobTemplateNode
+import kotlinx.serialization.json.JsonElement
+
+interface IControllerReadOnlyRepository {
+    suspend fun getOrganizations(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<Organization>>
+
+    suspend fun getUsers(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<User>>
+
+    suspend fun getTeams(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<Team>>
+
+    suspend fun getRoles(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<Role>>
+
+    suspend fun getRoleDefinitions(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<RoleDefinition>>
+
+    suspend fun getGroups(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<Group>>
+
+    suspend fun getInventorySources(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<InventorySource>>
+
+    suspend fun getLabels(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<Label>>
+
+    suspend fun getCredentialTypes(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<CredentialType>>
+
+    suspend fun getNotificationTemplates(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<NotificationTemplate>>
+
+    suspend fun getApplications(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<Application>>
+
+    suspend fun getTokens(
+        page: Int = 1,
+        pageSize: Int = 25,
+    ): Result<ListResult<AapToken>>
+
+    suspend fun getSettings(): Result<JsonElement>
+
+    suspend fun getConfig(): Result<JsonElement>
+
+    suspend fun getWorkflowJobTemplateNodes(
+        page: Int = 1,
+        pageSize: Int = 25,
+        workflowJobTemplate: Int? = null,
+    ): Result<ListResult<WorkflowJobTemplateNode>>
+
+    suspend fun getSurveySpec(id: Int): Result<SurveySpec>
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IEdaReadOnlyRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IEdaReadOnlyRepository.kt
@@ -1,0 +1,52 @@
+package io.github.leogallego.ansiblejane.data
+
+import io.github.leogallego.ansiblejane.model.EdaCredential
+import io.github.leogallego.ansiblejane.model.EdaCredentialType
+import io.github.leogallego.ansiblejane.model.EdaDecisionEnvironment
+import io.github.leogallego.ansiblejane.model.EdaEventStream
+import io.github.leogallego.ansiblejane.model.EdaProject
+import io.github.leogallego.ansiblejane.model.EdaRulebook
+import io.github.leogallego.ansiblejane.model.EdaUser
+
+interface IEdaReadOnlyRepository {
+    suspend fun getRulebooks(
+        page: Int = 1,
+        pageSize: Int = 20,
+        name: String? = null,
+    ): Result<ListResult<EdaRulebook>>
+
+    suspend fun getDecisionEnvironments(
+        page: Int = 1,
+        pageSize: Int = 20,
+        name: String? = null,
+    ): Result<ListResult<EdaDecisionEnvironment>>
+
+    suspend fun getProjects(
+        page: Int = 1,
+        pageSize: Int = 20,
+        name: String? = null,
+    ): Result<ListResult<EdaProject>>
+
+    suspend fun getCredentials(
+        page: Int = 1,
+        pageSize: Int = 20,
+        name: String? = null,
+    ): Result<ListResult<EdaCredential>>
+
+    suspend fun getCredentialTypes(
+        page: Int = 1,
+        pageSize: Int = 20,
+        name: String? = null,
+    ): Result<ListResult<EdaCredentialType>>
+
+    suspend fun getEventStreams(
+        page: Int = 1,
+        pageSize: Int = 20,
+        name: String? = null,
+    ): Result<ListResult<EdaEventStream>>
+
+    suspend fun getUsers(
+        page: Int = 1,
+        pageSize: Int = 20,
+    ): Result<ListResult<EdaUser>>
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IHubRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IHubRepository.kt
@@ -1,0 +1,57 @@
+package io.github.leogallego.ansiblejane.data
+
+import io.github.leogallego.ansiblejane.model.HubCollection
+import io.github.leogallego.ansiblejane.model.HubCollectionVersion
+import io.github.leogallego.ansiblejane.model.HubEeRegistry
+import io.github.leogallego.ansiblejane.model.HubEeRepository
+import io.github.leogallego.ansiblejane.model.HubGroup
+import io.github.leogallego.ansiblejane.model.HubNamespace
+import io.github.leogallego.ansiblejane.model.HubRoleDefinition
+import io.github.leogallego.ansiblejane.model.HubUser
+
+interface IHubRepository {
+    suspend fun getCollections(
+        page: Int = 1,
+        pageSize: Int = 20,
+        search: String? = null,
+    ): Result<ListResult<HubCollection>>
+
+    suspend fun getNamespaces(
+        page: Int = 1,
+        pageSize: Int = 20,
+        search: String? = null,
+    ): Result<ListResult<HubNamespace>>
+
+    suspend fun getCollectionVersions(
+        page: Int = 1,
+        pageSize: Int = 20,
+        status: String? = null,
+    ): Result<ListResult<HubCollectionVersion>>
+
+    suspend fun getEeRepositories(
+        page: Int = 1,
+        pageSize: Int = 20,
+        search: String? = null,
+    ): Result<ListResult<HubEeRepository>>
+
+    suspend fun getEeRegistries(
+        page: Int = 1,
+        pageSize: Int = 20,
+        search: String? = null,
+    ): Result<ListResult<HubEeRegistry>>
+
+    suspend fun getUsers(
+        page: Int = 1,
+        pageSize: Int = 20,
+    ): Result<ListResult<HubUser>>
+
+    suspend fun getGroups(
+        page: Int = 1,
+        pageSize: Int = 20,
+    ): Result<ListResult<HubGroup>>
+
+    suspend fun getRoleDefinitions(
+        page: Int = 1,
+        pageSize: Int = 20,
+    ): Result<ListResult<HubRoleDefinition>>
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IPlatformRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IPlatformRepository.kt
@@ -1,0 +1,50 @@
+package io.github.leogallego.ansiblejane.data
+
+import io.github.leogallego.ansiblejane.model.PlatformAuthenticator
+import io.github.leogallego.ansiblejane.model.PlatformOrganization
+import io.github.leogallego.ansiblejane.model.PlatformRoleDefinition
+import io.github.leogallego.ansiblejane.model.PlatformService
+import io.github.leogallego.ansiblejane.model.PlatformServiceCluster
+import io.github.leogallego.ansiblejane.model.PlatformTeam
+import io.github.leogallego.ansiblejane.model.PlatformUser
+
+interface IPlatformRepository {
+    suspend fun getOrganizations(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<PlatformOrganization>>
+
+    suspend fun getUsers(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<PlatformUser>>
+
+    suspend fun getTeams(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<PlatformTeam>>
+
+    suspend fun getRoleDefinitions(
+        page: Int = 1,
+        pageSize: Int = 25,
+        search: String? = null,
+    ): Result<ListResult<PlatformRoleDefinition>>
+
+    suspend fun getAuthenticators(
+        page: Int = 1,
+        pageSize: Int = 25,
+    ): Result<ListResult<PlatformAuthenticator>>
+
+    suspend fun getServices(
+        page: Int = 1,
+        pageSize: Int = 25,
+    ): Result<ListResult<PlatformService>>
+
+    suspend fun getServiceClusters(
+        page: Int = 1,
+        pageSize: Int = 25,
+    ): Result<ListResult<PlatformServiceCluster>>
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/PlatformRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/PlatformRepository.kt
@@ -4,57 +4,57 @@ import io.github.leogallego.ansiblejane.model.*
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import kotlin.coroutines.cancellation.CancellationException
 
-class PlatformRepository(private val apiProvider: IAapApiProvider) {
+class PlatformRepository(private val apiProvider: IAapApiProvider) : IPlatformRepository {
 
-    suspend fun getOrganizations(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getOrganizations(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<PlatformOrganization>> = runPaginated {
         apiProvider.getPlatformApiService().getOrganizations(page, pageSize, search)
     }
 
-    suspend fun getUsers(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getUsers(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<PlatformUser>> = runPaginated {
         apiProvider.getPlatformApiService().getUsers(page, pageSize, search)
     }
 
-    suspend fun getTeams(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getTeams(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<PlatformTeam>> = runPaginated {
         apiProvider.getPlatformApiService().getTeams(page, pageSize, search)
     }
 
-    suspend fun getRoleDefinitions(
-        page: Int = 1,
-        pageSize: Int = 25,
-        search: String? = null
+    override suspend fun getRoleDefinitions(
+        page: Int,
+        pageSize: Int,
+        search: String?
     ): Result<ListResult<PlatformRoleDefinition>> = runPaginated {
         apiProvider.getPlatformApiService().getRoleDefinitions(page, pageSize, search)
     }
 
-    suspend fun getAuthenticators(
-        page: Int = 1,
-        pageSize: Int = 25
+    override suspend fun getAuthenticators(
+        page: Int,
+        pageSize: Int
     ): Result<ListResult<PlatformAuthenticator>> = runPaginated {
         apiProvider.getPlatformApiService().getAuthenticators(page, pageSize)
     }
 
-    suspend fun getServices(
-        page: Int = 1,
-        pageSize: Int = 25
+    override suspend fun getServices(
+        page: Int,
+        pageSize: Int
     ): Result<ListResult<PlatformService>> = runPaginated {
         apiProvider.getPlatformApiService().getServices(page, pageSize)
     }
 
-    suspend fun getServiceClusters(
-        page: Int = 1,
-        pageSize: Int = 25
+    override suspend fun getServiceClusters(
+        page: Int,
+        pageSize: Int
     ): Result<ListResult<PlatformServiceCluster>> = runPaginated {
         apiProvider.getPlatformApiService().getServiceClusters(page, pageSize)
     }

--- a/shared/src/jvmMain/kotlin/io/github/leogallego/ansiblejane/platform/BackgroundWorker.jvm.kt
+++ b/shared/src/jvmMain/kotlin/io/github/leogallego/ansiblejane/platform/BackgroundWorker.jvm.kt
@@ -23,8 +23,12 @@ actual class BackgroundWorker {
                 }
             }
 
+            // Intentional no-op: workflow approval polling is Android-only
+            // (WorkManager + ApprovalPollingWorker in app/). Desktop keeps the
+            // schedule/cancel API for expect/actual parity but does not poll.
+            // See CLAUDE.md / service-contracts.md §3.
             val task = newExecutor.scheduleAtFixedRate(
-                { /* TODO(#243): wire to actual approval polling when assistant is ported */ },
+                { /* no-op: approval polling is Android-only */ },
                 intervalMinutes,
                 intervalMinutes,
                 TimeUnit.MINUTES

--- a/shared/src/jvmMain/kotlin/io/github/leogallego/ansiblejane/platform/BackgroundWorker.jvm.kt
+++ b/shared/src/jvmMain/kotlin/io/github/leogallego/ansiblejane/platform/BackgroundWorker.jvm.kt
@@ -1,81 +1,18 @@
 package io.github.leogallego.ansiblejane.platform
 
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.ScheduledFuture
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
-
+/**
+ * Desktop actual: intentional no-op.
+ *
+ * Workflow approval polling is Android-only (WorkManager + ApprovalPollingWorker in
+ * `app/`). This class keeps the expect/actual API surface but does not schedule work.
+ * See CLAUDE.md / service-contracts.md §3.
+ */
 actual class BackgroundWorker {
-    private val lock = ReentrantLock()
-    private var executor: ScheduledExecutorService? = null
-    private var scheduledTask: ScheduledFuture<*>? = null
-    private var shutdownHook: Thread? = null
-
     actual fun schedulePolling(intervalMinutes: Long) {
-        lock.withLock {
-            cancelPollingInternal()
-
-            val newExecutor = Executors.newSingleThreadScheduledExecutor { runnable ->
-                Thread(runnable, "approval-polling").apply {
-                    isDaemon = true
-                }
-            }
-
-            // Intentional no-op: workflow approval polling is Android-only
-            // (WorkManager + ApprovalPollingWorker in app/). Desktop keeps the
-            // schedule/cancel API for expect/actual parity but does not poll.
-            // See CLAUDE.md / service-contracts.md §3.
-            val task = newExecutor.scheduleAtFixedRate(
-                { /* no-op: approval polling is Android-only */ },
-                intervalMinutes,
-                intervalMinutes,
-                TimeUnit.MINUTES
-            )
-
-            executor = newExecutor
-            scheduledTask = task
-
-            val hookExecutor = newExecutor
-            val hook = Thread {
-                hookExecutor.shutdownNow()
-            }
-            Runtime.getRuntime().addShutdownHook(hook)
-            shutdownHook = hook
-        }
+        // no-op: approval polling is Android-only
     }
 
     actual fun cancelPolling() {
-        lock.withLock {
-            cancelPollingInternal()
-        }
-    }
-
-    private fun cancelPollingInternal() {
-        scheduledTask?.cancel(false)
-        scheduledTask = null
-
-        executor?.let {
-            it.shutdown()
-            try {
-                if (!it.awaitTermination(100, TimeUnit.MILLISECONDS)) {
-                    it.shutdownNow()
-                }
-            } catch (e: InterruptedException) {
-                it.shutdownNow()
-                Thread.currentThread().interrupt()
-            }
-        }
-        executor = null
-
-        shutdownHook?.let {
-            try {
-                Runtime.getRuntime().removeShutdownHook(it)
-            } catch (_: IllegalStateException) {
-                // JVM is already shutting down
-            }
-        }
-        shutdownHook = null
+        // no-op: approval polling is Android-only
     }
 }


### PR DESCRIPTION
## Summary
- **#433** — Rewrite CLAUDE.md AI Assistant section for post-#243 module layout; document desktop `BackgroundWorker` as intentional Android-only no-op (no desktop approval-polling parity); drop stale `#243` TODO; note in service-contracts §3.
- **#432** — Remove repository/manager `koinInject` from `HostDetailSheet` and `MainScreen`; add `HostDetailViewModel` + `MainViewModel` with sealed/presentation state and unit tests.
- **#434** — Add `IControllerReadOnlyRepository`, `IEdaReadOnlyRepository`, `IPlatformRepository`, `IHubRepository`; Koin `bind`; local tools depend on interfaces.
- **#435** — Unit tests for Dashboard, Assistant, Notifications, and WorkflowTemplateDetail ViewModels (happy path + error/empty).

## Deferred decision
Desktop approval polling parity is **out of scope**: JVM `BackgroundWorker` keeps schedule/cancel for expect/actual parity but does not poll. Documented in CLAUDE.md and `docs/architecture/service-contracts.md` §3.

## Test plan
- [x] `./gradlew --no-daemon :shared:compileKotlinJvm`
- [x] `./gradlew --no-daemon :composeApp:desktopTest --tests '...HostDetailViewModelTest' --tests '...MainViewModelTest'`
- [x] `./gradlew --no-daemon :composeApp:desktopTest --tests '...NotificationsViewModelTest' --tests '...WorkflowTemplateDetailViewModelTest' --tests '...DashboardViewModelTest' --tests '...AssistantViewModelTest'`
- [ ] CI green on this PR
- [ ] Spot-check Host detail sheet + Main top-bar provider switch / clear chat on desktop or Android

Closes #433
Closes #432
Closes #434
Closes #435