### PR TITLE
chore: bump version to v0.8.7-alpha.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.experimental.enableScreenshotTest=true
 kotlin.native.ignoreDisabledTargets=true
-appVersionName=0.8.6-alpha.2
-appVersionCode=26062302
+appVersionName=0.8.7-alpha.0
+appVersionCode=26080600


### PR DESCRIPTION
Automated version bump for release v0.8.7-alpha.0.

Includes merges since v0.8.6-alpha.2 (deps/maintenance, ToolRouter Tier 1, architecture hygiene, UX polish #442).

Merging this PR will auto-tag `v0.8.7-alpha.0` and dispatch the Release workflow.

Assisted-by: Cursor (Grok 4.5)