### PR TITLE
feat(toolrouter): Tier 1 routing + deterministic tool ordering (#120, #439)

### DIFF
--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
@@ -113,7 +113,11 @@ class FakeTokenManager : ITokenManager {
     ) {
         _instances.value = _instances.value.map {
             if (it.id == instanceId) {
-                it.copy(isSuperuser = isSuperuser, isSystemAuditor = isSystemAuditor)
+                it.copy(
+                    isSuperuser = isSuperuser,
+                    isSystemAuditor = isSystemAuditor,
+                    userRoleFetched = true
+                )
             } else it
         }
         _activeInstance.value?.let { active ->

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
@@ -106,6 +106,23 @@ class FakeTokenManager : ITokenManager {
         }
     }
 
+    override suspend fun updateUserRole(
+        instanceId: String,
+        isSuperuser: Boolean,
+        isSystemAuditor: Boolean
+    ) {
+        _instances.value = _instances.value.map {
+            if (it.id == instanceId) {
+                it.copy(isSuperuser = isSuperuser, isSystemAuditor = isSystemAuditor)
+            } else it
+        }
+        _activeInstance.value?.let { active ->
+            if (active.id == instanceId) {
+                _activeInstance.value = _instances.value.find { it.id == instanceId }
+            }
+        }
+    }
+
     override suspend fun clearCredentials() {
         _instances.value = emptyList()
         _activeInstance.value = null

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -19,6 +19,7 @@ import io.github.leogallego.ansiblejane.assistant.llm.LlmProvider
 import io.github.leogallego.ansiblejane.assistant.tools.CachedMcpTool
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.local.ListToolsLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.local.SearchAvailableToolsLocalTool
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.data.IToolManifestRepository
 import io.github.leogallego.ansiblejane.model.ToolManifest
@@ -209,8 +210,11 @@ class AssistantViewModel(
             val noToolsForCategory = queryResult.categoryMatched && queryResult.tools.isEmpty()
             val queryWords = text.lowercase().split(Regex("\\W+")).toSet()
             val isToolDiscoveryQuery = TOOL_DISCOVERY_WORDS.any { it in queryWords }
+            // When ToolRouter already returned meta-search / discovery tools, continue to the LLM
             val generalQueryInToolsOnly = !queryResult.categoryMatched &&
-                mode == TokenSavingMode.TOOLS_ONLY && !isToolDiscoveryQuery
+                mode == TokenSavingMode.TOOLS_ONLY &&
+                !isToolDiscoveryQuery &&
+                queryResult.tools.isEmpty()
 
             if (noToolsForCategory || generalQueryInToolsOnly) {
                 Log.d(TAG, "ROUTE: no tools path — noToolsForCategory=$noToolsForCategory, " +
@@ -256,13 +260,13 @@ class AssistantViewModel(
             val matchedLocal = queryResult.tools.filterIsInstance<LocalTool>()
             val matchedMcp = queryResult.tools.filter { it !is LocalTool }.take(mcpLimit)
             val budgetedTools = if (matchedLocal.isEmpty() && matchedMcp.isEmpty()) {
-                val listTool = ListToolsLocalTool { toolRouter.getAllRegisteredTools() }
-                listOf(listTool)
+                val searchTool = SearchAvailableToolsLocalTool { toolRouter }
+                listOf(searchTool)
             } else {
                 matchedLocal + matchedMcp
             }
             Log.d(TAG, "BUDGET: ${budgetedTools.size} tools [${budgetedTools.map { it.spec.name }}]" +
-                if (matchedLocal.isEmpty() && matchedMcp.isEmpty()) " (fallback: list_tools)" else "")
+                if (matchedLocal.isEmpty() && matchedMcp.isEmpty()) " (fallback: search_available_tools)" else "")
             val toolSpecs = budgetedTools.map { it.spec }
             val toolExecutor = ToolExecutor(budgetedTools)
             val engine = ChatEngine(provider, toolExecutor)

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -13,13 +13,12 @@ import io.github.leogallego.ansiblejane.assistant.engine.Role
 import io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
 import io.github.leogallego.ansiblejane.assistant.engine.ToolExecutor
 import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
+import io.github.leogallego.ansiblejane.assistant.engine.toAapRole
 import io.github.leogallego.ansiblejane.assistant.llm.GeminiLlmProvider
 import io.github.leogallego.ansiblejane.assistant.llm.KoogLlmProvider
 import io.github.leogallego.ansiblejane.assistant.llm.LlmProvider
 import io.github.leogallego.ansiblejane.assistant.tools.CachedMcpTool
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.ListToolsLocalTool
-import io.github.leogallego.ansiblejane.assistant.tools.local.SearchAvailableToolsLocalTool
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.data.IToolManifestRepository
 import io.github.leogallego.ansiblejane.model.ToolManifest
@@ -198,29 +197,23 @@ class AssistantViewModel(
 
             mcpServerManager.refreshConnections()
             val mcpTools = mcpServerManager.mcpTools.value
-            val serverConfigs = tokenManager.activeInstance.value?.mcpServerUrls ?: emptyList()
+            val activeInstance = tokenManager.activeInstance.value
+            val serverConfigs = activeInstance?.mcpServerUrls ?: emptyList()
+            val aapRole = activeInstance?.toAapRole()
             toolRouter.registerMcpTools(mcpTools)
 
-            Log.d(TAG, "ROUTE: query=\"$text\", ${localTools.size} local, ${mcpTools.size} mcp")
-            val queryResult = toolRouter.getToolsForQuery(text, serverConfigs)
+            Log.d(TAG, "ROUTE: query=\"$text\", ${localTools.size} local, ${mcpTools.size} mcp, role=$aapRole")
+            val queryResult = toolRouter.getToolsForQuery(text, serverConfigs, aapRole)
             val mode = config.tokenSavingMode
             Log.d(TAG, "ROUTE: categoryMatched=${queryResult.categoryMatched}, " +
                 "${queryResult.tools.size} tools selected, mode=$mode")
 
-            val noToolsForCategory = queryResult.categoryMatched && queryResult.tools.isEmpty()
-            val queryWords = text.lowercase().split(Regex("\\W+")).toSet()
-            val isToolDiscoveryQuery = TOOL_DISCOVERY_WORDS.any { it in queryWords }
-            // When ToolRouter already returned meta-search / discovery tools, continue to the LLM
-            val generalQueryInToolsOnly = !queryResult.categoryMatched &&
-                mode == TokenSavingMode.TOOLS_ONLY &&
-                !isToolDiscoveryQuery &&
-                queryResult.tools.isEmpty()
-
-            if (noToolsForCategory || generalQueryInToolsOnly) {
-                Log.d(TAG, "ROUTE: no tools path — noToolsForCategory=$noToolsForCategory, " +
-                    "generalQueryInToolsOnly=$generalQueryInToolsOnly")
+            // ToolRouter owns meta-search injection; empty means greetings / no match — do not re-inject
+            if (queryResult.tools.isEmpty()) {
+                val noCategory = !queryResult.categoryMatched
+                Log.d(TAG, "ROUTE: no tools path — categoryMatched=${queryResult.categoryMatched}")
                 val hasMcp = mcpServerManager.mcpTools.value.isNotEmpty()
-                val content = if (generalQueryInToolsOnly) {
+                val content = if (noCategory) {
                     "I can help you query your AAP instance. Try asking about:\n\n" +
                         "- **Inventory** — hosts, groups, inventories\n" +
                         "- **Jobs** — job templates, workflows, schedules\n" +
@@ -259,14 +252,8 @@ class AssistantViewModel(
             }
             val matchedLocal = queryResult.tools.filterIsInstance<LocalTool>()
             val matchedMcp = queryResult.tools.filter { it !is LocalTool }.take(mcpLimit)
-            val budgetedTools = if (matchedLocal.isEmpty() && matchedMcp.isEmpty()) {
-                val searchTool = SearchAvailableToolsLocalTool { toolRouter }
-                listOf(searchTool)
-            } else {
-                matchedLocal + matchedMcp
-            }
-            Log.d(TAG, "BUDGET: ${budgetedTools.size} tools [${budgetedTools.map { it.spec.name }}]" +
-                if (matchedLocal.isEmpty() && matchedMcp.isEmpty()) " (fallback: search_available_tools)" else "")
+            val budgetedTools = matchedLocal + matchedMcp
+            Log.d(TAG, "BUDGET: ${budgetedTools.size} tools [${budgetedTools.map { it.spec.name }}]")
             val toolSpecs = budgetedTools.map { it.spec }
             val toolExecutor = ToolExecutor(budgetedTools)
             val engine = ChatEngine(provider, toolExecutor)
@@ -445,8 +432,5 @@ class AssistantViewModel(
 
     companion object {
         private const val TAG = "AssistantVM"
-        private val TOOL_DISCOVERY_WORDS = setOf(
-            "tools", "tool", "capabilities", "capable", "help", "actions", "functions"
-        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -12,6 +12,7 @@ import io.github.leogallego.ansiblejane.assistant.engine.ResponseSource
 import io.github.leogallego.ansiblejane.assistant.engine.Role
 import io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
 import io.github.leogallego.ansiblejane.assistant.engine.ToolExecutor
+import io.github.leogallego.ansiblejane.assistant.engine.AapRole
 import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
 import io.github.leogallego.ansiblejane.assistant.engine.toAapRole
 import io.github.leogallego.ansiblejane.assistant.llm.GeminiLlmProvider
@@ -199,7 +200,8 @@ class AssistantViewModel(
             val mcpTools = mcpServerManager.mcpTools.value
             val activeInstance = tokenManager.activeInstance.value
             val serverConfigs = activeInstance?.mcpServerUrls ?: emptyList()
-            val aapRole = activeInstance?.toAapRole()
+            // No instance or role not yet fetched → AUDITOR (fail-closed)
+            val aapRole = activeInstance?.toAapRole() ?: AapRole.AUDITOR
             toolRouter.registerMcpTools(mcpTools)
 
             Log.d(TAG, "ROUTE: query=\"$text\", ${localTools.size} local, ${mcpTools.size} mcp, role=$aapRole")

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -59,6 +59,8 @@ class SettingsViewModel(
             val activeConfig = assistantRepository.loadLlmConfig()
             val initialActiveKey = assistantRepository.activeProviderKeyFlow.first()
 
+            // Unfiltered on purpose: Settings enable/disable UI lists every registered
+            // tool. Chat routing applies auditor filtering via getRoutableTools / getToolsForQuery.
             val initialLocalTools = toolRouter.getAllRegisteredTools()
                 .filter { (_, source) -> source == ToolSource.LOCAL }
                 .map { (tool, _) ->

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
@@ -113,7 +113,11 @@ class FakeTokenManager : ITokenManager {
     ) {
         _instances.value = _instances.value.map {
             if (it.id == instanceId) {
-                it.copy(isSuperuser = isSuperuser, isSystemAuditor = isSystemAuditor)
+                it.copy(
+                    isSuperuser = isSuperuser,
+                    isSystemAuditor = isSystemAuditor,
+                    userRoleFetched = true
+                )
             } else it
         }
         _activeInstance.value?.let { active ->

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
@@ -106,6 +106,23 @@ class FakeTokenManager : ITokenManager {
         }
     }
 
+    override suspend fun updateUserRole(
+        instanceId: String,
+        isSuperuser: Boolean,
+        isSystemAuditor: Boolean
+    ) {
+        _instances.value = _instances.value.map {
+            if (it.id == instanceId) {
+                it.copy(isSuperuser = isSuperuser, isSystemAuditor = isSystemAuditor)
+            } else it
+        }
+        _activeInstance.value?.let { active ->
+            if (active.id == instanceId) {
+                _activeInstance.value = _instances.value.find { it.id == instanceId }
+            }
+        }
+    }
+
     override suspend fun clearCredentials() {
         _instances.value = emptyList()
         _activeInstance.value = null

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -243,7 +243,7 @@ for one-shot discovery of external endpoints would be over-engineering.
 
 - **Documented exceptions** (currently acceptable):
   - `ChatEngine.kt` (~509 LOC) — agentic loop orchestration is inherently complex
-  - `ToolRouter.kt` (~485 LOC) — category matching + scoring + MCP/local merging
+  - `ToolRouter.kt` (~750 LOC) — category matching + scoring + meta-search + MCP/local merging
   - `AapApiClient.kt` (~413 LOC) — REST facade with 50+ endpoint wrappers
   - `TokenManager.kt` (~422 LOC) — token lifecycle (candidate for future extraction)
   - `McpServerManager.kt` (~357 LOC) — MCP connection lifecycle

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -243,7 +243,7 @@ for one-shot discovery of external endpoints would be over-engineering.
 
 - **Documented exceptions** (currently acceptable):
   - `ChatEngine.kt` (~509 LOC) — agentic loop orchestration is inherently complex
-  - `ToolRouter.kt` (~750 LOC) — category matching + scoring + meta-search + MCP/local merging
+  - `ToolRouter.kt` (~790 LOC) — category matching + scoring + meta-search + MCP/local merging
   - `AapApiClient.kt` (~413 LOC) — REST facade with 50+ endpoint wrappers
   - `TokenManager.kt` (~422 LOC) — token lifecycle (candidate for future extraction)
   - `McpServerManager.kt` (~357 LOC) — MCP connection lifecycle

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
@@ -138,4 +138,5 @@ val sharedAssistantModule = module {
 
     // Meta
     single { ListToolsLocalTool { get<ToolRouter>().getAllRegisteredTools() } } bind LocalTool::class
+    single { SearchAvailableToolsLocalTool { get<ToolRouter>() } } bind LocalTool::class
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
@@ -138,5 +138,9 @@ val sharedAssistantModule = module {
 
     // Meta
     single { ListToolsLocalTool { get<ToolRouter>().getAllRegisteredTools() } } bind LocalTool::class
-    single { SearchAvailableToolsLocalTool { get<ToolRouter>() } } bind LocalTool::class
+    single {
+        SearchAvailableToolsLocalTool { query, maxResults ->
+            get<ToolRouter>().searchAvailableTools(query, maxResults = maxResults)
+        }
+    } bind LocalTool::class
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
@@ -137,7 +137,7 @@ val sharedAssistantModule = module {
     single { ListHubRolesLocalTool(get(), get()) } bind LocalTool::class
 
     // Meta
-    single { ListToolsLocalTool { get<ToolRouter>().getAllRegisteredTools() } } bind LocalTool::class
+    single { ListToolsLocalTool { get<ToolRouter>().getRoutableTools() } } bind LocalTool::class
     single {
         SearchAvailableToolsLocalTool { query, maxResults ->
             get<ToolRouter>().searchAvailableTools(query, maxResults = maxResults)

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
@@ -1,8 +1,10 @@
 package io.github.leogallego.ansiblejane.assistant.di
 
 import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
+import io.github.leogallego.ansiblejane.assistant.engine.toAapRole
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.local.*
+import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.network.createPlatformHttpClient
 import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
 import io.ktor.client.plugins.defaultRequest
@@ -136,11 +138,22 @@ val sharedAssistantModule = module {
     single { ListHubGroupsLocalTool(get(), get()) } bind LocalTool::class
     single { ListHubRolesLocalTool(get(), get()) } bind LocalTool::class
 
-    // Meta
-    single { ListToolsLocalTool { get<ToolRouter>().getRoutableTools() } } bind LocalTool::class
+    // Meta — role from active instance (not lastRoutingContext alone) so list/search
+    // honor auditor filtering even before the first getToolsForQuery in a process.
+    single {
+        ListToolsLocalTool {
+            val role = get<ITokenManager>().activeInstance.value?.toAapRole()
+            get<ToolRouter>().getRoutableTools(role)
+        }
+    } bind LocalTool::class
     single {
         SearchAvailableToolsLocalTool { query, maxResults ->
-            get<ToolRouter>().searchAvailableTools(query, maxResults = maxResults)
+            val role = get<ITokenManager>().activeInstance.value?.toAapRole()
+            get<ToolRouter>().searchAvailableTools(
+                query,
+                maxResults = maxResults,
+                aapRole = role
+            )
         }
     } bind LocalTool::class
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/AapRole.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/AapRole.kt
@@ -1,0 +1,19 @@
+package io.github.leogallego.ansiblejane.assistant.engine
+
+import io.github.leogallego.ansiblejane.model.User
+
+/**
+ * Coarse AAP RBAC role used by [ToolRouter] to hide write/destructive tools
+ * from auditor accounts (see #120 Tier 1).
+ */
+enum class AapRole {
+    ADMIN,
+    AUDITOR,
+    OPERATOR
+}
+
+fun User.toAapRole(): AapRole = when {
+    isSuperuser -> AapRole.ADMIN
+    isSystemAuditor -> AapRole.AUDITOR
+    else -> AapRole.OPERATOR
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/AapRole.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/AapRole.kt
@@ -13,13 +13,30 @@ enum class AapRole {
     OPERATOR
 }
 
+/**
+ * Local tool names that mutate AAP state but do not end with [io.github.leogallego.ansiblejane.assistant.tools.Tool.WRITE_SUFFIXES].
+ * Must stay in sync with `isDestructive = true` on the corresponding `*LocalTool` classes.
+ */
+val DESTRUCTIVE_LOCAL_TOOL_NAMES = setOf(
+    "launch_job",
+    "launch_workflow",
+    "approve_workflow",
+    "deny_workflow",
+    "toggle_schedule",
+)
+
 fun User.toAapRole(): AapRole = when {
     isSuperuser -> AapRole.ADMIN
     isSystemAuditor -> AapRole.AUDITOR
     else -> AapRole.OPERATOR
 }
 
+/**
+ * Maps persisted instance flags to a routing role.
+ * Fail-closed: until `/api/v2/me/` role flags are fetched, treat as [AapRole.AUDITOR].
+ */
 fun AapInstance.toAapRole(): AapRole = when {
+    !userRoleFetched -> AapRole.AUDITOR
     isSuperuser -> AapRole.ADMIN
     isSystemAuditor -> AapRole.AUDITOR
     else -> AapRole.OPERATOR

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/AapRole.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/AapRole.kt
@@ -1,5 +1,6 @@
 package io.github.leogallego.ansiblejane.assistant.engine
 
+import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.model.User
 
 /**
@@ -13,6 +14,12 @@ enum class AapRole {
 }
 
 fun User.toAapRole(): AapRole = when {
+    isSuperuser -> AapRole.ADMIN
+    isSystemAuditor -> AapRole.AUDITOR
+    else -> AapRole.OPERATOR
+}
+
+fun AapInstance.toAapRole(): AapRole = when {
     isSuperuser -> AapRole.ADMIN
     isSystemAuditor -> AapRole.AUDITOR
     else -> AapRole.OPERATOR

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
@@ -67,7 +67,10 @@ class ChatEngine(
             history.filter { it.role == Role.USER || it.role == Role.ASSISTANT }
                 .forEach { messages.add(it) }
 
-            val toolDescriptors = tools.map { it.toToolDescriptor() }
+            // #439: stable alphabetical order so LLM KV/prefix caches can reuse tool schemas
+            val toolDescriptors = tools
+                .sortedBy { it.name }
+                .map { it.toToolDescriptor() }
             val toolSchemaChars = toolDescriptors.sumOf {
                 it.name.length + it.description.length +
                     it.requiredParameters.sumOf { p -> p.name.length + p.description.length + 20 } +

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -312,12 +312,49 @@ class ToolRouter(
         }
 
         fun stem(word: String): String {
-            val result = word
-                .removeSuffix("ies").let { if (it != word) "${it}y" else it }
-                .removeSuffix("es")
-                .removeSuffix("s")
-                .removeSuffix("e")
-            return if (result.length < 2) word else result
+            var w = word
+
+            // Longer morphological suffixes first (Tier 1 #120)
+            w = when {
+                w.endsWith("ies") && w.length > 4 ->
+                    w.dropLast(3) + "y"
+                w.endsWith("tion") && w.length > 5 ->
+                    w.dropLast(3) // execution → execut
+                w.endsWith("sion") && w.length > 5 ->
+                    w.dropLast(3)
+                w.endsWith("ing") && w.length > 5 ->
+                    undouble(w.dropLast(3))
+                w.endsWith("ed") && w.length > 4 ->
+                    undouble(w.dropLast(2))
+                w.endsWith("er") && w.length > 5 ->
+                    undouble(w.dropLast(2))
+                else -> {
+                    // Legacy plural chain: -ies/-es/-s then trailing -e
+                    val beforeIes = w
+                    w = w.removeSuffix("ies").let { if (it != beforeIes) "${it}y" else it }
+                    w = w.removeSuffix("es")
+                    w = w.removeSuffix("s")
+                    w = w.removeSuffix("e")
+                    w
+                }
+            }
+
+            // Plural strip may leave -tion (executions → execution → execut)
+            if (w.endsWith("tion") && w.length > 5) w = w.dropLast(3)
+            else if (w.endsWith("sion") && w.length > 5) w = w.dropLast(3)
+
+            // Trailing -e after morphological strip (execute → execut)
+            if (w.endsWith("e") && w.length > 2) w = w.dropLast(1)
+
+            return if (w.length < 2) word else w
+        }
+
+        /** Collapse a doubled final consonant (running → runn → run). */
+        private fun undouble(base: String): String {
+            if (base.length < 2) return base
+            val last = base.last()
+            val prev = base[base.lastIndex - 1]
+            return if (last == prev && last !in "aeiou") base.dropLast(1) else base
         }
     }
 

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -311,6 +311,9 @@ class ToolRouter(
             "tools", "tool", "capabilities", "capable", "help", "actions", "functions"
         )
 
+        /** Cap for meta-search results returned into the LLM tool list. */
+        const val MAX_META_SEARCH_RESULTS = 20
+
         /** Synonym expansion applied to query tokens before stemming (#120 Tier 1). */
         val SYNONYMS = mapOf(
             "playbook" to setOf("job", "template"),
@@ -336,6 +339,16 @@ class ToolRouter(
             "ansible" to setOf("job", "playbook", "template"),
         )
 
+        /** Stemmed synonym keys so "deploying"/"deployed" expand like "deploy". */
+        private val STEMMED_SYNONYMS: Map<String, Set<String>> by lazy {
+            buildMap {
+                for ((key, values) in SYNONYMS) {
+                    val stemmedKey = stem(key)
+                    put(stemmedKey, get(stemmedKey).orEmpty() + values)
+                }
+            }
+        }
+
         private val TOOLSET_CATEGORY_MAP = mapOf(
             "job_management" to setOf(Category.JOBS),
             "inventory_management" to setOf(Category.INVENTORY),
@@ -354,44 +367,46 @@ class ToolRouter(
         }
 
         fun stem(word: String): String {
-            var w = word
+            if (word.length < 2) return word
+            // Keep "setting(s)" intact — stripping -ing/-s yields "set" and false-matches CONFIGURATION
+            if (word == "setting" || word == "settings") return "setting"
 
-            // Longer morphological suffixes first (Tier 1 #120)
+            // 1) Plural normalization first so worker/workers and execution/executions share a form
+            // Short EDA tokens ("des"/"ees"): removeSuffix("es") would leave 1 char — keep original
+            var w = when {
+                word.endsWith("ies") && word.length > 4 -> word.dropLast(3) + "y"
+                word.length <= 3 && word.endsWith("es") -> word
+                word.endsWith("es") && word.length > 3 -> word.dropLast(2)
+                word.endsWith("s") && !word.endsWith("ss") && word.length > 2 -> word.dropLast(1)
+                else -> word
+            }
+            if (w.length < 2) return word
+
+            // 2) Morphological suffixes on the singular-ish form
             w = when {
-                w.endsWith("ies") && w.length > 4 ->
-                    w.dropLast(3) + "y"
-                w.endsWith("tion") && w.length > 5 ->
+                w.endsWith("tion") && w.length > 5 && !isProtectedTionStem(w) ->
                     w.dropLast(3) // execution → execut
                 w.endsWith("sion") && w.length > 5 ->
                     w.dropLast(3)
-                // Keep "setting" intact — stripping -ing yields "set" and false-matches CONFIGURATION
-                w == "setting" -> w
                 w.endsWith("ing") && w.length > 5 ->
                     undouble(w.dropLast(3))
                 w.endsWith("ed") && w.length > 4 ->
                     undouble(w.dropLast(2))
                 w.endsWith("er") && w.length > 5 ->
                     undouble(w.dropLast(2))
-                else -> {
-                    // Legacy plural chain: -ies/-es/-s then trailing -e
-                    val beforeIes = w
-                    w = w.removeSuffix("ies").let { if (it != beforeIes) "${it}y" else it }
-                    w = w.removeSuffix("es")
-                    w = w.removeSuffix("s")
-                    w = w.removeSuffix("e")
-                    w
-                }
+                else -> w
             }
 
-            // Plural strip may leave -tion (executions → execution → execut)
-            if (w.endsWith("tion") && w.length > 5) w = w.dropLast(3)
-            else if (w.endsWith("sion") && w.length > 5) w = w.dropLast(3)
-
-            // Trailing -e after morphological strip (execute → execut)
+            // 3) Trailing -e (template → templat, execute → execut)
             if (w.endsWith("e") && w.length > 2) w = w.dropLast(1)
 
             return if (w.length < 2) word else w
         }
+
+        /** Words where -tion is part of the root (station/question), not a verb noun suffix. */
+        private fun isProtectedTionStem(w: String): Boolean =
+            w.endsWith("station") || w.endsWith("question") || w.endsWith("portion") ||
+                w.endsWith("position") || w.endsWith("condition") || w.endsWith("tradition")
 
         /** Collapse a doubled final consonant (running → runn → run). */
         private fun undouble(base: String): String {
@@ -405,6 +420,7 @@ class ToolRouter(
             val expanded = words.toMutableSet()
             for (word in words) {
                 SYNONYMS[word]?.let { expanded.addAll(it) }
+                STEMMED_SYNONYMS[stem(word)]?.let { expanded.addAll(it) }
             }
             return expanded
         }
@@ -614,26 +630,30 @@ class ToolRouter(
             return QueryResult(emptyList(), categoryMatched = false)
         }
 
+        // Discovery intent first — inject a single meta tool; do not bulk-match on "tool"
+        if (isToolDiscoveryQuery(queryWords)) {
+            val meta = findMetaSearchTool(aapRole)
+            if (meta != null) {
+                Log.d(TAG, "META: discovery inject ${meta.spec.name}")
+                return QueryResult(listOf(meta), categoryMatched = false)
+            }
+        }
+
         if (stemmedQuery.isNotEmpty()) {
             val searched = cherryPick(
                 collectEnabledTools(serverConfigs, aapRole),
                 stemmedQuery,
                 requireOverlap = true
-            )
+            ).take(MAX_META_SEARCH_RESULTS)
             if (searched.isNotEmpty()) {
                 Log.d(TAG, "META: description/name search hit ${searched.size} tools")
                 return QueryResult(searched, categoryMatched = false)
             }
         }
 
-        if (isToolDiscoveryQuery(queryWords) || stemmedQuery.isNotEmpty()) {
-            val meta = localTools.firstOrNull { tool ->
-                tool.spec.name == "search_available_tools" &&
-                    isToolEnabled(tool.spec.name, ToolSource.LOCAL)
-            } ?: localTools.firstOrNull { tool ->
-                tool.spec.name == "list_tools" &&
-                    isToolEnabled(tool.spec.name, ToolSource.LOCAL)
-            }
+        // Non-discovery miss with leftover tokens — still offer meta-search when available
+        if (stemmedQuery.isNotEmpty()) {
+            val meta = findMetaSearchTool(aapRole)
             if (meta != null) {
                 Log.d(TAG, "META: injecting ${meta.spec.name}")
                 return QueryResult(listOf(meta), categoryMatched = false)
@@ -641,6 +661,20 @@ class ToolRouter(
         }
 
         return QueryResult(emptyList(), categoryMatched = false)
+    }
+
+    /** Prefer search_available_tools; never fall back to unfiltered list_tools for auditors. */
+    private fun findMetaSearchTool(aapRole: AapRole?): Tool? {
+        val search = localTools.firstOrNull { tool ->
+            tool.spec.name == "search_available_tools" &&
+                isToolEnabled(tool.spec.name, ToolSource.LOCAL)
+        }
+        if (search != null) return search
+        if (aapRole == AapRole.AUDITOR) return null
+        return localTools.firstOrNull { tool ->
+            tool.spec.name == "list_tools" &&
+                isToolEnabled(tool.spec.name, ToolSource.LOCAL)
+        }
     }
 
     private fun collectEnabledTools(
@@ -694,7 +728,7 @@ class ToolRouter(
             var score = nameOverlap * 10 + descOverlap * 3
             if (tool.spec.name.contains("list") || tool.spec.name.contains("ping")) score += 3
             if (tool.spec.name.contains("get") || tool.spec.name.contains("read") || tool.spec.name.contains("retrieve")) score += 1
-            if (nameOverlap > 0 && tool.isDestructive) score -= 5
+            if (overlap > 0 && tool.isDestructive) score -= 5
             ScoredTool(tool, score, overlap)
         }
         Log.d(TAG, "SCORES: ${scored.map { "${it.tool.spec.name}=${it.score}" }}")
@@ -709,6 +743,28 @@ class ToolRouter(
         val result = mutableListOf<Pair<Tool, ToolSource>>()
         localTools.forEach { result.add(it to ToolSource.LOCAL) }
         mcpTools.forEach { result.add(it to ToolSource.MCP) }
+        result
+    }
+
+    /**
+     * Like [getAllRegisteredTools] but applies the last routing role filter so
+     * [ListToolsLocalTool] does not disclose write tools to auditors.
+     */
+    fun getRoutableTools(): List<Pair<Tool, ToolSource>> = synchronized(this) {
+        val role = lastRoutingContext.aapRole
+        val result = mutableListOf<Pair<Tool, ToolSource>>()
+        localTools.forEach { tool ->
+            if (isToolEnabled(tool.spec.name, ToolSource.LOCAL) && passesRoleFilter(tool, role)) {
+                result.add(tool to ToolSource.LOCAL)
+            }
+        }
+        mcpTools.forEach { tool ->
+            if (isToolEnabled(tool.spec.name, ToolSource.MCP, tool.serverLabel) &&
+                passesRoleFilter(tool, role)
+            ) {
+                result.add(tool to ToolSource.MCP)
+            }
+        }
         result
     }
 

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -529,7 +529,8 @@ class ToolRouter(
     fun getToolsForQuery(
         query: String,
         serverConfigs: List<McpServerConfig> = emptyList(),
-        aapRole: AapRole? = null
+        /** Default OPERATOR for callers that omit role; pass explicit role from the active instance. Unknown/`null` fail-closes. */
+        aapRole: AapRole? = AapRole.OPERATOR
     ): QueryResult = synchronized(this) {
         lastRoutingContext = RoutingContext(serverConfigs, aapRole)
         val queryWords = tokenizeQuery(query)
@@ -663,14 +664,15 @@ class ToolRouter(
         return QueryResult(emptyList(), categoryMatched = false)
     }
 
-    /** Prefer search_available_tools; never fall back to unfiltered list_tools for auditors. */
+    /** Prefer search_available_tools; never fall back to unfiltered list_tools for auditors/unknown. */
     private fun findMetaSearchTool(aapRole: AapRole?): Tool? {
         val search = localTools.firstOrNull { tool ->
             tool.spec.name == "search_available_tools" &&
                 isToolEnabled(tool.spec.name, ToolSource.LOCAL)
         }
         if (search != null) return search
-        if (aapRole == AapRole.AUDITOR) return null
+        // null role = unknown → fail closed (same as auditor)
+        if (aapRole == null || aapRole == AapRole.AUDITOR) return null
         return localTools.firstOrNull { tool ->
             tool.spec.name == "list_tools" &&
                 isToolEnabled(tool.spec.name, ToolSource.LOCAL)
@@ -697,8 +699,15 @@ class ToolRouter(
         return enabledLocal + enabledMcp
     }
 
+    /**
+     * Fail-closed: [AapRole.AUDITOR] and unknown (`null`) hide destructive / write-suffix tools.
+     * [AapRole.ADMIN] and [AapRole.OPERATOR] see the full enabled set.
+     */
     private fun passesRoleFilter(tool: Tool, aapRole: AapRole?): Boolean {
-        if (aapRole != AapRole.AUDITOR) return true
+        when (aapRole) {
+            AapRole.ADMIN, AapRole.OPERATOR -> return true
+            AapRole.AUDITOR, null -> Unit
+        }
         if (tool.isDestructive) return false
         return WRITE_ACTIONS.none { action -> tool.spec.name.endsWith(action) }
     }
@@ -747,11 +756,14 @@ class ToolRouter(
     }
 
     /**
-     * Like [getAllRegisteredTools] but applies the last routing role filter so
+     * Like [getAllRegisteredTools] but applies a role filter so
      * [ListToolsLocalTool] does not disclose write tools to auditors.
+     *
+     * Prefer an explicit [aapRole] from the active instance; falls back to the
+     * last [getToolsForQuery] context. Unknown/`null` fail-closes like auditor.
      */
-    fun getRoutableTools(): List<Pair<Tool, ToolSource>> = synchronized(this) {
-        val role = lastRoutingContext.aapRole
+    fun getRoutableTools(aapRole: AapRole? = null): List<Pair<Tool, ToolSource>> = synchronized(this) {
+        val role = aapRole ?: lastRoutingContext.aapRole
         val result = mutableListOf<Pair<Tool, ToolSource>>()
         localTools.forEach { tool ->
             if (isToolEnabled(tool.spec.name, ToolSource.LOCAL) && passesRoleFilter(tool, role)) {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -294,6 +294,41 @@ class ToolRouter(
             "any", "been"
         )
 
+        private val GREETING_WORDS = setOf(
+            "hi", "hello", "hey", "thanks", "thank", "bye", "goodbye", "ok", "okay", "sure"
+        )
+
+        private val PRONOUN_WORDS = setOf("you", "we", "they", "he", "she", "it", "your", "our")
+
+        private val TOOL_DISCOVERY_WORDS = setOf(
+            "tools", "tool", "capabilities", "capable", "help", "actions", "functions"
+        )
+
+        /** Synonym expansion applied to query tokens before stemming (#120 Tier 1). */
+        val SYNONYMS = mapOf(
+            "playbook" to setOf("job", "template"),
+            "playbooks" to setOf("job", "template"),
+            "deploy" to setOf("launch", "run", "execute"),
+            "deployment" to setOf("launch", "job", "run"),
+            "provision" to setOf("launch", "run"),
+            "machine" to setOf("host", "server", "node", "instance"),
+            "machines" to setOf("host", "server", "node", "instance"),
+            "workstation" to setOf("host", "server", "machine"),
+            "workstations" to setOf("host", "server", "machine"),
+            "cred" to setOf("credential", "secret", "key"),
+            "creds" to setOf("credential", "secret", "key"),
+            "execute" to setOf("launch", "run", "job"),
+            "execution" to setOf("job", "run"),
+            "executions" to setOf("job", "run"),
+            "worker" to setOf("instance", "node"),
+            "workers" to setOf("instance", "node"),
+            "secret" to setOf("credential"),
+            "secrets" to setOf("credential"),
+            "vault" to setOf("credential", "secret"),
+            "automation" to setOf("job", "workflow"),
+            "ansible" to setOf("job", "playbook", "template"),
+        )
+
         private val TOOLSET_CATEGORY_MAP = mapOf(
             "job_management" to setOf(Category.JOBS),
             "inventory_management" to setOf(Category.INVENTORY),
@@ -355,6 +390,33 @@ class ToolRouter(
             val last = base.last()
             val prev = base[base.lastIndex - 1]
             return if (last == prev && last !in "aeiou") base.dropLast(1) else base
+        }
+
+        fun expandSynonyms(words: Set<String>): Set<String> {
+            val expanded = words.toMutableSet()
+            for (word in words) {
+                SYNONYMS[word]?.let { expanded.addAll(it) }
+            }
+            return expanded
+        }
+
+        fun tokenizeQuery(query: String): Set<String> =
+            query.lowercase().split(Regex("\\W+")).filter { it.isNotEmpty() }.toSet()
+
+        fun stemQueryTokens(queryWords: Set<String>): Set<String> {
+            val expanded = expandSynonyms(queryWords - STOP_WORDS)
+            return expanded.map { stem(it) }.filter { it.isNotEmpty() }.toSet()
+        }
+
+        private fun isTrivialQuery(queryWords: Set<String>): Boolean {
+            val meaningful = queryWords - STOP_WORDS - PRONOUN_WORDS - GREETING_WORDS
+            return meaningful.isEmpty()
+        }
+
+        private fun isToolDiscoveryQuery(queryWords: Set<String>): Boolean {
+            if (TOOL_DISCOVERY_WORDS.any { it in queryWords }) return true
+            // "what can you do?" — discovery intent without explicit "tools"
+            return "what" in queryWords && "do" in queryWords
         }
     }
 
@@ -441,19 +503,19 @@ class ToolRouter(
 
     fun getToolsForQuery(
         query: String,
-        serverConfigs: List<McpServerConfig> = emptyList()
+        serverConfigs: List<McpServerConfig> = emptyList(),
+        aapRole: AapRole? = null
     ): QueryResult = synchronized(this) {
-        val queryWords = query.lowercase().split(Regex("\\W+")).toSet()
-        val stemmedQuery = (queryWords - STOP_WORDS).map { stem(it) }.toSet()
-        Log.d(TAG, "QUERY: words=$queryWords, stemmed=$stemmedQuery")
+        val queryWords = tokenizeQuery(query)
+        val stemmedQuery = stemQueryTokens(queryWords)
+        Log.d(TAG, "QUERY: words=$queryWords, stemmed=$stemmedQuery, role=$aapRole")
 
         val matchedCategories = Category.entries.filter { category ->
             category.stemmedKeywords.any { it in stemmedQuery }
         }
 
         if (matchedCategories.isEmpty()) {
-            Log.d(TAG, "QUERY: no categories matched")
-            return@synchronized QueryResult(emptyList(), categoryMatched = false)
+            return@synchronized noCategoryMatchFallback(queryWords, stemmedQuery, serverConfigs, aapRole)
         }
         Log.d(TAG, "QUERY: matched categories=${matchedCategories.map { it.name }}")
 
@@ -466,7 +528,8 @@ class ToolRouter(
 
         val filteredLocal = localTools.filter { tool ->
             tool.spec.name in matchedLocalNames &&
-                isToolEnabled(tool.spec.name, ToolSource.LOCAL)
+                isToolEnabled(tool.spec.name, ToolSource.LOCAL) &&
+                passesRoleFilter(tool, aapRole)
         }
 
         val routedMcp = mutableListOf<Tool>()
@@ -474,6 +537,7 @@ class ToolRouter(
 
         for (tool in mcpTools) {
             if (!isToolEnabled(tool.spec.name, ToolSource.MCP, tool.serverLabel)) continue
+            if (!passesRoleFilter(tool, aapRole)) continue
 
             val passesReadOnly = tool.serverLabel !in readOnlyLabels ||
                 WRITE_ACTIONS.none { action -> tool.spec.name.endsWith(action) }
@@ -505,6 +569,90 @@ class ToolRouter(
         QueryResult(allCherryPicked, categoryMatched = true)
     }
 
+    /**
+     * Search all enabled tools by name + description tokens (meta-search / #120).
+     * Stable: score desc, then name asc.
+     */
+    fun searchAvailableTools(
+        query: String,
+        maxResults: Int = 20,
+        serverConfigs: List<McpServerConfig> = emptyList(),
+        aapRole: AapRole? = null
+    ): List<Tool> = synchronized(this) {
+        val stemmedQuery = stemQueryTokens(tokenizeQuery(query))
+        if (stemmedQuery.isEmpty()) return emptyList()
+        val candidates = collectEnabledTools(serverConfigs, aapRole)
+        return cherryPick(candidates, stemmedQuery, requireOverlap = true).take(maxResults.coerceAtLeast(0))
+    }
+
+    private fun noCategoryMatchFallback(
+        queryWords: Set<String>,
+        stemmedQuery: Set<String>,
+        serverConfigs: List<McpServerConfig>,
+        aapRole: AapRole?
+    ): QueryResult {
+        Log.d(TAG, "QUERY: no categories matched — meta-search fallback")
+
+        if (isTrivialQuery(queryWords) && !isToolDiscoveryQuery(queryWords)) {
+            Log.d(TAG, "QUERY: trivial/greeting — empty tools")
+            return QueryResult(emptyList(), categoryMatched = false)
+        }
+
+        if (stemmedQuery.isNotEmpty()) {
+            val searched = cherryPick(
+                collectEnabledTools(serverConfigs, aapRole),
+                stemmedQuery,
+                requireOverlap = true
+            )
+            if (searched.isNotEmpty()) {
+                Log.d(TAG, "META: description/name search hit ${searched.size} tools")
+                return QueryResult(searched, categoryMatched = false)
+            }
+        }
+
+        if (isToolDiscoveryQuery(queryWords) || stemmedQuery.isNotEmpty()) {
+            val meta = localTools.firstOrNull { tool ->
+                tool.spec.name == "search_available_tools" &&
+                    isToolEnabled(tool.spec.name, ToolSource.LOCAL)
+            } ?: localTools.firstOrNull { tool ->
+                tool.spec.name == "list_tools" &&
+                    isToolEnabled(tool.spec.name, ToolSource.LOCAL)
+            }
+            if (meta != null) {
+                Log.d(TAG, "META: injecting ${meta.spec.name}")
+                return QueryResult(listOf(meta), categoryMatched = false)
+            }
+        }
+
+        return QueryResult(emptyList(), categoryMatched = false)
+    }
+
+    private fun collectEnabledTools(
+        serverConfigs: List<McpServerConfig>,
+        aapRole: AapRole?
+    ): List<Tool> {
+        val readOnlyLabels = serverConfigs
+            .filter { it.readOnly }
+            .map { it.label }
+            .toSet()
+        val enabledLocal = localTools.filter {
+            isToolEnabled(it.spec.name, ToolSource.LOCAL) && passesRoleFilter(it, aapRole)
+        }
+        val enabledMcp = mcpTools.filter { tool ->
+            isToolEnabled(tool.spec.name, ToolSource.MCP, tool.serverLabel) &&
+                passesRoleFilter(tool, aapRole) &&
+                (tool.serverLabel !in readOnlyLabels ||
+                    WRITE_ACTIONS.none { action -> tool.spec.name.endsWith(action) })
+        }
+        return enabledLocal + enabledMcp
+    }
+
+    private fun passesRoleFilter(tool: Tool, aapRole: AapRole?): Boolean {
+        if (aapRole != AapRole.AUDITOR) return true
+        if (tool.isDestructive) return false
+        return WRITE_ACTIONS.none { action -> tool.spec.name.endsWith(action) }
+    }
+
     private data class ScoredTool(val tool: Tool, val score: Int, val overlap: Int)
 
     private fun cherryPick(
@@ -516,18 +664,28 @@ class ToolRouter(
             val nameParts = tool.spec.name
                 .split(".", "_")
                 .map { stem(it) }
+                .filter { it.isNotEmpty() }
                 .toSet()
-            val overlap = (nameParts intersect stemmedQuery).size
-            var score = overlap * 10
+            val descParts = tool.spec.description.lowercase()
+                .split(Regex("\\W+"))
+                .filter { it.isNotEmpty() && it !in STOP_WORDS }
+                .map { stem(it) }
+                .filter { it.isNotEmpty() }
+                .toSet()
+            val nameOverlap = (nameParts intersect stemmedQuery).size
+            val descOverlap = (descParts intersect stemmedQuery).size
+            val overlap = nameOverlap + descOverlap
+            var score = nameOverlap * 10 + descOverlap * 3
             if (tool.spec.name.contains("list") || tool.spec.name.contains("ping")) score += 3
             if (tool.spec.name.contains("get") || tool.spec.name.contains("read") || tool.spec.name.contains("retrieve")) score += 1
-            if (overlap > 0 && tool.isDestructive) score -= 5
+            if (nameOverlap > 0 && tool.isDestructive) score -= 5
             ScoredTool(tool, score, overlap)
         }
         Log.d(TAG, "SCORES: ${scored.map { "${it.tool.spec.name}=${it.score}" }}")
         return scored
             .filter { it.score > 0 && (!requireOverlap || it.overlap > 0) }
-            .sortedByDescending { it.score }
+            // #439: secondary sort by name for stable KV-cache-friendly ordering
+            .sortedWith(compareByDescending<ScoredTool> { it.score }.thenBy { it.tool.spec.name })
             .map { it.tool }
     }
 

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -52,6 +52,13 @@ class ToolRouter(
     private val userDisabled = mutableSetOf<ToolKey>()
     private val userEnabled = mutableSetOf<ToolKey>()
 
+    /** Last role/config from [getToolsForQuery] — used by meta-search so LLM tool calls honor filters. */
+    private data class RoutingContext(
+        val serverConfigs: List<McpServerConfig> = emptyList(),
+        val aapRole: AapRole? = null
+    )
+    private var lastRoutingContext = RoutingContext()
+
     private val initialized = atomic(false)
 
     init {
@@ -357,6 +364,8 @@ class ToolRouter(
                     w.dropLast(3) // execution → execut
                 w.endsWith("sion") && w.length > 5 ->
                     w.dropLast(3)
+                // Keep "setting" intact — stripping -ing yields "set" and false-matches CONFIGURATION
+                w == "setting" -> w
                 w.endsWith("ing") && w.length > 5 ->
                     undouble(w.dropLast(3))
                 w.endsWith("ed") && w.length > 4 ->
@@ -506,6 +515,7 @@ class ToolRouter(
         serverConfigs: List<McpServerConfig> = emptyList(),
         aapRole: AapRole? = null
     ): QueryResult = synchronized(this) {
+        lastRoutingContext = RoutingContext(serverConfigs, aapRole)
         val queryWords = tokenizeQuery(query)
         val stemmedQuery = stemQueryTokens(queryWords)
         Log.d(TAG, "QUERY: words=$queryWords, stemmed=$stemmedQuery, role=$aapRole")
@@ -572,6 +582,10 @@ class ToolRouter(
     /**
      * Search all enabled tools by name + description tokens (meta-search / #120).
      * Stable: score desc, then name asc.
+     *
+     * When [serverConfigs] is empty and [aapRole] is null, reuses the last
+     * [getToolsForQuery] routing context so auditor / read-only filters apply
+     * to LLM-invoked meta-search.
      */
     fun searchAvailableTools(
         query: String,
@@ -581,7 +595,9 @@ class ToolRouter(
     ): List<Tool> = synchronized(this) {
         val stemmedQuery = stemQueryTokens(tokenizeQuery(query))
         if (stemmedQuery.isEmpty()) return emptyList()
-        val candidates = collectEnabledTools(serverConfigs, aapRole)
+        val effectiveConfigs = serverConfigs.ifEmpty { lastRoutingContext.serverConfigs }
+        val effectiveRole = aapRole ?: lastRoutingContext.aapRole
+        val candidates = collectEnabledTools(effectiveConfigs, effectiveRole)
         return cherryPick(candidates, stemmedQuery, requireOverlap = true).take(maxResults.coerceAtLeast(0))
     }
 

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/SearchAvailableToolsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/SearchAvailableToolsLocalTool.kt
@@ -2,16 +2,19 @@ package io.github.leogallego.ansiblejane.assistant.tools.local
 
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.serialization.typeToken
-import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
 import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import kotlinx.serialization.Serializable
 
 /**
  * Meta-search tool injected when category routing finds no match (#120 Tier 1).
  * Searches registered tool names + descriptions and returns matching summaries.
+ *
+ * Depends on a search lambda (not ToolRouter directly) to keep Tools → Engine
+ * layer direction correct — DI closes over ToolRouter + request context.
  */
 class SearchAvailableToolsLocalTool(
-    private val routerProvider: () -> ToolRouter
+    private val search: (query: String, maxResults: Int) -> List<Tool>
 ) : AapLocalTool<SearchAvailableToolsLocalTool.Args>(
     typeToken<Args>(),
     Args.serializer(),
@@ -28,7 +31,7 @@ class SearchAvailableToolsLocalTool(
     )
 
     override suspend fun execute(args: Args): String {
-        val hits = routerProvider().searchAvailableTools(args.query, maxResults = args.limit.coerceIn(1, 50))
+        val hits = search(args.query, args.limit.coerceIn(1, 50))
         if (hits.isEmpty()) {
             return "No tools matched \"${args.query}\". Try different keywords " +
                 "(e.g. hosts, jobs, credentials, eda)."

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/SearchAvailableToolsLocalTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/local/SearchAvailableToolsLocalTool.kt
@@ -1,0 +1,43 @@
+package io.github.leogallego.ansiblejane.assistant.tools.local
+
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.serialization.typeToken
+import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
+import io.github.leogallego.ansiblejane.assistant.tools.AapLocalTool
+import kotlinx.serialization.Serializable
+
+/**
+ * Meta-search tool injected when category routing finds no match (#120 Tier 1).
+ * Searches registered tool names + descriptions and returns matching summaries.
+ */
+class SearchAvailableToolsLocalTool(
+    private val routerProvider: () -> ToolRouter
+) : AapLocalTool<SearchAvailableToolsLocalTool.Args>(
+    typeToken<Args>(),
+    Args.serializer(),
+    name = "search_available_tools",
+    description = "Search available tools by name or description when the current tools " +
+        "do not cover the user's request. Pass a short natural-language query."
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("Natural-language search query for tools")
+        val query: String,
+        @property:LLMDescription("Maximum number of tools to return (default 10)")
+        val limit: Int = 10,
+    )
+
+    override suspend fun execute(args: Args): String {
+        val hits = routerProvider().searchAvailableTools(args.query, maxResults = args.limit.coerceIn(1, 50))
+        if (hits.isEmpty()) {
+            return "No tools matched \"${args.query}\". Try different keywords " +
+                "(e.g. hosts, jobs, credentials, eda)."
+        }
+        val sb = StringBuilder()
+        sb.appendLine("Matching tools (${hits.size}):")
+        hits.forEach { tool ->
+            sb.appendLine("- ${tool.spec.name}: ${tool.spec.description}")
+        }
+        return sb.toString()
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/AuthRepository.kt
@@ -47,6 +47,11 @@ class AuthRepository(
                 alias = alias,
                 existingId = existingInstanceId
             )
+            tokenManager.updateUserRole(
+                instanceId = instanceId,
+                isSuperuser = user.isSuperuser,
+                isSystemAuditor = user.isSystemAuditor
+            )
 
             apiProvider.evictInstance(instanceId)
             launchDiscovery(instanceId, baseUrl, token, apiVersion, trustSelfSigned)
@@ -82,6 +87,11 @@ class AuthRepository(
                 alias = instance.alias,
                 existingId = instanceId
             )
+            tokenManager.updateUserRole(
+                instanceId = instanceId,
+                isSuperuser = user.isSuperuser,
+                isSystemAuditor = user.isSystemAuditor
+            )
 
             apiProvider.evictInstance(instanceId)
             launchDiscovery(instanceId, instance.baseUrl, newToken, apiVersion, trustSelfSigned)
@@ -112,6 +122,11 @@ class AuthRepository(
                 api.getMe().results.firstOrNull()
             } ?: return CredentialStatus.ValidationFailed(
                 Exception("No user data returned")
+            )
+            tokenManager.updateUserRole(
+                instanceId = activeInstance.id,
+                isSuperuser = user.isSuperuser,
+                isSystemAuditor = user.isSystemAuditor
             )
             CredentialStatus.Valid(user)
         } catch (e: CancellationException) {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ITokenManager.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ITokenManager.kt
@@ -48,6 +48,13 @@ interface ITokenManager {
         servers: List<McpServerConfig>?
     )
 
+    /** Persist `/api/v2/me/` RBAC flags for ToolRouter auditor filtering. */
+    suspend fun updateUserRole(
+        instanceId: String,
+        isSuperuser: Boolean,
+        isSystemAuditor: Boolean
+    )
+
     suspend fun clearCredentials()
 
     suspend fun saveLlmApiKey(providerKey: String, apiKey: String)

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
@@ -37,7 +37,9 @@ data class SerializedInstance(
     val certFingerprint: String? = null,
     val mcpServerUrls: List<McpServerConfig>? = null,
     val mcpEnabled: Boolean = false,
-    val instanceInfo: InstanceInfo? = null
+    val instanceInfo: InstanceInfo? = null,
+    val isSuperuser: Boolean = false,
+    val isSystemAuditor: Boolean = false
 )
 
 @Serializable
@@ -96,7 +98,9 @@ class TokenManager(
             certFingerprint = serialized.certFingerprint,
             mcpServerUrls = serialized.mcpServerUrls?.map { decryptHeaders(it) },
             mcpEnabled = serialized.mcpEnabled,
-            instanceInfo = serialized.instanceInfo
+            instanceInfo = serialized.instanceInfo,
+            isSuperuser = serialized.isSuperuser,
+            isSystemAuditor = serialized.isSystemAuditor
         )
     }
 
@@ -111,7 +115,9 @@ class TokenManager(
             certFingerprint = instance.certFingerprint,
             mcpServerUrls = instance.mcpServerUrls?.map { encryptHeaders(it) },
             mcpEnabled = instance.mcpEnabled,
-            instanceInfo = instance.instanceInfo
+            instanceInfo = instance.instanceInfo,
+            isSuperuser = instance.isSuperuser,
+            isSystemAuditor = instance.isSystemAuditor
         )
     }
 
@@ -333,6 +339,24 @@ class TokenManager(
                 serialized.copy(
                     mcpEnabled = enabled,
                     mcpServerUrls = servers?.map { encryptHeaders(it) }
+                )
+            } else serialized
+        }
+        writeState(state.copy(instances = updatedInstances))
+    }
+
+    override suspend fun updateUserRole(
+        instanceId: String,
+        isSuperuser: Boolean,
+        isSystemAuditor: Boolean
+    ) {
+        val state = readState()
+        if (state.instances.none { it.id == instanceId }) return
+        val updatedInstances = state.instances.map { serialized ->
+            if (serialized.id == instanceId) {
+                serialized.copy(
+                    isSuperuser = isSuperuser,
+                    isSystemAuditor = isSystemAuditor
                 )
             } else serialized
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
@@ -39,7 +39,8 @@ data class SerializedInstance(
     val mcpEnabled: Boolean = false,
     val instanceInfo: InstanceInfo? = null,
     val isSuperuser: Boolean = false,
-    val isSystemAuditor: Boolean = false
+    val isSystemAuditor: Boolean = false,
+    val userRoleFetched: Boolean = false
 )
 
 @Serializable
@@ -100,7 +101,8 @@ class TokenManager(
             mcpEnabled = serialized.mcpEnabled,
             instanceInfo = serialized.instanceInfo,
             isSuperuser = serialized.isSuperuser,
-            isSystemAuditor = serialized.isSystemAuditor
+            isSystemAuditor = serialized.isSystemAuditor,
+            userRoleFetched = serialized.userRoleFetched
         )
     }
 
@@ -117,7 +119,8 @@ class TokenManager(
             mcpEnabled = instance.mcpEnabled,
             instanceInfo = instance.instanceInfo,
             isSuperuser = instance.isSuperuser,
-            isSystemAuditor = instance.isSystemAuditor
+            isSystemAuditor = instance.isSystemAuditor,
+            userRoleFetched = instance.userRoleFetched
         )
     }
 
@@ -356,7 +359,8 @@ class TokenManager(
             if (serialized.id == instanceId) {
                 serialized.copy(
                     isSuperuser = isSuperuser,
-                    isSystemAuditor = isSystemAuditor
+                    isSystemAuditor = isSystemAuditor,
+                    userRoleFetched = true
                 )
             } else serialized
         }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/AapInstance.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/AapInstance.kt
@@ -24,7 +24,10 @@ data class AapInstance(
     val certFingerprint: String? = null,
     val mcpServerUrls: List<McpServerConfig>? = null,
     val mcpEnabled: Boolean = false,
-    val instanceInfo: InstanceInfo? = null
+    val instanceInfo: InstanceInfo? = null,
+    /** From `/api/v2/me/` — used by ToolRouter auditor filtering (#120). */
+    val isSuperuser: Boolean = false,
+    val isSystemAuditor: Boolean = false
 ) {
     val displayLabel: String
         get() = alias ?: extractHost(baseUrl)

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/AapInstance.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/AapInstance.kt
@@ -27,7 +27,12 @@ data class AapInstance(
     val instanceInfo: InstanceInfo? = null,
     /** From `/api/v2/me/` — used by ToolRouter auditor filtering (#120). */
     val isSuperuser: Boolean = false,
-    val isSystemAuditor: Boolean = false
+    val isSystemAuditor: Boolean = false,
+    /**
+     * True after [io.github.leogallego.ansiblejane.data.ITokenManager.updateUserRole]
+     * persists `/api/v2/me/` flags. Until then routing fail-closes as auditor.
+     */
+    val userRoleFetched: Boolean = false
 ) {
     val displayLabel: String
         get() = alias ?: extractHost(baseUrl)

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/User.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/User.kt
@@ -10,5 +10,6 @@ data class User(
     @SerialName("first_name") val firstName: String = "",
     @SerialName("last_name") val lastName: String = "",
     val email: String = "",
-    @SerialName("is_superuser") val isSuperuser: Boolean = false
+    @SerialName("is_superuser") val isSuperuser: Boolean = false,
+    @SerialName("is_system_auditor") val isSystemAuditor: Boolean = false
 )

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineTest.kt
@@ -133,6 +133,52 @@ class ChatEngineTest {
             awaitComplete()
         }
     }
+
+    @Test
+    fun `toolDescriptors SHOULD be sorted by name for stable prompt caching`() = runTest {
+        val provider = CapturingLlmProvider()
+        val executor = ToolExecutor(emptyList())
+        val engine = ChatEngine(provider, executor)
+        val tools = listOf(
+            io.github.leogallego.ansiblejane.assistant.tools.ToolSpec(
+                "zeta_tool", "Z", kotlinx.serialization.json.JsonObject(emptyMap())
+            ),
+            io.github.leogallego.ansiblejane.assistant.tools.ToolSpec(
+                "alpha_tool", "A", kotlinx.serialization.json.JsonObject(emptyMap())
+            ),
+            io.github.leogallego.ansiblejane.assistant.tools.ToolSpec(
+                "middle_tool", "M", kotlinx.serialization.json.JsonObject(emptyMap())
+            ),
+        )
+
+        engine.processMessage("hi", emptyList(), tools).test {
+            while (awaitItem() !is ChatEvent.AssistantMessage) { /* drain */ }
+            awaitComplete()
+        }
+
+        assertEquals(
+            listOf("alpha_tool", "middle_tool", "zeta_tool"),
+            provider.lastToolNames
+        )
+    }
+}
+
+private class CapturingLlmProvider : LlmProvider {
+    var lastToolNames: List<String> = emptyList()
+
+    override fun generateStream(
+        prompt: Prompt,
+        tools: List<ToolDescriptor>,
+        maxTokens: Int?
+    ): Flow<StreamFrame> = flow {
+        lastToolNames = tools.map { it.name }
+        emit(StreamFrame.TextDelta("ok"))
+        emit(StreamFrame.End(finishReason = "stop"))
+    }
+
+    override fun isAvailable(): Boolean = true
+    override fun modelInfo(): ModelInfo = ModelInfo("fake-model")
+    override fun close() {}
 }
 
 private data class FakeToolCall(val id: String, val name: String, val arguments: String)

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -827,6 +827,34 @@ class ToolRouterTest {
         assertEquals("inventory", ToolRouter.stem("inventories"))
     }
 
+    @Test
+    fun `stem SHOULD strip ing ed er and tion suffixes`() {
+        assertEquals("run", ToolRouter.stem("running"))
+        assertEquals("monitor", ToolRouter.stem("monitoring"))
+        assertEquals("fail", ToolRouter.stem("failed"))
+        assertEquals("launch", ToolRouter.stem("launched"))
+        assertEquals("launch", ToolRouter.stem("launcher"))
+        assertEquals("execut", ToolRouter.stem("execution"))
+        assertEquals("execut", ToolRouter.stem("executions"))
+        assertEquals("execut", ToolRouter.stem("execute"))
+    }
+
+    @Test
+    fun `SHOULD match JOBS WHEN query uses launcher stemmed to launch`() {
+        val tools = listOf(
+            localTool("launch_job", destructive = true),
+            localTool("list_job_templates"),
+            localTool("list_hosts")
+        )
+        router.registerLocalTools(tools)
+
+        val result = router.getToolsForQuery("use the launcher").tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("launch_job" in names || "list_job_templates" in names)
+        assertFalse("list_hosts" in names)
+    }
+
     // --- New keyword tests ---
 
     @Test

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -850,6 +850,14 @@ class ToolRouterTest {
     }
 
     @Test
+    fun `stem SHOULD preserve workstation and unify worker forms`() {
+        assertEquals("workstation", ToolRouter.stem("workstation"))
+        assertEquals("workstation", ToolRouter.stem("workstations"))
+        assertEquals("work", ToolRouter.stem("worker"))
+        assertEquals("work", ToolRouter.stem("workers"))
+    }
+
+    @Test
     fun `SHOULD NOT match CONFIGURATION WHEN query is please set a reminder`() {
         router.registerLocalTools(
             listOf(
@@ -860,7 +868,8 @@ class ToolRouterTest {
         )
         val result = router.getToolsForQuery("please set a reminder")
         assertFalse(result.categoryMatched)
-        assertTrue(result.tools.isEmpty() || result.tools.none { it.spec.name == "get_settings" })
+        assertTrue(result.tools.none { it.spec.name == "get_settings" })
+        assertTrue(result.tools.isEmpty())
     }
 
     @Test
@@ -1646,6 +1655,22 @@ class ToolRouterTest {
     }
 
     @Test
+    fun `SHOULD match JOBS WHEN query uses inflected deploy synonym`() {
+        val tools = listOf(
+            localTool("launch_job", destructive = true),
+            localTool("list_job_templates"),
+            localTool("list_hosts")
+        )
+        router.registerLocalTools(tools)
+
+        val result = router.getToolsForQuery("deploying my application").tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("launch_job" in names || "list_job_templates" in names)
+        assertFalse("list_hosts" in names)
+    }
+
+    @Test
     fun `SHOULD match INVENTORY WHEN query uses workstation synonym for host`() {
         val tools = listOf(
             localTool("list_hosts"),
@@ -1693,6 +1718,43 @@ class ToolRouterTest {
         val result = router.getToolsForQuery("what can you do?")
         assertFalse(result.categoryMatched)
         assertEquals(listOf("search_available_tools"), result.tools.map { it.spec.name })
+    }
+
+    @Test
+    fun `SHOULD inject only search_available_tools WHEN query mentions tools`() {
+        val search = localTool("search_available_tools", description = "Search available tools by name")
+        val listTools = localTool("list_tools", description = "List all available tools")
+        val hosts = localTool("list_hosts", description = "List inventory hosts")
+        router.registerLocalTools(listOf(search, listTools, hosts))
+
+        for (query in listOf("what tools do you have?", "list my tools", "show tool capabilities")) {
+            val result = router.getToolsForQuery(query)
+            assertFalse(result.categoryMatched, query)
+            assertEquals(
+                listOf("search_available_tools"),
+                result.tools.map { it.spec.name },
+                "Expected single meta inject for: $query"
+            )
+        }
+    }
+
+    @Test
+    fun `meta-search fallback SHOULD cap results at MAX_META_SEARCH_RESULTS`() {
+        val tools = (1..30).map { i ->
+            localTool(
+                "custom_tool_$i",
+                description = "Unique widget gadget helper number $i"
+            )
+        }
+        router.registerLocalTools(tools)
+
+        val result = router.getToolsForQuery("widget gadget")
+        assertFalse(result.categoryMatched)
+        assertTrue(result.tools.isNotEmpty())
+        assertTrue(
+            result.tools.size <= ToolRouter.MAX_META_SEARCH_RESULTS,
+            "Expected <= ${ToolRouter.MAX_META_SEARCH_RESULTS}, got ${result.tools.size}"
+        )
     }
 
     @Test
@@ -1830,7 +1892,22 @@ class ToolRouterTest {
 
         val hits = router.searchAvailableTools("launch job")
         assertFalse(hits.any { it.spec.name == "launch_job" })
-        assertTrue(hits.any { it.spec.name == "list_job_templates" } || hits.isEmpty())
+        assertTrue(hits.any { it.spec.name == "list_job_templates" })
+    }
+
+    @Test
+    fun `getRoutableTools SHOULD hide destructive tools for AUDITOR context`() {
+        router.registerLocalTools(
+            listOf(
+                localTool("list_job_templates"),
+                localTool("launch_job", destructive = true)
+            )
+        )
+        router.getToolsForQuery("list templates", aapRole = AapRole.AUDITOR)
+
+        val names = router.getRoutableTools().map { it.first.spec.name }
+        assertTrue("list_job_templates" in names)
+        assertFalse("launch_job" in names)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -844,6 +844,35 @@ class ToolRouterTest {
     }
 
     @Test
+    fun `stem SHOULD keep setting intact to avoid set false-match`() {
+        assertEquals("setting", ToolRouter.stem("setting"))
+        assertEquals("setting", ToolRouter.stem("settings"))
+    }
+
+    @Test
+    fun `SHOULD NOT match CONFIGURATION WHEN query is please set a reminder`() {
+        router.registerLocalTools(
+            listOf(
+                localTool("get_settings"),
+                localTool("list_notification_templates"),
+                localTool("list_jobs")
+            )
+        )
+        val result = router.getToolsForQuery("please set a reminder")
+        assertFalse(result.categoryMatched)
+        assertTrue(result.tools.isEmpty() || result.tools.none { it.spec.name == "get_settings" })
+    }
+
+    @Test
+    fun `SHOULD match CONFIGURATION WHEN query asks for settings`() {
+        router.registerLocalTools(
+            listOf(localTool("get_settings"), localTool("list_hosts"))
+        )
+        val result = router.getToolsForQuery("show settings").tools
+        assertTrue(result.any { it.spec.name == "get_settings" })
+    }
+
+    @Test
     fun `SHOULD match JOBS WHEN query uses launcher stemmed to launch`() {
         val tools = listOf(
             localTool("launch_job", destructive = true),
@@ -1786,5 +1815,44 @@ class ToolRouterTest {
             AapRole.OPERATOR,
             User(3, "op").toAapRole()
         )
+    }
+
+    @Test
+    fun `searchAvailableTools SHOULD honor AUDITOR from last getToolsForQuery context`() {
+        router.registerLocalTools(
+            listOf(
+                localTool("list_job_templates"),
+                localTool("launch_job", destructive = true)
+            )
+        )
+        // Seed routing context with auditor role
+        router.getToolsForQuery("list job templates", aapRole = AapRole.AUDITOR)
+
+        val hits = router.searchAvailableTools("launch job")
+        assertFalse(hits.any { it.spec.name == "launch_job" })
+        assertTrue(hits.any { it.spec.name == "list_job_templates" } || hits.isEmpty())
+    }
+
+    @Test
+    fun `searchAvailableTools SHOULD filter MCP write tools for AUDITOR`() {
+        router.registerMcpTools(
+            listOf(
+                mcpTool("job_templates_list", toolset = "job_management"),
+                mcpTool("job_templates_launch_create", toolset = "job_management")
+            )
+        )
+        router.getToolsForQuery("list templates", aapRole = AapRole.AUDITOR)
+
+        val hits = router.searchAvailableTools("launch create template")
+        assertFalse(hits.any { it.spec.name.endsWith("_create") || it.spec.name.contains("launch") })
+    }
+
+    @Test
+    fun `AapInstance toAapRole SHOULD map persisted flags`() {
+        val auditor = io.github.leogallego.ansiblejane.model.AapInstance(
+            id = "1", baseUrl = "https://aap.example", token = "t",
+            isSystemAuditor = true
+        )
+        assertEquals(AapRole.AUDITOR, auditor.toAapRole())
     }
 }

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -1,6 +1,7 @@
 package io.github.leogallego.ansiblejane.assistant.engine
 
 import io.github.leogallego.ansiblejane.TestOnly
+import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolStub
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
@@ -1928,8 +1929,96 @@ class ToolRouterTest {
     fun `AapInstance toAapRole SHOULD map persisted flags`() {
         val auditor = io.github.leogallego.ansiblejane.model.AapInstance(
             id = "1", baseUrl = "https://aap.example", token = "t",
-            isSystemAuditor = true
+            isSystemAuditor = true,
+            userRoleFetched = true
         )
         assertEquals(AapRole.AUDITOR, auditor.toAapRole())
+    }
+
+    @Test
+    fun `AapInstance toAapRole SHOULD fail closed WHEN userRoleFetched is false`() {
+        val unknown = io.github.leogallego.ansiblejane.model.AapInstance(
+            id = "1", baseUrl = "https://aap.example", token = "t",
+            isSuperuser = true // ignored until fetched
+        )
+        assertEquals(AapRole.AUDITOR, unknown.toAapRole())
+
+        val operator = unknown.copy(
+            isSuperuser = false,
+            isSystemAuditor = false,
+            userRoleFetched = true
+        )
+        assertEquals(AapRole.OPERATOR, operator.toAapRole())
+    }
+
+    @Test
+    fun `null aapRole SHOULD fail closed like AUDITOR`() {
+        val tools = listOf(
+            localTool("list_job_templates"),
+            localTool("launch_job", destructive = true)
+        )
+        router.registerLocalTools(tools)
+
+        val result = router.getToolsForQuery(
+            "launch a job template",
+            aapRole = null
+        ).tools
+        assertFalse(result.any { it.spec.name == "launch_job" })
+    }
+
+    @Test
+    fun `getRoutableTools SHOULD hide destructive tools WHEN explicit AUDITOR without prior routing`() {
+        router.registerLocalTools(
+            listOf(
+                localTool("list_job_templates"),
+                localTool("launch_job", destructive = true)
+            )
+        )
+
+        val names = router.getRoutableTools(AapRole.AUDITOR).map { it.first.spec.name }
+        assertTrue("list_job_templates" in names)
+        assertFalse("launch_job" in names)
+    }
+
+    @Test
+    fun `getRoutableTools SHOULD fail closed WHEN role unknown and no routing context`() {
+        router.registerLocalTools(
+            listOf(
+                localTool("list_job_templates"),
+                localTool("launch_job", destructive = true)
+            )
+        )
+
+        val names = router.getRoutableTools(aapRole = null).map { it.first.spec.name }
+        assertTrue("list_job_templates" in names)
+        assertFalse("launch_job" in names)
+    }
+
+    @Test
+    fun `DESTRUCTIVE_LOCAL_TOOL_NAMES SHOULD all be hidden from AUDITOR when flagged`() {
+        val tools = DESTRUCTIVE_LOCAL_TOOL_NAMES.map { localTool(it, destructive = true) } +
+            localTool("list_jobs")
+        router.registerLocalTools(tools)
+
+        val names = router.getToolsForQuery(
+            "launch approve deny toggle job workflow schedule",
+            aapRole = AapRole.AUDITOR
+        ).tools.map { it.spec.name }.toSet()
+
+        for (writeName in DESTRUCTIVE_LOCAL_TOOL_NAMES) {
+            assertFalse(writeName in names, "$writeName should be hidden from auditor")
+        }
+        assertTrue("list_jobs" in names)
+    }
+
+    @Test
+    fun `DESTRUCTIVE_LOCAL_TOOL_NAMES SHOULD not rely on WRITE_SUFFIXES alone`() {
+        for (name in DESTRUCTIVE_LOCAL_TOOL_NAMES) {
+            val matchedBySuffix = Tool.WRITE_SUFFIXES.any { name.endsWith(it) }
+            assertFalse(
+                matchedBySuffix,
+                "$name unexpectedly matches WRITE_SUFFIXES — remove from DESTRUCTIVE_LOCAL_TOOL_NAMES"
+            )
+        }
     }
 }

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -7,6 +7,7 @@ import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
 import io.github.leogallego.ansiblejane.model.McpServerConfig
+import io.github.leogallego.ansiblejane.model.User
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -52,8 +53,12 @@ class ToolRouterTest {
         ToolStub(name, serverLabel = serverLabel, toolset = toolset,
             description = "[$serverLabel] description of $name")
 
-    private fun localTool(name: String, destructive: Boolean = false) = object : LocalTool {
-        override val spec = ToolSpec(name, "Local: $name", JsonObject(emptyMap()))
+    private fun localTool(
+        name: String,
+        destructive: Boolean = false,
+        description: String = "Local: $name"
+    ) = object : LocalTool {
+        override val spec = ToolSpec(name, description, JsonObject(emptyMap()))
         override val isDestructive = destructive
         override suspend fun execute(args: JsonObject) = ToolResult(success = true)
     }
@@ -122,7 +127,6 @@ class ToolRouterTest {
 
         assertTrue(router.getToolsForQuery("hi").tools.isEmpty())
         assertTrue(router.getToolsForQuery("hello there").tools.isEmpty())
-        assertTrue(router.getToolsForQuery("what can you do?").tools.isEmpty())
         assertTrue(router.getToolsForQuery("thanks").tools.isEmpty())
     }
 
@@ -1591,6 +1595,196 @@ class ToolRouterTest {
         assertTrue(
             notFound.isEmpty(),
             "OVERLAP_MAPPING values not matching verified server tools: $notFound"
+        )
+    }
+
+    // --- Synonym expansion (#120 Tier 1) ---
+
+    @Test
+    fun `SHOULD match JOBS WHEN query uses deploy synonym`() {
+        val tools = listOf(
+            localTool("launch_job", destructive = true),
+            localTool("list_job_templates"),
+            localTool("list_hosts")
+        )
+        router.registerLocalTools(tools)
+
+        val result = router.getToolsForQuery("deploy my application").tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("launch_job" in names || "list_job_templates" in names)
+        assertFalse("list_hosts" in names)
+    }
+
+    @Test
+    fun `SHOULD match INVENTORY WHEN query uses workstation synonym for host`() {
+        val tools = listOf(
+            localTool("list_hosts"),
+            localTool("list_inventories"),
+            localTool("list_jobs")
+        )
+        router.registerLocalTools(tools)
+
+        val result = router.getToolsForQuery("list workstations").tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("list_hosts" in names || "list_inventories" in names)
+        assertFalse("list_jobs" in names)
+    }
+
+    // --- Description-based scoring (#120 Tier 1) ---
+
+    @Test
+    fun `SHOULD rank tool higher WHEN description matches query tokens`() {
+        val withLabel = localTool(
+            "list_job_templates",
+            description = "List job templates with optional search and label filter"
+        )
+        val plain = localTool(
+            "list_workflow_templates",
+            description = "List workflow job templates"
+        )
+        router.registerLocalTools(listOf(withLabel, plain))
+
+        val result = router.getToolsForQuery("filter templates by label").tools
+        val names = result.map { it.spec.name }
+
+        assertTrue(names.isNotEmpty())
+        assertEquals("list_job_templates", names.first())
+    }
+
+    // --- Meta-search / no-match fallback (#120 Tier 1) ---
+
+    @Test
+    fun `SHOULD return search_available_tools WHEN query is tool discovery`() {
+        val search = localTool("search_available_tools", description = "Search available tools")
+        val hosts = localTool("list_hosts")
+        router.registerLocalTools(listOf(search, hosts))
+
+        val result = router.getToolsForQuery("what can you do?")
+        assertFalse(result.categoryMatched)
+        assertEquals(listOf("search_available_tools"), result.tools.map { it.spec.name })
+    }
+
+    @Test
+    fun `SHOULD meta-search by description WHEN no category matches`() {
+        val obscure = localTool(
+            "list_notification_templates",
+            description = "Manage alert smtp destinations and pagerduty channels"
+        )
+        val hosts = localTool("list_hosts", description = "List inventory hosts")
+        router.registerLocalTools(listOf(obscure, hosts))
+
+        // "smtp"/"pagerduty" are not category keywords; description search should still find the tool
+        val result = router.getToolsForQuery("smtp pagerduty destinations")
+        assertFalse(result.categoryMatched)
+        assertTrue(result.tools.any { it.spec.name == "list_notification_templates" })
+        assertFalse(result.tools.any { it.spec.name == "list_hosts" })
+    }
+
+    @Test
+    fun `searchAvailableTools SHOULD score name and description`() {
+        router.registerLocalTools(
+            listOf(
+                localTool("list_hosts", description = "List inventory hosts"),
+                localTool(
+                    "list_job_templates",
+                    description = "List job templates with optional label filter"
+                )
+            )
+        )
+
+        val hits = router.searchAvailableTools("label filter", maxResults = 5)
+        assertTrue(hits.any { it.spec.name == "list_job_templates" })
+        assertEquals("list_job_templates", hits.first().spec.name)
+    }
+
+    // --- Deterministic ordering (#439) ---
+
+    @Test
+    fun `cherryPick SHOULD break score ties by tool name alphabetically`() {
+        // Same name-overlap score for both list_ tools (+3 list boost); name secondary sort
+        val tools = listOf(
+            localTool("list_jobs"),
+            localTool("list_job_templates"),
+            localTool("get_job")
+        )
+        router.registerLocalTools(tools)
+
+        val first = router.getToolsForQuery("show jobs").tools.map { it.spec.name }
+        val second = router.getToolsForQuery("show jobs").tools.map { it.spec.name }
+
+        assertEquals(first, second)
+        // Among equal high-score list_ tools, alphabetical order must be stable
+        val listTools = first.filter { it.startsWith("list_") }
+        assertEquals(listTools.sorted(), listTools)
+    }
+
+    @Test
+    fun `identical tool sets SHOULD produce identical ordering across queries`() {
+        val tools = listOf(
+            localTool("list_hosts"),
+            localTool("list_inventories"),
+            localTool("list_groups"),
+            localTool("get_host_facts")
+        )
+        router.registerLocalTools(tools)
+
+        val a = router.getToolsForQuery("show hosts inventory groups").tools.map { it.spec.name }
+        val b = router.getToolsForQuery("show hosts inventory groups").tools.map { it.spec.name }
+        assertEquals(a, b)
+        assertTrue(a.size >= 2)
+    }
+
+    // --- AAP role filtering (#120 Tier 1) ---
+
+    @Test
+    fun `SHOULD filter destructive tools WHEN aapRole is AUDITOR`() {
+        val tools = listOf(
+            localTool("list_job_templates"),
+            localTool("launch_job", destructive = true),
+            localTool("list_jobs")
+        )
+        router.registerLocalTools(tools)
+
+        val result = router.getToolsForQuery(
+            "launch a job template",
+            aapRole = AapRole.AUDITOR
+        ).tools
+        val names = result.map { it.spec.name }
+
+        assertTrue("list_job_templates" in names || "list_jobs" in names)
+        assertFalse("launch_job" in names)
+    }
+
+    @Test
+    fun `SHOULD keep destructive tools WHEN aapRole is OPERATOR`() {
+        val tools = listOf(
+            localTool("list_job_templates"),
+            localTool("launch_job", destructive = true)
+        )
+        router.registerLocalTools(tools)
+
+        val result = router.getToolsForQuery(
+            "launch a job template",
+            aapRole = AapRole.OPERATOR
+        ).tools
+        assertTrue(result.any { it.spec.name == "launch_job" })
+    }
+
+    @Test
+    fun `User toAapRole SHOULD map system auditor and superuser`() {
+        assertEquals(
+            AapRole.AUDITOR,
+            User(1, "aud", isSystemAuditor = true).toAapRole()
+        )
+        assertEquals(
+            AapRole.ADMIN,
+            User(2, "admin", isSuperuser = true, isSystemAuditor = true).toAapRole()
+        )
+        assertEquals(
+            AapRole.OPERATOR,
+            User(3, "op").toAapRole()
         )
     }
 }


### PR DESCRIPTION
## Summary
- **#120 Tier 1 (Phase 1):** expanded stemmer (`-ing`/`-ed`/`-er`/`-tion`), synonym expansion before stemming, description-weighted `cherryPick()` scoring, `search_available_tools` meta-search fallback, and AAP auditor role filtering via `User.isSystemAuditor` → persisted on `AapInstance` → `getToolsForQuery(..., aapRole)`.
- **#439 (partial):** deterministic ordering — secondary name sort on score ties in `cherryPick()`, and alphabetical `toolDescriptors` sort in `ChatEngine` before LLM send (provider cache hints deferred).

## Review fixes (post-PR architecture/core review)
- Wire auditor role end-to-end: persist flags from `/api/v2/me/` on login/reauth/check; ViewModel passes `activeInstance.toAapRole()`.
- Meta-search reuses last routing context (role + serverConfigs) so LLM-invoked search honors auditor/read-only filters.
- `SearchAvailableToolsLocalTool` takes a search lambda (no Tools→Engine import).
- Stemmer keeps `setting` intact (`setting`→`set` false CONFIGURATION match).
- ViewModel no longer re-injects tools when ToolRouter returns empty (greetings stay empty).

## Out of scope (follow-ups)
- #120 Tier 2–5 (Model2Vec, middleware, Maven extraction, config-driven categories)
- #439 Anthropic `cache_control`, Ollama `keep_alive`, cache-hit logging

## Test plan
- [x] `./gradlew --no-daemon :shared:jvmTest --tests '*ToolRouter*' --tests '*ChatEngine*'`
- [x] `./gradlew --no-daemon :composeApp:compileKotlinDesktop`
- [ ] Spot-check Jane: auditor account hides `launch_job`; "please set a reminder" does not open Settings tools; "what can you do?" → `search_available_tools`
- [ ] CI green on this PR

**Plain English:** Optional — open Jane and try those prompts. You can skip; CI covers the automated tests.

Refs #120
Partial #439