### PR TITLE
fix(android): enable androidResources for CMP string packaging

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -60,6 +60,13 @@ kotlin {
         namespace = "io.github.leogallego.ansiblejane.composeapp"
         compileSdk = 37
         minSdk = 31
+        // Required for Compose Multiplatform resources (.cvr) to package into the APK.
+        // AGP's com.android.kotlin.multiplatform.library leaves this off by default;
+        // without it, stringResource() crashes with MissingResourceException (CMP-9547).
+        // https://kotlinlang.org/docs/multiplatform/compose-multiplatform-resources-setup.html#resources-in-the-androidlibrary-target
+        androidResources {
+            enable = true
+        }
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
         }


### PR DESCRIPTION
## Summary
- Enable `androidResources { enable = true }` on `:composeApp`'s Android KMP target so Compose Multiplatform `.cvr` assets are packaged into the APK
- Fixes launch crash after #412: `MissingResourceException` for `strings.commonMain.cvr` (CMP-9547 / documented AGP opt-in)

## Test plan
- [x] `./gradlew :composeApp:copyAndroidMainComposeResourcesToAndroidAssets` succeeds
- [x] Debug APK contains `assets/composeResources/.../strings.commonMain.cvr`
- [x] Emulator launch reaches auth screen (no MissingResourceException)
- [ ] CI green
- [ ] Follow-up: cut `v0.8.7-alpha.1` after merge

Assisted-by: Cursor (Grok 4.5)