### PR TITLE
chore: bump version to v0.8.7-alpha.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.experimental.enableScreenshotTest=true
 kotlin.native.ignoreDisabledTargets=true
-appVersionName=0.8.7-alpha.0
-appVersionCode=26080600
+appVersionName=0.8.7-alpha.1
+appVersionCode=26080601


### PR DESCRIPTION
Automated version bump for release v0.8.7-alpha.1.

Includes #445 fix: enable androidResources so CMP strings package into the Android APK.

Assisted-by: Cursor (Grok 4.5)