### PR TITLE
ci: trigger F-Droid after successful release APK

### DIFF
--- a/.github/workflows/fdroid-repo.yml
+++ b/.github/workflows/fdroid-repo.yml
@@ -1,9 +1,8 @@
 name: Update F-Droid repo
 
+# Triggered explicitly from Build and Release after a successful APK upload
+# (workflow_run misses re-runs after a failed first attempt). Manual dispatch OK.
 on:
-  workflow_run:
-    workflows: ["Build and Release"]
-    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -18,9 +17,6 @@ concurrency:
 jobs:
   update-repo:
     name: Build and deploy F-Droid repo
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -559,3 +559,11 @@ jobs:
             ansible-jane-desktop-macos-*.dmg
             ansible-jane-desktop-windows-*.msi
           prerelease: ${{ contains(env.RELEASE_TAG, '-') }}
+
+      # workflow_dispatch (unlike workflow_run) still fires when this job is re-run
+      # after a failed APK attempt — that was how alpha.1 missed F-Droid indexing.
+      - name: Trigger F-Droid repo update
+        if: needs.apk.result == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run fdroid-repo.yml --ref main


### PR DESCRIPTION
## Summary
- Build and Release now dispatches **Update F-Droid repo** when the APK job succeeded (including after a job re-run)
- Drop `workflow_run` trigger that skipped F-Droid for `v0.8.7-alpha.1` after the APK rate-limit failure/re-run
- Manual **Update F-Droid repo** still available (already dispatched to index alpha.1)

## Test plan
- [ ] Watch the manual F-Droid run index `0.8.7-alpha.1`
- [ ] Confirm live index at https://jane.ansible.ar/fdroid/repo lists alpha.1
- [ ] Next release should auto-trigger F-Droid without a manual dispatch

Assisted-by: Cursor (Grok 4.5)