### PR TITLE
feat(ui): UX polish — tool indicators, ANSI job output, swipe actions

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -426,6 +426,8 @@
     <!-- ChatBubble.kt -->
     <string name="cd_copy_message">Copy message</string>
     <string name="chat_tool_call">Using %1$s</string>
+    <string name="cd_tool_read">Read tool: %1$s</string>
+    <string name="cd_tool_write">Write tool: %1$s</string>
     <string name="chat_action_copy">Copy</string>
     <string name="chat_action_regenerate">Regenerate</string>
 

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -444,4 +444,10 @@
 
     <!-- DetailRow.kt / DetailScaffold.kt / DetailSheetHeader.kt -->
     <string name="cd_close_details">Close details</string>
+
+    <!-- Swipe actions (#266) -->
+    <string name="swipe_favorite">Favorite</string>
+    <string name="swipe_unfavorite">Unfavorite</string>
+    <string name="swipe_view_details">Details</string>
+    <string name="swipe_dismiss">Dismiss</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantUiState.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantUiState.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.assistant.presentation
 
 import androidx.compose.runtime.Immutable
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
+import io.github.leogallego.ansiblejane.assistant.engine.ToolUsage
 import io.github.leogallego.ansiblejane.model.AppError
 import io.github.leogallego.ansiblejane.network.mcp.McpConnectionState
 import kotlinx.collections.immutable.ImmutableList
@@ -22,6 +23,8 @@ sealed interface AssistantUiState {
         val messages: ImmutableList<ChatMessage> = persistentListOf(),
         val isGenerating: Boolean = false,
         val streamingText: String? = null,
+        /** Tool currently being queried, for read/write indicator on the streaming row. */
+        val streamingTool: ToolUsage? = null,
         val connections: Map<String, McpConnectionState> = emptyMap(),
         val pendingConfirmation: PendingConfirmation? = null,
         val sessionTokens: Int = 0

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -14,12 +14,14 @@ import io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
 import io.github.leogallego.ansiblejane.assistant.engine.ToolExecutor
 import io.github.leogallego.ansiblejane.assistant.engine.AapRole
 import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
+import io.github.leogallego.ansiblejane.assistant.engine.ToolUsage
 import io.github.leogallego.ansiblejane.assistant.engine.toAapRole
 import io.github.leogallego.ansiblejane.assistant.llm.GeminiLlmProvider
 import io.github.leogallego.ansiblejane.assistant.llm.KoogLlmProvider
 import io.github.leogallego.ansiblejane.assistant.llm.LlmProvider
 import io.github.leogallego.ansiblejane.assistant.tools.CachedMcpTool
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
+import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.data.IToolManifestRepository
 import io.github.leogallego.ansiblejane.model.ToolManifest
@@ -268,11 +270,12 @@ class AssistantViewModel(
 
             val textBuilder = StringBuilder()
             val usedSources = mutableSetOf<String>()
-            val usedToolNames = mutableListOf<String>()
+            val usedTools = linkedMapOf<String, ToolUsage>()
             var pendingTokenUsage: TokenUsage? = null
             val localNames = matchedLocal.map { it.spec.name }.toSet()
+            val toolByName: Map<String, Tool> = budgetedTools.associateBy { it.spec.name }
 
-            updateState { copy(streamingText = "Thinking...") }
+            updateState { copy(streamingText = "Thinking...", streamingTool = null) }
 
             engine.processMessage(
                 text, repository.getHistory(), toolSpecs, maxTokens, contextChars,
@@ -292,20 +295,29 @@ class AssistantViewModel(
                     when (event) {
                         is ChatEvent.TextDelta -> {
                             textBuilder.append(event.text)
-                            updateState { copy(streamingText = "Generating response...") }
+                            updateState { copy(streamingText = "Generating response...", streamingTool = null) }
                         }
                         is ChatEvent.ToolExecuting -> {
                             val toolSource = if (event.toolName in localNames) "local" else "mcp"
                             usedSources.add(toolSource)
-                            usedToolNames.add(event.toolName)
-                            updateState { copy(streamingText = "Querying [$toolSource]: ${event.toolName}...") }
+                            val usage = ToolUsage(
+                                name = event.toolName,
+                                isDestructive = toolByName[event.toolName]?.isDestructive == true,
+                            )
+                            usedTools[event.toolName] = usage
+                            updateState {
+                                copy(
+                                    streamingText = "Querying [$toolSource]: ${event.toolName}...",
+                                    streamingTool = usage,
+                                )
+                            }
                         }
                         is ChatEvent.ToolResult -> {
-                            updateState { copy(streamingText = "Processing results...") }
+                            updateState { copy(streamingText = "Processing results...", streamingTool = null) }
                             textBuilder.clear()
                         }
                         is ChatEvent.ConfirmationRequired -> {
-                            updateState { copy(streamingText = "Waiting for confirmation...") }
+                            updateState { copy(streamingText = "Waiting for confirmation...", streamingTool = null) }
                         }
                         is ChatEvent.AssistantMessage -> {
                             val responseSource = when {
@@ -318,7 +330,7 @@ class AssistantViewModel(
                                 role = Role.ASSISTANT,
                                 content = event.fullText,
                                 source = responseSource,
-                                toolsUsed = usedToolNames.distinct(),
+                                toolsUsed = usedTools.values.toList(),
                                 tokenUsage = pendingTokenUsage
                             )
                             repository.addMessage(finalMsg)
@@ -326,7 +338,8 @@ class AssistantViewModel(
                                 copy(
                                     messages = repository.getHistory().toImmutableList(),
                                     isGenerating = false,
-                                    streamingText = null
+                                    streamingText = null,
+                                    streamingTool = null,
                                 )
                             }
                         }
@@ -340,7 +353,8 @@ class AssistantViewModel(
                                 copy(
                                     messages = repository.getHistory().toImmutableList(),
                                     isGenerating = false,
-                                    streamingText = null
+                                    streamingText = null,
+                                    streamingTool = null,
                                 )
                             }
                         }
@@ -361,7 +375,7 @@ class AssistantViewModel(
 
     fun stopGeneration() {
         generateJob?.cancel()
-        updateState { copy(isGenerating = false, streamingText = null, pendingConfirmation = null) }
+        updateState { copy(isGenerating = false, streamingText = null, streamingTool = null, pendingConfirmation = null) }
     }
 
     fun regenerateLastMessage() {

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
 import io.github.leogallego.ansiblejane.assistant.engine.ResponseSource
 import io.github.leogallego.ansiblejane.assistant.engine.Role
+import io.github.leogallego.ansiblejane.assistant.engine.ToolUsage
 import io.github.leogallego.ansiblejane.assistant.presentation.AssistantUiState
 import io.github.leogallego.ansiblejane.assistant.presentation.AssistantViewModel
 import io.github.leogallego.ansiblejane.network.mcp.McpConnectionState
@@ -292,7 +293,10 @@ private fun ActiveChatContent(
 
             if (state.isGenerating) {
                 item(key = "streaming", contentType = "streaming") {
-                    StreamingIndicator(statusText = state.streamingText ?: stringResource(Res.string.assistant_thinking))
+                    StreamingIndicator(
+                        statusText = state.streamingText ?: stringResource(Res.string.assistant_thinking),
+                        streamingTool = state.streamingTool,
+                    )
                 }
             }
         }
@@ -361,6 +365,7 @@ private fun ActiveChatContent(
 @Composable
 private fun StreamingIndicator(
     statusText: String,
+    streamingTool: ToolUsage? = null,
     modifier: Modifier = Modifier
 ) {
     val infiniteTransition = rememberInfiniteTransition(label = "pulse")
@@ -400,7 +405,11 @@ private fun StreamingIndicator(
                 .clip(CircleShape)
                 .background(MaterialTheme.colorScheme.primary)
         )
-        Spacer(Modifier.width(8.dp))
+        Spacer(modifier.width(8.dp))
+        if (streamingTool != null) {
+            ToolCallIndicator(tool = streamingTool)
+            Spacer(modifier.width(8.dp))
+        }
         Text(
             text = statusText,
             style = MaterialTheme.typography.bodyMedium,
@@ -442,7 +451,7 @@ private fun AssistantWithMessagesPreview() {
                             "2. **System Health Check** - Runs health checks\n" +
                             "3. **Patch Management** - Applies security patches",
                         source = ResponseSource.MIXED,
-                        toolsUsed = listOf("list_job_templates"),
+                        toolsUsed = listOf(ToolUsage("list_job_templates"), ToolUsage("launch_job", isDestructive = true)),
                     ),
                     ChatMessage(
                         role = Role.USER,

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ChatBubble.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ChatBubble.kt
@@ -4,19 +4,25 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -42,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
 import io.github.leogallego.ansiblejane.assistant.engine.ResponseSource
 import io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
+import io.github.leogallego.ansiblejane.assistant.engine.ToolUsage
 import com.mikepenz.markdown.compose.LocalBulletListHandler
 import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.compose.components.markdownComponents
@@ -104,7 +111,7 @@ fun UserBubble(
 fun AssistantMessage(
     content: String,
     source: ResponseSource? = null,
-    toolsUsed: List<String> = emptyList(),
+    toolsUsed: List<ToolUsage> = emptyList(),
     tokenUsage: TokenUsage? = null,
     onCopy: (() -> Unit)? = null,
     onRegenerate: (() -> Unit)? = null,
@@ -228,10 +235,11 @@ fun AssistantMessage(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun SourceBand(
     source: ResponseSource,
-    toolsUsed: List<String>,
+    toolsUsed: List<ToolUsage>,
     tokenUsage: TokenUsage? = null,
     modifier: Modifier = Modifier
 ) {
@@ -253,33 +261,14 @@ private fun SourceBand(
                 style = MaterialTheme.typography.labelSmall,
                 color = color,
             )
-            if (toolsUsed.isNotEmpty()) {
-                Spacer(Modifier.width(6.dp))
-                Text(
-                    text = "·",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = color,
-                )
-                Spacer(Modifier.width(6.dp))
-                Text(
-                    text = toolsUsed.joinToString(", "),
-                    style = MaterialTheme.typography.labelSmall.copy(
-                        fontFamily = FontFamily.Monospace
-                    ),
-                    color = color,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f, fill = false),
-                )
-            }
             if (tokenUsage != null) {
-                Spacer(Modifier.width(6.dp))
+                Spacer(modifier.width(6.dp))
                 Text(
                     text = "·",
                     style = MaterialTheme.typography.labelSmall,
                     color = color,
                 )
-                Spacer(Modifier.width(6.dp))
+                Spacer(modifier.width(6.dp))
                 Text(
                     text = stringResource(Res.string.provider_tokens, tokenUsage.formatTotal()),
                     style = MaterialTheme.typography.labelSmall,
@@ -290,11 +279,82 @@ private fun SourceBand(
                 )
             }
         }
+        if (toolsUsed.isNotEmpty()) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 6.dp),
+            ) {
+                toolsUsed.forEach { tool ->
+                    ToolCallIndicator(tool = tool)
+                }
+            }
+        }
         HorizontalDivider(
             color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
             thickness = 0.5.dp,
             modifier = Modifier.padding(top = 4.dp),
         )
+    }
+}
+
+/**
+ * Visual read vs write/action indicator for a tool invoked in chat.
+ * Purely presentational — confirmation gating stays on Tool.isDestructive in the engine.
+ */
+@Composable
+fun ToolCallIndicator(
+    tool: ToolUsage,
+    modifier: Modifier = Modifier,
+) {
+    val isWrite = tool.isDestructive
+    val icon = if (isWrite) Icons.Default.Edit else Icons.Default.Visibility
+    val tint = if (isWrite) {
+        MaterialTheme.colorScheme.tertiary
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+    }
+    val label = if (isWrite) {
+        stringResource(Res.string.cd_tool_write, tool.name)
+    } else {
+        stringResource(Res.string.cd_tool_read, tool.name)
+    }
+    val tag = if (isWrite) "badge_tool_write" else "badge_tool_read"
+
+    Surface(
+        shape = RoundedCornerShape(8.dp),
+        color = if (isWrite) {
+            MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.55f)
+        } else {
+            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.55f)
+        },
+        modifier = modifier
+            .testTag(tag)
+            .semantics { contentDescription = label },
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = tint,
+                modifier = Modifier.size(12.dp),
+            )
+            Spacer(modifier.width(4.dp))
+            Text(
+                text = tool.name,
+                style = MaterialTheme.typography.labelSmall.copy(
+                    fontFamily = FontFamily.Monospace
+                ),
+                color = tint,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/notifications/NotificationsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/notifications/NotificationsViewModel.kt
@@ -40,6 +40,13 @@ class NotificationsViewModel(
         }
     }
 
+    /** Hide an approval from the sheet until the next refresh (session-local). */
+    fun dismissApproval(approvalId: Int) {
+        _uiState.update { state ->
+            state.copy(approvals = state.approvals.filterNot { it.id == approvalId })
+        }
+    }
+
     fun refresh() {
         val oldJob = refreshJob
         refreshJob = viewModelScope.launch {

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/notifications/NotificationsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/notifications/NotificationsViewModel.kt
@@ -27,27 +27,37 @@ class NotificationsViewModel(
     private val _uiState = MutableStateFlow(NotificationsUiState())
     val uiState: StateFlow<NotificationsUiState> = _uiState.asStateFlow()
 
+    /** Session-local hide set so refresh cannot resurrect a swiped-away row. */
+    private val dismissedIds = mutableSetOf<Int>()
+
     private var refreshJob: Job? = null
     private var lastFetchTime: Long = 0L
 
     init {
-        refresh()
+        refresh(clearSessionDismissals = false)
     }
 
     fun refreshIfStale(maxAgeMs: Long = 30_000L) {
         if (kotlin.time.Clock.System.now().toEpochMilliseconds() - lastFetchTime > maxAgeMs) {
-            refresh()
+            refresh(clearSessionDismissals = false)
         }
     }
 
-    /** Hide an approval from the sheet until the next refresh (session-local). */
+    /**
+     * Hide an approval from the sheet for this ViewModel session.
+     * Survives stale/background refresh; an explicit [refresh] clears the hide set.
+     */
     fun dismissApproval(approvalId: Int) {
+        dismissedIds += approvalId
         _uiState.update { state ->
-            state.copy(approvals = state.approvals.filterNot { it.id == approvalId })
+            state.copy(approvals = state.approvals.filterNot { it.id in dismissedIds })
         }
     }
 
-    fun refresh() {
+    fun refresh(clearSessionDismissals: Boolean = true) {
+        if (clearSessionDismissals) {
+            dismissedIds.clear()
+        }
         val oldJob = refreshJob
         refreshJob = viewModelScope.launch {
             oldJob?.cancelAndJoin()
@@ -57,7 +67,7 @@ class NotificationsViewModel(
                     lastFetchTime = kotlin.time.Clock.System.now().toEpochMilliseconds()
                     _uiState.update {
                         NotificationsUiState(
-                            approvals = result.approvals,
+                            approvals = result.approvals.filterNot { it.id in dismissedIds },
                             isLoading = false,
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/AnsiText.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/AnsiText.kt
@@ -1,0 +1,88 @@
+package io.github.leogallego.ansiblejane.ui.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import io.github.leogallego.ansiblejane.util.AnsiNamedColor
+import io.github.leogallego.ansiblejane.util.AnsiParser
+import io.github.leogallego.ansiblejane.util.AnsiSpan
+import io.github.leogallego.ansiblejane.util.AnsiStyle
+
+/**
+ * Monospace job stdout with ANSI SGR colors mapped to Material 3 tokens.
+ * Parsing is memoized on [text] to avoid jank on long logs.
+ */
+@Composable
+fun AnsiText(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    val colorScheme = MaterialTheme.colorScheme
+    val onSurface = colorScheme.onSurface
+    val annotated = remember(text, colorScheme) {
+        ansiToAnnotatedString(
+            spans = AnsiParser.parse(text),
+            defaultColor = onSurface,
+            colorFor = { named -> named.toMaterialColor(colorScheme) },
+        )
+    }
+    Text(
+        text = annotated,
+        style = MaterialTheme.typography.bodySmall.copy(
+            fontFamily = FontFamily.Monospace,
+            color = onSurface,
+        ),
+        modifier = modifier.testTag("text_job_stdout"),
+    )
+}
+
+internal fun ansiToAnnotatedString(
+    spans: List<AnsiSpan>,
+    defaultColor: Color,
+    colorFor: (AnsiNamedColor) -> Color,
+): AnnotatedString = buildAnnotatedString {
+    for (span in spans) {
+        if (span.text.isEmpty()) continue
+        withStyle(span.style.toSpanStyle(defaultColor, colorFor)) {
+            append(span.text)
+        }
+    }
+}
+
+private fun AnsiStyle.toSpanStyle(
+    defaultColor: Color,
+    colorFor: (AnsiNamedColor) -> Color,
+): SpanStyle {
+    val base = foreground?.let(colorFor) ?: defaultColor
+    val color = when {
+        dim -> base.copy(alpha = 0.55f)
+        else -> base
+    }
+    return SpanStyle(
+        color = color,
+        fontWeight = if (bold) FontWeight.Bold else FontWeight.Normal,
+    )
+}
+
+private fun AnsiNamedColor.toMaterialColor(
+    colors: androidx.compose.material3.ColorScheme,
+): Color = when (this) {
+    AnsiNamedColor.BLACK, AnsiNamedColor.BRIGHT_BLACK -> colors.onSurface.copy(alpha = 0.7f)
+    AnsiNamedColor.RED, AnsiNamedColor.BRIGHT_RED -> colors.error
+    AnsiNamedColor.GREEN, AnsiNamedColor.BRIGHT_GREEN -> colors.tertiary
+    AnsiNamedColor.YELLOW, AnsiNamedColor.BRIGHT_YELLOW -> colors.secondary
+    AnsiNamedColor.BLUE, AnsiNamedColor.BRIGHT_BLUE -> colors.primary
+    AnsiNamedColor.MAGENTA, AnsiNamedColor.BRIGHT_MAGENTA -> colors.primary.copy(alpha = 0.85f)
+    AnsiNamedColor.CYAN, AnsiNamedColor.BRIGHT_CYAN -> colors.secondary.copy(alpha = 0.9f)
+    AnsiNamedColor.WHITE, AnsiNamedColor.BRIGHT_WHITE -> colors.onSurface
+}

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/SwipeActionBox.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/SwipeActionBox.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -23,12 +24,14 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 
 /**
  * One-sided (or two-sided) swipe action wrapper around Material 3 [SwipeToDismissBox].
  *
  * Set [SwipeAction.removesItem] to false for toggle-style actions (favorite, open details)
- * so the row snaps back after the gesture. True removes/settles the row (e.g. dismiss).
+ * so the row snaps back after the gesture via [SwipeToDismissBoxState.reset].
+ * True leaves the dismiss settled so the parent can remove the row from the list.
  */
 data class SwipeAction(
     val icon: ImageVector,
@@ -48,23 +51,8 @@ fun SwipeActionBox(
     testTag: String? = null,
     content: @Composable () -> Unit,
 ) {
-    val state = rememberSwipeToDismissBoxState(
-        confirmValueChange = { value ->
-            when (value) {
-                SwipeToDismissBoxValue.EndToStart -> {
-                    val action = endToStart ?: return@rememberSwipeToDismissBoxState false
-                    action.onAction()
-                    action.removesItem
-                }
-                SwipeToDismissBoxValue.StartToEnd -> {
-                    val action = startToEnd ?: return@rememberSwipeToDismissBoxState false
-                    action.onAction()
-                    action.removesItem
-                }
-                SwipeToDismissBoxValue.Settled -> true
-            }
-        }
-    )
+    val state = rememberSwipeToDismissBoxState()
+    val scope = rememberCoroutineScope()
 
     val a11y = buildString {
         endToStart?.let { append("Swipe left: ${it.label}. ") }
@@ -84,8 +72,23 @@ fun SwipeActionBox(
             ),
         enableDismissFromEndToStart = endToStart != null,
         enableDismissFromStartToEnd = startToEnd != null,
+        onDismiss = { direction ->
+            val action = when (direction) {
+                SwipeToDismissBoxValue.EndToStart -> endToStart
+                SwipeToDismissBoxValue.StartToEnd -> startToEnd
+                SwipeToDismissBoxValue.Settled -> null
+            }
+            if (action == null) {
+                scope.launch { state.reset() }
+                return@SwipeToDismissBox
+            }
+            action.onAction()
+            if (!action.removesItem) {
+                scope.launch { state.reset() }
+            }
+        },
         backgroundContent = {
-            val direction = state.dismissDirection
+            val direction = state.targetValue
             val action = when (direction) {
                 SwipeToDismissBoxValue.EndToStart -> endToStart
                 SwipeToDismissBoxValue.StartToEnd -> startToEnd

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/SwipeActionBox.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/components/SwipeActionBox.kt
@@ -1,0 +1,148 @@
+package io.github.leogallego.ansiblejane.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+/**
+ * One-sided (or two-sided) swipe action wrapper around Material 3 [SwipeToDismissBox].
+ *
+ * Set [SwipeAction.removesItem] to false for toggle-style actions (favorite, open details)
+ * so the row snaps back after the gesture. True removes/settles the row (e.g. dismiss).
+ */
+data class SwipeAction(
+    val icon: ImageVector,
+    val label: String,
+    val containerColor: Color,
+    val contentColor: Color,
+    val onAction: () -> Unit,
+    val removesItem: Boolean = false,
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SwipeActionBox(
+    modifier: Modifier = Modifier,
+    endToStart: SwipeAction? = null,
+    startToEnd: SwipeAction? = null,
+    testTag: String? = null,
+    content: @Composable () -> Unit,
+) {
+    val state = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            when (value) {
+                SwipeToDismissBoxValue.EndToStart -> {
+                    val action = endToStart ?: return@rememberSwipeToDismissBoxState false
+                    action.onAction()
+                    action.removesItem
+                }
+                SwipeToDismissBoxValue.StartToEnd -> {
+                    val action = startToEnd ?: return@rememberSwipeToDismissBoxState false
+                    action.onAction()
+                    action.removesItem
+                }
+                SwipeToDismissBoxValue.Settled -> true
+            }
+        }
+    )
+
+    val a11y = buildString {
+        endToStart?.let { append("Swipe left: ${it.label}. ") }
+        startToEnd?.let { append("Swipe right: ${it.label}.") }
+    }.trim()
+
+    SwipeToDismissBox(
+        state = state,
+        modifier = modifier
+            .then(if (testTag != null) Modifier.testTag(testTag) else Modifier)
+            .then(
+                if (a11y.isNotEmpty()) {
+                    Modifier.semantics { contentDescription = a11y }
+                } else {
+                    Modifier
+                }
+            ),
+        enableDismissFromEndToStart = endToStart != null,
+        enableDismissFromStartToEnd = startToEnd != null,
+        backgroundContent = {
+            val direction = state.dismissDirection
+            val action = when (direction) {
+                SwipeToDismissBoxValue.EndToStart -> endToStart
+                SwipeToDismissBoxValue.StartToEnd -> startToEnd
+                else -> null
+            }
+            if (action != null) {
+                SwipeActionBackground(
+                    action = action,
+                    alignEnd = direction == SwipeToDismissBoxValue.EndToStart,
+                )
+            }
+        },
+        content = { content() },
+    )
+}
+
+@Composable
+private fun SwipeActionBackground(
+    action: SwipeAction,
+    alignEnd: Boolean,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(action.containerColor)
+            .padding(horizontal = 24.dp),
+        contentAlignment = if (alignEnd) Alignment.CenterEnd else Alignment.CenterStart,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (!alignEnd) {
+                Icon(
+                    imageVector = action.icon,
+                    contentDescription = null,
+                    tint = action.contentColor,
+                    modifier = Modifier.size(22.dp),
+                )
+                Text(
+                    text = action.label,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = action.contentColor,
+                )
+            } else {
+                Text(
+                    text = action.label,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = action.contentColor,
+                )
+                Icon(
+                    imageVector = action.icon,
+                    contentDescription = null,
+                    tint = action.contentColor,
+                    modifier = Modifier.size(22.dp),
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/jobs/JobStatusScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/jobs/JobStatusScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -33,6 +32,7 @@ import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import io.github.leogallego.ansiblejane.ui.components.DetailRowHorizontal
 import io.github.leogallego.ansiblejane.ui.components.DetailScaffold
 import io.github.leogallego.ansiblejane.ui.components.ErrorMessage
+import io.github.leogallego.ansiblejane.ui.components.AnsiText
 import io.github.leogallego.ansiblejane.ui.components.JobStatusBadge
 import org.jetbrains.compose.resources.stringResource
 import aapremotecontrol.composeapp.generated.resources.*
@@ -144,11 +144,8 @@ private fun JobDetailContent(job: Job, isActive: Boolean, stdout: String? = null
                         shape = MaterialTheme.shapes.small,
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        Text(
+                        AnsiText(
                             text = stdout,
-                            style = MaterialTheme.typography.bodySmall.copy(
-                                fontFamily = FontFamily.Monospace
-                            ),
                             modifier = Modifier
                                 .padding(12.dp)
                                 .horizontalScroll(rememberScrollState())

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/jobs/RecentJobsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/jobs/RecentJobsScreen.kt
@@ -36,7 +36,11 @@ import io.github.leogallego.ansiblejane.presentation.jobs.RecentJobsViewModel
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import io.github.leogallego.ansiblejane.ui.components.EmptyState
 import io.github.leogallego.ansiblejane.ui.components.ErrorMessage
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import io.github.leogallego.ansiblejane.ui.components.JobStatusBadge
+import io.github.leogallego.ansiblejane.ui.components.SwipeAction
+import io.github.leogallego.ansiblejane.ui.components.SwipeActionBox
 import io.github.leogallego.ansiblejane.ui.components.LoadMoreIndicator
 import io.github.leogallego.ansiblejane.ui.components.LoadingList
 import io.github.leogallego.ansiblejane.ui.components.PaginationEffect
@@ -128,10 +132,22 @@ fun RecentJobsScreen(
                                     items = state.jobs,
                                     key = { it.id }
                                 ) { job ->
-                                    RecentJobItem(
-                                        job = job,
-                                        onClick = { onNavigateToJobStatus(job.id) }
-                                    )
+                                    SwipeActionBox(
+                                        endToStart = SwipeAction(
+                                            icon = Icons.AutoMirrored.Filled.OpenInNew,
+                                            label = stringResource(Res.string.swipe_view_details),
+                                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                                            onAction = { onNavigateToJobStatus(job.id) },
+                                            removesItem = false,
+                                        ),
+                                        testTag = "swipe_job_${job.id}",
+                                    ) {
+                                        RecentJobItem(
+                                            job = job,
+                                            onClick = { onNavigateToJobStatus(job.id) }
+                                        )
+                                    }
                                 }
 
                                 if (state.isLoadingMore) {

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/main/MainScreen.kt
@@ -321,7 +321,10 @@ fun MainScreen(
             onApprovalClick = { approvalId ->
                 showNotificationsSheet = false
                 onNavigateToApproval(approvalId)
-            }
+            },
+            onDismissApproval = { approvalId ->
+                notificationsViewModel.dismissApproval(approvalId)
+            },
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/notifications/NotificationsSheet.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/notifications/NotificationsSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.HourglassTop
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -35,6 +36,8 @@ import androidx.compose.ui.unit.dp
 import io.github.leogallego.ansiblejane.model.WorkflowApproval
 import io.github.leogallego.ansiblejane.presentation.notifications.NotificationsUiState
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
+import io.github.leogallego.ansiblejane.ui.components.SwipeAction
+import io.github.leogallego.ansiblejane.ui.components.SwipeActionBox
 import org.jetbrains.compose.resources.stringResource
 import aapremotecontrol.composeapp.generated.resources.*
 
@@ -45,6 +48,7 @@ fun NotificationsSheet(
     onDismiss: () -> Unit,
     onRefresh: () -> Unit,
     onApprovalClick: (Int) -> Unit,
+    onDismissApproval: (Int) -> Unit = {},
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -137,10 +141,22 @@ fun NotificationsSheet(
                     Spacer(modifier = Modifier.height(8.dp))
                     LazyColumn {
                         items(uiState.approvals, key = { it.id }) { approval ->
-                            ApprovalNotificationItem(
-                                approval = approval,
-                                onClick = { onApprovalClick(approval.id) }
-                            )
+                            SwipeActionBox(
+                                endToStart = SwipeAction(
+                                    icon = Icons.Default.Delete,
+                                    label = stringResource(Res.string.swipe_dismiss),
+                                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                                    onAction = { onDismissApproval(approval.id) },
+                                    removesItem = true,
+                                ),
+                                testTag = "swipe_notification_${approval.id}",
+                            ) {
+                                ApprovalNotificationItem(
+                                    approval = approval,
+                                    onClick = { onApprovalClick(approval.id) }
+                                )
+                            }
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/templates/TemplateListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/templates/TemplateListScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarOutline
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -46,6 +48,8 @@ import io.github.leogallego.ansiblejane.ui.components.LoadMoreIndicator
 import io.github.leogallego.ansiblejane.ui.components.LoadingList
 import io.github.leogallego.ansiblejane.ui.components.PaginationEffect
 import io.github.leogallego.ansiblejane.ui.components.SearchBar
+import io.github.leogallego.ansiblejane.ui.components.SwipeAction
+import io.github.leogallego.ansiblejane.ui.components.SwipeActionBox
 import io.github.leogallego.ansiblejane.ui.components.TemplateCard
 import io.github.leogallego.ansiblejane.model.AppError
 import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
@@ -189,14 +193,31 @@ fun TemplateListScreen(
                                     items = displayTemplates,
                                     key = { it.id }
                                 ) { template ->
-                                    TemplateCard(
-                                        template = template,
-                                        onClick = { viewModel.requestLaunch(template) },
-                                        onLaunch = { viewModel.requestLaunch(template) },
-                                        isFavorite = template.id in favoriteIds,
-                                        onToggleFavorite = { viewModel.toggleFavorite(template.id) },
-                                        testTagPrefix = "button"
-                                    )
+                                    val isFavorite = template.id in favoriteIds
+                                    SwipeActionBox(
+                                        endToStart = SwipeAction(
+                                            icon = if (isFavorite) Icons.Outlined.StarOutline else Icons.Filled.Star,
+                                            label = if (isFavorite) {
+                                                stringResource(Res.string.swipe_unfavorite)
+                                            } else {
+                                                stringResource(Res.string.swipe_favorite)
+                                            },
+                                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                                            onAction = { viewModel.toggleFavorite(template.id) },
+                                            removesItem = false,
+                                        ),
+                                        testTag = "swipe_template_${template.id}",
+                                    ) {
+                                        TemplateCard(
+                                            template = template,
+                                            onClick = { viewModel.requestLaunch(template) },
+                                            onLaunch = { viewModel.requestLaunch(template) },
+                                            isFavorite = isFavorite,
+                                            onToggleFavorite = { viewModel.toggleFavorite(template.id) },
+                                            testTagPrefix = "button"
+                                        )
+                                    }
                                 }
 
                                 if (state.isLoadingMore && !showFavoritesOnly) {

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/workflows/WorkflowNodeCard.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/workflows/WorkflowNodeCard.kt
@@ -25,12 +25,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.leogallego.ansiblejane.presentation.workflows.NodeStdoutState
 import org.jetbrains.compose.resources.stringResource
 import aapremotecontrol.composeapp.generated.resources.*
+import io.github.leogallego.ansiblejane.ui.components.AnsiText
 import io.github.leogallego.ansiblejane.ui.components.JobStatusBadge
 
 @Composable
@@ -125,11 +125,8 @@ fun WorkflowNodeCard(
                                 .fillMaxWidth()
                                 .padding(horizontal = 16.dp, vertical = 4.dp)
                         ) {
-                            Text(
+                            AnsiText(
                                 text = stdoutState.stdout,
-                                style = MaterialTheme.typography.bodySmall.copy(
-                                    fontFamily = FontFamily.Monospace
-                                ),
                                 modifier = Modifier
                                     .padding(12.dp)
                                     .horizontalScroll(rememberScrollState())

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/notifications/NotificationsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/notifications/NotificationsViewModelTest.kt
@@ -81,4 +81,42 @@ class NotificationsViewModelTest {
             assertEquals("Network error", state.error)
         }
     }
+
+    @Test
+    fun `dismissApproval hides item across refreshIfStale reload`() = runTest {
+        fakeWorkflowRepo.approvals = listOf(
+            WorkflowApproval(id = 1, name = "Deploy to prod", status = "pending"),
+            WorkflowApproval(id = 2, name = "Scale web", status = "pending"),
+        )
+        val viewModel = NotificationsViewModel(fakeWorkflowRepo)
+        advanceUntilIdle()
+
+        viewModel.dismissApproval(1)
+        assertEquals(listOf(2), viewModel.uiState.value.approvals.map { it.id })
+
+        // Stale reopen path must not resurrect a swiped-away approval.
+        viewModel.refresh(clearSessionDismissals = false)
+        advanceUntilIdle()
+
+        assertEquals(listOf(2), viewModel.uiState.value.approvals.map { it.id })
+        assertEquals(1, viewModel.uiState.value.pendingCount)
+    }
+
+    @Test
+    fun `explicit refresh restores previously dismissed approvals`() = runTest {
+        fakeWorkflowRepo.approvals = listOf(
+            WorkflowApproval(id = 1, name = "Deploy to prod", status = "pending"),
+            WorkflowApproval(id = 2, name = "Scale web", status = "pending"),
+        )
+        val viewModel = NotificationsViewModel(fakeWorkflowRepo)
+        advanceUntilIdle()
+
+        viewModel.dismissApproval(1)
+        assertEquals(1, viewModel.uiState.value.approvals.size)
+
+        viewModel.refresh() // default clears session dismissals
+        advanceUntilIdle()
+
+        assertEquals(listOf(1, 2), viewModel.uiState.value.approvals.map { it.id })
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ToolCallIndicatorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ToolCallIndicatorTest.kt
@@ -51,7 +51,10 @@ class ToolCallIndicatorTest {
         }
         waitForIdle()
 
-        onNodeWithTag("badge_tool_read").assertIsDisplayed()
-        onNodeWithTag("badge_tool_write").assertIsDisplayed()
+        // Parent combinedClickable merges semantics; query unmerged tree for tags.
+        onNodeWithTag("badge_tool_read", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithTag("badge_tool_write", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText("list_hosts", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText("launch_job", useUnmergedTree = true).assertIsDisplayed()
     }
 }

--- a/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ToolCallIndicatorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/assistant/ui/ToolCallIndicatorTest.kt
@@ -1,0 +1,57 @@
+package io.github.leogallego.ansiblejane.assistant.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import io.github.leogallego.ansiblejane.assistant.engine.ResponseSource
+import io.github.leogallego.ansiblejane.assistant.engine.ToolUsage
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ToolCallIndicatorTest {
+
+    @Test
+    fun shows_read_and_write_indicators() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                Column {
+                    ToolCallIndicator(tool = ToolUsage(name = "list_hosts"))
+                    ToolCallIndicator(tool = ToolUsage(name = "launch_job", isDestructive = true))
+                }
+            }
+        }
+        waitForIdle()
+
+        onNodeWithTag("badge_tool_read").assertIsDisplayed()
+        onNodeWithTag("badge_tool_write").assertIsDisplayed()
+        onNodeWithText("list_hosts").assertIsDisplayed()
+        onNodeWithText("launch_job").assertIsDisplayed()
+        onNodeWithContentDescription("Read tool: list_hosts").assertIsDisplayed()
+        onNodeWithContentDescription("Write tool: launch_job").assertIsDisplayed()
+    }
+
+    @Test
+    fun assistant_message_source_band_shows_tool_indicators() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                AssistantMessage(
+                    content = "Found hosts.",
+                    source = ResponseSource.LOCAL,
+                    toolsUsed = listOf(
+                        ToolUsage("list_hosts"),
+                        ToolUsage("launch_job", isDestructive = true),
+                    ),
+                )
+            }
+        }
+        waitForIdle()
+
+        onNodeWithTag("badge_tool_read").assertIsDisplayed()
+        onNodeWithTag("badge_tool_write").assertIsDisplayed()
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/ui/components/SwipeActionBoxTest.kt
+++ b/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/ui/components/SwipeActionBoxTest.kt
@@ -1,0 +1,49 @@
+package io.github.leogallego.ansiblejane.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class SwipeActionBoxTest {
+
+    @Test
+    fun exposes_swipe_container_test_tag_and_keeps_click() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                SwipeActionBox(
+                    endToStart = SwipeAction(
+                        icon = Icons.Filled.Star,
+                        label = "Favorite",
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        onAction = {},
+                        removesItem = false,
+                    ),
+                    testTag = "swipe_template_1",
+                ) {
+                    TextButton(onClick = { clicked = true }) {
+                        Text("Deploy App")
+                    }
+                }
+            }
+        }
+        waitForIdle()
+
+        onNodeWithTag("swipe_template_1").assertIsDisplayed()
+        onNodeWithText("Deploy App").performClick()
+        waitForIdle()
+        assertTrue(clicked)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/ui/components/SwipeActionBoxTest.kt
+++ b/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/ui/components/SwipeActionBoxTest.kt
@@ -1,17 +1,23 @@
 package io.github.leogallego.ansiblejane.ui.components
 
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.swipeLeft
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
@@ -45,5 +51,65 @@ class SwipeActionBoxTest {
         onNodeWithText("Deploy App").performClick()
         waitForIdle()
         assertTrue(clicked)
+    }
+
+    @Test
+    fun swipe_left_invokes_end_to_start_action_without_removing() = runComposeUiTest {
+        var actionCount = 0
+        setContent {
+            MaterialTheme {
+                SwipeActionBox(
+                    endToStart = SwipeAction(
+                        icon = Icons.Filled.Star,
+                        label = "Favorite",
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        onAction = { actionCount++ },
+                        removesItem = false,
+                    ),
+                    testTag = "swipe_template_1",
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("Deploy App", modifier = Modifier.fillMaxWidth())
+                }
+            }
+        }
+        waitForIdle()
+
+        onNodeWithTag("swipe_template_1").performTouchInput { swipeLeft() }
+        waitForIdle()
+
+        assertEquals(1, actionCount)
+        // Snap-back keeps content available for further interaction.
+        onNodeWithText("Deploy App").assertIsDisplayed()
+    }
+
+    @Test
+    fun swipe_left_invokes_removing_action() = runComposeUiTest {
+        var dismissed = false
+        setContent {
+            MaterialTheme {
+                SwipeActionBox(
+                    endToStart = SwipeAction(
+                        icon = Icons.Filled.Delete,
+                        label = "Dismiss",
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        onAction = { dismissed = true },
+                        removesItem = true,
+                    ),
+                    testTag = "swipe_notification_1",
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("Pending approval", modifier = Modifier.fillMaxWidth())
+                }
+            }
+        }
+        waitForIdle()
+
+        onNodeWithTag("swipe_notification_1").performTouchInput { swipeLeft() }
+        waitForIdle()
+
+        assertTrue(dismissed)
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatMessage.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatMessage.kt
@@ -32,6 +32,16 @@ data class TokenUsage(
 @OptIn(ExperimentalAtomicApi::class)
 private val messageCounter = AtomicLong(0)
 
+/**
+ * A tool that was invoked while producing an assistant message.
+ * [isDestructive] mirrors [io.github.leogallego.ansiblejane.assistant.tools.Tool.isDestructive]
+ * for UI read/write indicators without changing confirmation behavior.
+ */
+data class ToolUsage(
+    val name: String,
+    val isDestructive: Boolean = false,
+)
+
 data class ChatMessage(
     val role: Role,
     val content: String,
@@ -39,7 +49,7 @@ data class ChatMessage(
     val toolCallId: String? = null,
     val toolName: String? = null,
     val source: ResponseSource? = null,
-    val toolsUsed: List<String> = emptyList(),
+    val toolsUsed: List<ToolUsage> = emptyList(),
     val tokenUsage: TokenUsage? = null,
     val timestamp: Long = 0L,
     val id: Long = nextId()

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/util/AnsiParser.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/util/AnsiParser.kt
@@ -100,9 +100,16 @@ object AnsiParser {
             }
 
             if (!foundFinal) {
-                // Partial sequence — emit remaining input as plain text.
-                buffer.append(input, i, input.length)
-                break
+                if (j >= input.length) {
+                    // Incomplete CSI at EOF — keep remainder as plain text.
+                    buffer.append(input, i, input.length)
+                    break
+                }
+                // Overlong / malformed CSI mid-stream — keep ESC as literal and resume
+                // so the rest of the log can still be colored.
+                buffer.append(ESC)
+                i++
+                continue
             }
 
             val finalByte = input[j]

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/util/AnsiParser.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/util/AnsiParser.kt
@@ -1,0 +1,214 @@
+package io.github.leogallego.ansiblejane.util
+
+/**
+ * Named ANSI SGR colors used by job stdout (Ansible/AWX).
+ * UI maps these to Material 3 tokens.
+ */
+enum class AnsiNamedColor {
+    BLACK,
+    RED,
+    GREEN,
+    YELLOW,
+    BLUE,
+    MAGENTA,
+    CYAN,
+    WHITE,
+    BRIGHT_BLACK,
+    BRIGHT_RED,
+    BRIGHT_GREEN,
+    BRIGHT_YELLOW,
+    BRIGHT_BLUE,
+    BRIGHT_MAGENTA,
+    BRIGHT_CYAN,
+    BRIGHT_WHITE,
+}
+
+data class AnsiStyle(
+    val foreground: AnsiNamedColor? = null,
+    val bold: Boolean = false,
+    val dim: Boolean = false,
+) {
+    companion object {
+        val Default = AnsiStyle()
+    }
+}
+
+data class AnsiSpan(
+    val text: String,
+    val style: AnsiStyle = AnsiStyle.Default,
+)
+
+/**
+ * Pure ANSI CSI/SGR parser for job stdout. No Compose dependency.
+ *
+ * Handles colors, bold, and dim. Incomplete escape sequences at the end of
+ * [input] are treated as plain text (no dropped characters, no janky wait).
+ */
+object AnsiParser {
+    private const val ESC = '\u001B'
+    private const val MAX_CSI_LENGTH = 64
+
+    fun parse(input: String): List<AnsiSpan> {
+        if (input.isEmpty()) return emptyList()
+        if (ESC !in input) return listOf(AnsiSpan(input))
+
+        val spans = ArrayList<AnsiSpan>()
+        val buffer = StringBuilder()
+        var style = AnsiStyle.Default
+        var i = 0
+
+        fun flush() {
+            if (buffer.isEmpty()) return
+            spans += AnsiSpan(buffer.toString(), style)
+            buffer.clear()
+        }
+
+        while (i < input.length) {
+            val c = input[i]
+            if (c != ESC) {
+                buffer.append(c)
+                i++
+                continue
+            }
+
+            // Incomplete ESC at end — keep as literal.
+            if (i + 1 >= input.length) {
+                buffer.append(c)
+                i++
+                continue
+            }
+
+            val next = input[i + 1]
+            if (next != '[') {
+                // Non-CSI escape (e.g. OSC) — skip ESC and continue; keep following char.
+                buffer.append(c)
+                i++
+                continue
+            }
+
+            // Parse CSI: ESC [ params final
+            val paramsStart = i + 2
+            var j = paramsStart
+            var foundFinal = false
+            while (j < input.length && j - paramsStart < MAX_CSI_LENGTH) {
+                val ch = input[j]
+                if (ch in '@'..'~') {
+                    foundFinal = true
+                    break
+                }
+                j++
+            }
+
+            if (!foundFinal) {
+                // Partial sequence — emit remaining input as plain text.
+                buffer.append(input, i, input.length)
+                break
+            }
+
+            val finalByte = input[j]
+            val params = input.substring(paramsStart, j)
+            flush()
+            if (finalByte == 'm') {
+                style = applySgr(style, params)
+            }
+            // Other CSI sequences (cursor moves, etc.) are stripped.
+            i = j + 1
+        }
+
+        flush()
+        return mergeAdjacent(spans)
+    }
+
+    /** Strip ANSI escapes, returning plain text. */
+    fun strip(input: String): String =
+        parse(input).joinToString(separator = "") { it.text }
+
+    private fun applySgr(current: AnsiStyle, params: String): AnsiStyle {
+        if (params.isEmpty()) return AnsiStyle.Default
+
+        var style = current
+        val codes = params.split(';').mapNotNull { it.toIntOrNull() }
+        if (codes.isEmpty()) return AnsiStyle.Default
+
+        var idx = 0
+        while (idx < codes.size) {
+            when (val code = codes[idx]) {
+                0 -> style = AnsiStyle.Default
+                1 -> style = style.copy(bold = true, dim = false)
+                2 -> style = style.copy(dim = true, bold = false)
+                22 -> style = style.copy(bold = false, dim = false)
+                39 -> style = style.copy(foreground = null)
+                in 30..37 -> style = style.copy(foreground = standardColor(code - 30, bright = false))
+                in 90..97 -> style = style.copy(foreground = standardColor(code - 90, bright = true))
+                38 -> {
+                    // 38;5;n or 38;2;r;g;b — approximate to nearest named color or ignore.
+                    val (color, consumed) = parseExtendedColor(codes, idx + 1)
+                    if (color != null) style = style.copy(foreground = color)
+                    idx += consumed
+                }
+                // Background codes intentionally ignored for monospace job logs.
+                in 40..47, in 100..107, 48, 49 -> {
+                    if (code == 48) {
+                        val (_, consumed) = parseExtendedColor(codes, idx + 1)
+                        idx += consumed
+                    }
+                }
+            }
+            idx++
+        }
+        return style
+    }
+
+    private fun parseExtendedColor(codes: List<Int>, start: Int): Pair<AnsiNamedColor?, Int> {
+        if (start >= codes.size) return null to 0
+        return when (codes[start]) {
+            5 -> {
+                if (start + 1 >= codes.size) return null to 1
+                val n = codes[start + 1]
+                approximate256(n) to 2
+            }
+            2 -> {
+                // Skip r;g;b — no named mapping; consume 4 values (2 + r + g + b) relative to start-1... 
+                // codes[start]=2, then r,g,b → consume 4
+                if (start + 3 >= codes.size) return null to (codes.size - start)
+                null to 4
+            }
+            else -> null to 0
+        }
+    }
+
+    private fun approximate256(n: Int): AnsiNamedColor? = when (n) {
+        in 0..7 -> standardColor(n, bright = false)
+        in 8..15 -> standardColor(n - 8, bright = true)
+        else -> null
+    }
+
+    private fun standardColor(index: Int, bright: Boolean): AnsiNamedColor =
+        when (index) {
+            0 -> if (bright) AnsiNamedColor.BRIGHT_BLACK else AnsiNamedColor.BLACK
+            1 -> if (bright) AnsiNamedColor.BRIGHT_RED else AnsiNamedColor.RED
+            2 -> if (bright) AnsiNamedColor.BRIGHT_GREEN else AnsiNamedColor.GREEN
+            3 -> if (bright) AnsiNamedColor.BRIGHT_YELLOW else AnsiNamedColor.YELLOW
+            4 -> if (bright) AnsiNamedColor.BRIGHT_BLUE else AnsiNamedColor.BLUE
+            5 -> if (bright) AnsiNamedColor.BRIGHT_MAGENTA else AnsiNamedColor.MAGENTA
+            6 -> if (bright) AnsiNamedColor.BRIGHT_CYAN else AnsiNamedColor.CYAN
+            else -> if (bright) AnsiNamedColor.BRIGHT_WHITE else AnsiNamedColor.WHITE
+        }
+
+    private fun mergeAdjacent(spans: List<AnsiSpan>): List<AnsiSpan> {
+        if (spans.size <= 1) return spans
+        val merged = ArrayList<AnsiSpan>(spans.size)
+        var current = spans.first()
+        for (i in 1 until spans.size) {
+            val next = spans[i]
+            if (next.style == current.style) {
+                current = AnsiSpan(current.text + next.text, current.style)
+            } else {
+                merged += current
+                current = next
+            }
+        }
+        merged += current
+        return merged
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/util/AnsiParserTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/util/AnsiParserTest.kt
@@ -63,6 +63,17 @@ class AnsiParserTest {
     }
 
     @Test
+    fun overlong_csi_mid_stream_does_not_abort_rest_of_log() {
+        // CSI params longer than MAX_CSI_LENGTH without a final byte, then a valid SGR.
+        val junk = "0;".repeat(40) // 80 chars of params, no final
+        val input = "pre\u001B[$junk\u001B[31mRED\u001B[0m post"
+        val spans = AnsiParser.parse(input)
+        assertTrue(spans.any { it.text.contains("RED") && it.style.foreground == AnsiNamedColor.RED })
+        assertTrue(AnsiParser.strip(input).contains("RED"))
+        assertTrue(AnsiParser.strip(input).endsWith(" post"))
+    }
+
+    @Test
     fun merges_adjacent_same_style() {
         val input = "\u001B[32ma\u001B[32mb\u001B[0m"
         val spans = AnsiParser.parse(input)

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/util/AnsiParserTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/util/AnsiParserTest.kt
@@ -1,0 +1,89 @@
+package io.github.leogallego.ansiblejane.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AnsiParserTest {
+
+    @Test
+    fun plain_text_passthrough() {
+        val spans = AnsiParser.parse("PLAY [all] ***")
+        assertEquals(1, spans.size)
+        assertEquals("PLAY [all] ***", spans.single().text)
+        assertEquals(AnsiStyle.Default, spans.single().style)
+    }
+
+    @Test
+    fun strips_and_colors_basic_sgr() {
+        val input = "\u001B[31mFAILED\u001B[0m ok"
+        val spans = AnsiParser.parse(input)
+        assertEquals(2, spans.size)
+        assertEquals("FAILED", spans[0].text)
+        assertEquals(AnsiNamedColor.RED, spans[0].style.foreground)
+        assertEquals(" ok", spans[1].text)
+        assertEquals(AnsiStyle.Default, spans[1].style)
+        assertEquals("FAILED ok", AnsiParser.strip(input))
+    }
+
+    @Test
+    fun bold_and_bright_green() {
+        val input = "\u001B[1;92mchanged\u001B[0m"
+        val spans = AnsiParser.parse(input)
+        assertEquals(1, spans.size)
+        assertEquals("changed", spans[0].text)
+        assertTrue(spans[0].style.bold)
+        assertEquals(AnsiNamedColor.BRIGHT_GREEN, spans[0].style.foreground)
+    }
+
+    @Test
+    fun dim_style() {
+        val input = "\u001B[2mskipping\u001B[22m done"
+        val spans = AnsiParser.parse(input)
+        assertEquals(2, spans.size)
+        assertTrue(spans[0].style.dim)
+        assertEquals("skipping", spans[0].text)
+        assertEquals(" done", spans[1].text)
+        assertEquals(AnsiStyle.Default, spans[1].style)
+    }
+
+    @Test
+    fun incomplete_escape_kept_as_plain_text() {
+        val input = "hello \u001B[31"
+        val spans = AnsiParser.parse(input)
+        assertEquals(1, spans.size)
+        assertEquals(input, spans.single().text)
+    }
+
+    @Test
+    fun incomplete_esc_only_kept() {
+        val input = "tail\u001B"
+        val spans = AnsiParser.parse(input)
+        assertEquals("tail\u001B", spans.single().text)
+    }
+
+    @Test
+    fun merges_adjacent_same_style() {
+        val input = "\u001B[32ma\u001B[32mb\u001B[0m"
+        val spans = AnsiParser.parse(input)
+        assertEquals(1, spans.size)
+        assertEquals("ab", spans.single().text)
+        assertEquals(AnsiNamedColor.GREEN, spans.single().style.foreground)
+    }
+
+    @Test
+    fun strips_non_sgr_csi() {
+        val input = "a\u001B[2Kb"
+        assertEquals("ab", AnsiParser.strip(input))
+    }
+
+    @Test
+    fun ansible_like_mixed_line() {
+        val input = "\u001B[0;32mok\u001B[0m: [localhost] => \u001B[0;33m{\u001B[0m\"msg\": \"hi\"\u001B[0;33m}\u001B[0m"
+        val text = AnsiParser.strip(input)
+        assertEquals("ok: [localhost] => {\"msg\": \"hi\"}", text)
+        val spans = AnsiParser.parse(input)
+        assertTrue(spans.any { it.style.foreground == AnsiNamedColor.GREEN })
+        assertTrue(spans.any { it.style.foreground == AnsiNamedColor.YELLOW })
+    }
+}


### PR DESCRIPTION
## Summary
- **#340** — Read vs write badges on assistant tool chips (and streaming tool row) using existing `Tool.isDestructive`; confirmation flow unchanged
- **#267** — Shared ANSI CSI/SGR parser + Material 3–mapped `AnnotatedString` rendering for job stdout (Job Status + workflow node output)
- **#266** — Material 3 `SwipeToDismissBox` actions: template favorite, job details, session-local notification dismiss; click targets and favorite star kept

Independent of Session 2 (#120 / #439); no ToolRouter / ChatEngine routing / MCP client changes.

## Test plan
- [x] `:shared:jvmTest` — `AnsiParserTest`
- [x] `:composeApp:desktopTest` — `ToolCallIndicatorTest`, `SwipeActionBoxTest`, existing list screen tests
- [ ] Manual: assistant chat — read tool shows eye badge; write tool shows edit/warning-colored badge; confirmation still only for destructive tools
- [ ] Manual: job stdout with ANSI colors renders green/red/yellow-ish via theme tokens; incomplete escape sequences do not crash
- [ ] Manual: swipe template → favorite toggles and snaps back; star button still works; swipe job → opens details; swipe notification → hides until refresh; tap still opens items

Closes #340, Closes #267, Closes #266