### PR TITLE
perf(assistant): reduce tool schema token cost per query (#330)

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -207,8 +207,8 @@ class AssistantViewModel(
             toolRouter.registerMcpTools(mcpTools)
 
             Log.d(TAG, "ROUTE: query=\"$text\", ${localTools.size} local, ${mcpTools.size} mcp, role=$aapRole")
-            val queryResult = toolRouter.getToolsForQuery(text, serverConfigs, aapRole)
             val mode = config.tokenSavingMode
+            val queryResult = toolRouter.getToolsForQuery(text, serverConfigs, aapRole, mode)
             Log.d(TAG, "ROUTE: categoryMatched=${queryResult.categoryMatched}, " +
                 "${queryResult.tools.size} tools selected, mode=$mode")
 
@@ -290,7 +290,8 @@ class AssistantViewModel(
                     val result = deferred.await()
                     updateState { copy(pendingConfirmation = null) }
                     result
-                }
+                },
+                tokenSavingMode = mode
             ).collect { event ->
                     when (event) {
                         is ChatEvent.TextDelta -> {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
@@ -11,8 +11,10 @@ import io.github.leogallego.ansiblejane.assistant.llm.LlmProvider
 import io.github.leogallego.ansiblejane.assistant.llm.LlmRateLimitException
 import io.github.leogallego.ansiblejane.assistant.llm.LlmServerException
 import io.github.leogallego.ansiblejane.assistant.llm.LlmTimeoutException
+import io.github.leogallego.ansiblejane.assistant.data.TokenSavingMode
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.assistant.tools.toSchemaCompression
 import io.github.leogallego.ansiblejane.assistant.tools.toToolDescriptor
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.ensureActive
@@ -54,7 +56,9 @@ class ChatEngine(
         tools: List<ToolSpec>,
         maxTokens: Int? = null,
         contextChars: Int = DEFAULT_CONTEXT_CHARS,
-        onConfirmationRequired: (suspend (toolName: String, description: String, args: JsonObject) -> Boolean)? = null
+        onConfirmationRequired: (suspend (toolName: String, description: String, args: JsonObject) -> Boolean)? = null,
+        /** #330: STANDARD keeps full schemas; TOKEN_SAVER strips optional param detail. */
+        tokenSavingMode: TokenSavingMode = TokenSavingMode.STANDARD
     ): Flow<ChatEvent> = flow {
         var accInputTokens = 0
         var accOutputTokens = 0
@@ -68,9 +72,11 @@ class ChatEngine(
                 .forEach { messages.add(it) }
 
             // #439: stable alphabetical order so LLM KV/prefix caches can reuse tool schemas
+            // #330: schema compression by TokenSavingMode
+            val compression = tokenSavingMode.toSchemaCompression()
             val toolDescriptors = tools
                 .sortedBy { it.name }
-                .map { it.toToolDescriptor() }
+                .map { it.toToolDescriptor(compression) }
             val toolSchemaChars = toolDescriptors.sumOf {
                 it.name.length + it.description.length +
                     it.requiredParameters.sumOf { p -> p.name.length + p.description.length + 20 } +
@@ -78,7 +84,8 @@ class ChatEngine(
             }
             val msgChars = messages.sumOf { it.content.length }
             Log.d(TAG, "PAYLOAD: ${tools.size} tools (~${toolSchemaChars} schema chars), " +
-                "${messages.size} messages (~${msgChars} msg chars), total ~${toolSchemaChars + msgChars} chars")
+                "${messages.size} messages (~${msgChars} msg chars), mode=$tokenSavingMode/$compression, " +
+                "total ~${toolSchemaChars + msgChars} chars")
             Log.d(TAG, "PAYLOAD tools: ${tools.map { it.name }}")
             var iterations = 0
             var totalToolCalls = 0

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -2,6 +2,7 @@ package io.github.leogallego.ansiblejane.assistant.engine
 
 import io.github.leogallego.ansiblejane.TestOnly
 import io.github.leogallego.ansiblejane.assistant.data.IAssistantRepository
+import io.github.leogallego.ansiblejane.assistant.data.TokenSavingMode
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
@@ -314,6 +315,15 @@ class ToolRouter(
         /** Cap for meta-search results returned into the LLM tool list. */
         const val MAX_META_SEARCH_RESULTS = 20
 
+        /** Soft top-K for category-matched tools (#330). Generous enough to avoid hard top-1 FNs. */
+        const val TOP_K_STANDARD = 5
+        const val TOP_K_TOKEN_SAVER = 3
+
+        fun softTopK(mode: TokenSavingMode): Int = when (mode) {
+            TokenSavingMode.STANDARD -> TOP_K_STANDARD
+            TokenSavingMode.TOKEN_SAVER, TokenSavingMode.TOOLS_ONLY -> TOP_K_TOKEN_SAVER
+        }
+
         /** Synonym expansion applied to query tokens before stemming (#120 Tier 1). */
         val SYNONYMS = mapOf(
             "playbook" to setOf("job", "template"),
@@ -530,12 +540,14 @@ class ToolRouter(
         query: String,
         serverConfigs: List<McpServerConfig> = emptyList(),
         /** Default OPERATOR for callers that omit role; pass explicit role from the active instance. Unknown/`null` fail-closes. */
-        aapRole: AapRole? = AapRole.OPERATOR
+        aapRole: AapRole? = AapRole.OPERATOR,
+        /** Soft top-K after overlap scoring (#330). STANDARD stays slightly generous. */
+        tokenSavingMode: TokenSavingMode = TokenSavingMode.STANDARD
     ): QueryResult = synchronized(this) {
         lastRoutingContext = RoutingContext(serverConfigs, aapRole)
         val queryWords = tokenizeQuery(query)
         val stemmedQuery = stemQueryTokens(queryWords)
-        Log.d(TAG, "QUERY: words=$queryWords, stemmed=$stemmedQuery, role=$aapRole")
+        Log.d(TAG, "QUERY: words=$queryWords, stemmed=$stemmedQuery, role=$aapRole, mode=$tokenSavingMode")
 
         val matchedCategories = Category.entries.filter { category ->
             category.stemmedKeywords.any { it in stemmedQuery }
@@ -586,14 +598,36 @@ class ToolRouter(
         }
 
         Log.d(TAG, "FILTER: ${filteredLocal.size} local, ${routedMcp.size} routed mcp, ${unroutedMcp.size} unrouted mcp")
-        val cherryPickedLocal = cherryPick(filteredLocal, stemmedQuery)
-        val cherryPickedRouted = cherryPick(routedMcp, stemmedQuery)
-        val cherryPickedUnrouted = cherryPick(unroutedMcp, stemmedQuery, requireOverlap = true)
-        val allCherryPicked = cherryPickedLocal + cherryPickedRouted + cherryPickedUnrouted
-        Log.d(TAG, "CHERRY: ${cherryPickedLocal.size} local, ${cherryPickedRouted.size} routed, " +
-            "${cherryPickedUnrouted.size} unrouted [${allCherryPicked.map { it.spec.name }}]")
+        // #330: prefer name/desc overlap for category-routed tools. When any overlaps, list_/get_
+        // boost alone cannot admit zero-overlap siblings (e.g. list_labels for "how many hosts?").
+        // If nothing overlaps, soft top-K fallback keeps category-keyword queries (health/jt/ee)
+        // FN-safe without dumping the whole category. Unrouted MCP always requires overlap.
+        val topK = softTopK(tokenSavingMode)
+        val routedCandidates = filteredLocal + routedMcp
+        val routedOverlap = cherryPickScored(routedCandidates, stemmedQuery, requireOverlap = true)
+        val routedScored = if (routedOverlap.isNotEmpty()) {
+            routedOverlap
+        } else {
+            Log.d(TAG, "CHERRY: zero name/desc overlap on routed — soft top-K category fallback")
+            cherryPickScored(routedCandidates, stemmedQuery, requireOverlap = false)
+        }
+        val unroutedScored = cherryPickScored(unroutedMcp, stemmedQuery, requireOverlap = true)
+        val cherryPicked = (routedScored + unroutedScored)
+            .sortedWith(compareByDescending<ScoredTool> { it.score }.thenBy { it.tool.spec.name })
+            .take(topK)
+            .map { it.tool }
+        Log.d(TAG, "CHERRY: ${cherryPicked.size}/$topK tools [${cherryPicked.map { it.spec.name }}]")
 
-        QueryResult(allCherryPicked, categoryMatched = true)
+        if (cherryPicked.isEmpty()) {
+            val meta = findMetaSearchTool(aapRole)
+            if (meta != null) {
+                Log.d(TAG, "META: category match but empty cherry-pick — inject ${meta.spec.name}")
+                return@synchronized QueryResult(listOf(meta), categoryMatched = true)
+            }
+            return@synchronized QueryResult(emptyList(), categoryMatched = true)
+        }
+
+        QueryResult(cherryPicked, categoryMatched = true)
     }
 
     /**
@@ -718,7 +752,13 @@ class ToolRouter(
         tools: List<Tool>,
         stemmedQuery: Set<String>,
         requireOverlap: Boolean = false
-    ): List<Tool> {
+    ): List<Tool> = cherryPickScored(tools, stemmedQuery, requireOverlap).map { it.tool }
+
+    private fun cherryPickScored(
+        tools: List<Tool>,
+        stemmedQuery: Set<String>,
+        requireOverlap: Boolean = false
+    ): List<ScoredTool> {
         val scored = tools.map { tool ->
             val nameParts = tool.spec.name
                 .split(".", "_")
@@ -745,7 +785,6 @@ class ToolRouter(
             .filter { it.score > 0 && (!requireOverlap || it.overlap > 0) }
             // #439: secondary sort by name for stable KV-cache-friendly ordering
             .sortedWith(compareByDescending<ScoredTool> { it.score }.thenBy { it.tool.spec.name })
-            .map { it.tool }
     }
 
     fun getAllRegisteredTools(): List<Pair<Tool, ToolSource>> = synchronized(this) {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -598,24 +598,40 @@ class ToolRouter(
         }
 
         Log.d(TAG, "FILTER: ${filteredLocal.size} local, ${routedMcp.size} routed mcp, ${unroutedMcp.size} unrouted mcp")
-        // #330: prefer name/desc overlap for category-routed tools. When any overlaps, list_/get_
-        // boost alone cannot admit zero-overlap siblings (e.g. list_labels for "how many hosts?").
-        // If nothing overlaps, soft top-K fallback keeps category-keyword queries (health/jt/ee)
-        // FN-safe without dumping the whole category. Unrouted MCP always requires overlap.
+        // #330: overlap-first PER matched category, then merge. A JOBS tool whose description
+        // contains "status" must not suppress MONITORING's zero-overlap boost fallback.
+        // Within a category: when any tool overlaps, list_/get_ boost alone cannot admit
+        // zero-overlap siblings (e.g. list_labels). Unrouted MCP always requires overlap.
+        // Soft top-K prefers routed tools so unrouted MCP cannot crowd them out.
         val topK = softTopK(tokenSavingMode)
-        val routedCandidates = filteredLocal + routedMcp
-        val routedOverlap = cherryPickScored(routedCandidates, stemmedQuery, requireOverlap = true)
-        val routedScored = if (routedOverlap.isNotEmpty()) {
-            routedOverlap
-        } else {
-            Log.d(TAG, "CHERRY: zero name/desc overlap on routed — soft top-K category fallback")
-            cherryPickScored(routedCandidates, stemmedQuery, requireOverlap = false)
+        val routedBest = linkedMapOf<String, ScoredTool>()
+        for (category in matchedCategories) {
+            val localForCat = filteredLocal.filter { it.spec.name in category.localToolNames }
+            val mcpForCat = routedMcp.filter { tool ->
+                val cats = tool.toolset?.let { TOOLSET_CATEGORY_MAP[it] }
+                cats != null && category in cats
+            }
+            val candidates = localForCat + mcpForCat
+            if (candidates.isEmpty()) continue
+            val overlap = cherryPickScored(candidates, stemmedQuery, requireOverlap = true)
+            val picked = if (overlap.isNotEmpty()) {
+                overlap
+            } else {
+                Log.d(TAG, "CHERRY: ${category.name} zero overlap — soft boost fallback")
+                cherryPickScored(candidates, stemmedQuery, requireOverlap = false)
+            }
+            for (scored in picked) {
+                val key = toolIdentityKey(scored.tool)
+                val existing = routedBest[key]
+                if (existing == null || scored.score > existing.score) {
+                    routedBest[key] = scored
+                }
+            }
         }
-        val unroutedScored = cherryPickScored(unroutedMcp, stemmedQuery, requireOverlap = true)
-        val cherryPicked = (routedScored + unroutedScored)
+        val routedScored = routedBest.values
             .sortedWith(compareByDescending<ScoredTool> { it.score }.thenBy { it.tool.spec.name })
-            .take(topK)
-            .map { it.tool }
+        val unroutedScored = cherryPickScored(unroutedMcp, stemmedQuery, requireOverlap = true)
+        val cherryPicked = fillTopKPreferringRouted(routedScored, unroutedScored, topK)
         Log.d(TAG, "CHERRY: ${cherryPicked.size}/$topK tools [${cherryPicked.map { it.spec.name }}]")
 
         if (cherryPicked.isEmpty()) {
@@ -629,6 +645,31 @@ class ToolRouter(
 
         QueryResult(cherryPicked, categoryMatched = true)
     }
+
+    /** Prefer category-routed tools when filling soft top-K; unrouted fills remaining slots only. */
+    private fun fillTopKPreferringRouted(
+        routedScored: List<ScoredTool>,
+        unroutedScored: List<ScoredTool>,
+        topK: Int
+    ): List<Tool> {
+        if (topK <= 0) return emptyList()
+        val result = ArrayList<Tool>(topK)
+        val seen = HashSet<String>()
+        for (scored in routedScored) {
+            if (result.size >= topK) break
+            val key = toolIdentityKey(scored.tool)
+            if (seen.add(key)) result.add(scored.tool)
+        }
+        for (scored in unroutedScored) {
+            if (result.size >= topK) break
+            val key = toolIdentityKey(scored.tool)
+            if (seen.add(key)) result.add(scored.tool)
+        }
+        return result
+    }
+
+    private fun toolIdentityKey(tool: Tool): String =
+        "${tool.spec.name}\u0000${tool.serverLabel ?: ""}\u0000${if (tool is LocalTool) "L" else "M"}"
 
     /**
      * Search all enabled tools by name + description tokens (meta-search / #120).

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolDescriptorMapping.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolDescriptorMapping.kt
@@ -3,6 +3,7 @@ package io.github.leogallego.ansiblejane.assistant.tools
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
+import io.github.leogallego.ansiblejane.assistant.data.TokenSavingMode
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -10,7 +11,24 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
-fun ToolSpec.toToolDescriptor(): ToolDescriptor {
+/**
+ * How much JSON Schema detail to send to the LLM for each tool (#330).
+ * FULL ≈ STANDARD; STRIPPED ≈ TOKEN_SAVER (required params kept, optionals folded into description).
+ * Minimal/lazy full-schema (TOOLS_ONLY 2-call path) is deferred.
+ */
+enum class SchemaCompressionLevel {
+    FULL,
+    STRIPPED
+}
+
+fun TokenSavingMode.toSchemaCompression(): SchemaCompressionLevel = when (this) {
+    TokenSavingMode.STANDARD -> SchemaCompressionLevel.FULL
+    TokenSavingMode.TOKEN_SAVER, TokenSavingMode.TOOLS_ONLY -> SchemaCompressionLevel.STRIPPED
+}
+
+fun ToolSpec.toToolDescriptor(
+    compression: SchemaCompressionLevel = SchemaCompressionLevel.FULL
+): ToolDescriptor {
     val schema = compactSchema(parametersSchema)
     val properties = schema["properties"]?.jsonObject ?: emptyMap()
     val requiredNames = schema["required"]?.jsonArray
@@ -18,6 +36,7 @@ fun ToolSpec.toToolDescriptor(): ToolDescriptor {
 
     val required = mutableListOf<ToolParameterDescriptor>()
     val optional = mutableListOf<ToolParameterDescriptor>()
+    val optionalNames = mutableListOf<String>()
 
     properties.forEach { (paramName, paramValue) ->
         val prop = paramValue.jsonObject
@@ -26,12 +45,25 @@ fun ToolSpec.toToolDescriptor(): ToolDescriptor {
             description = prop["description"]?.jsonPrimitive?.content ?: paramName,
             type = parseParamType(prop)
         )
-        if (paramName in requiredNames) required.add(descriptor) else optional.add(descriptor)
+        if (paramName in requiredNames) {
+            required.add(descriptor)
+        } else {
+            optionalNames.add(paramName)
+            if (compression == SchemaCompressionLevel.FULL) {
+                optional.add(descriptor)
+            }
+        }
+    }
+
+    val finalDescription = when {
+        compression == SchemaCompressionLevel.STRIPPED && optionalNames.isNotEmpty() ->
+            "$description. Optional: ${optionalNames.joinToString(", ")}"
+        else -> description
     }
 
     return ToolDescriptor(
         name = name,
-        description = description,
+        description = finalDescription,
         requiredParameters = required,
         optionalParameters = optional
     )

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -1015,20 +1015,25 @@ class ToolRouterTest {
 
     @Test
     fun `SHOULD match both JOBS and MONITORING via keyword status`() {
+        // Production-like descriptions: list_jobs contains "status" so overlap-first must be
+        // per-category — otherwise MONITORING never gets the zero-overlap boost fallback.
         val tools = listOf(
-            localTool("list_jobs"),
-            localTool("get_job"),
-            localTool("list_instances"),
-            localTool("ping"),
-            localTool("list_hosts")
+            localTool("list_jobs", description = "List recent jobs with optional status filter"),
+            localTool("get_job", description = "Get job details by ID"),
+            localTool("list_instances", description = "List controller instances"),
+            localTool("ping", description = "Ping the controller API"),
+            localTool("list_hosts", description = "List hosts, optionally filtered by inventory ID")
         )
         router.registerLocalTools(tools)
 
         val result = router.getToolsForQuery("what is the status").tools
         val names = result.map { it.spec.name }
 
-        assertTrue("list_jobs" in names || "get_job" in names)
-        assertTrue("list_instances" in names || "ping" in names)
+        assertTrue("list_jobs" in names || "get_job" in names, "JOBS tools expected, got $names")
+        assertTrue(
+            "list_instances" in names || "ping" in names,
+            "MONITORING must survive when JOBS already has desc overlap on 'status'; got $names"
+        )
     }
 
     @Test
@@ -2130,5 +2135,55 @@ class ToolRouterTest {
         assertTrue(standard >= saver, "STANDARD=$standard should be >= TOKEN_SAVER=$saver")
         assertTrue(saver <= 3, "TOKEN_SAVER soft top-K expected <= 3, got $saver")
         assertTrue(standard <= 5, "STANDARD soft top-K expected <= 5, got $standard")
+    }
+
+    @Test
+    fun `golden status query with production list_jobs desc SHOULD keep MONITORING tools`() {
+        router.registerLocalTools(
+            listOf(
+                localTool("list_jobs", description = "List recent jobs with optional status filter"),
+                localTool("get_job", description = "Get job details by ID"),
+                localTool("list_instances", description = "List controller instances"),
+                localTool("ping", description = "Ping the controller API"),
+                localTool("get_mesh_topology", description = "Get mesh visualizer topology"),
+                localTool("search_available_tools", description = "Search available tools")
+            )
+        )
+
+        val names = router.getToolsForQuery("what is the status").tools.map { it.spec.name }
+        assertTrue("list_jobs" in names)
+        assertTrue(
+            "list_instances" in names || "ping" in names,
+            "Per-category overlap-first must not drop MONITORING; got $names"
+        )
+        assertFalse("search_available_tools" in names)
+    }
+
+    @Test
+    fun `soft top-K SHOULD prefer routed tools over unrouted when filling budget`() {
+        // Equal-score unrouted tools that sort alphabetically before list_hosts would fill top-K=3
+        // under a naive merged take(); routed-preferring fill must keep list_hosts.
+        val local = listOf(
+            localTool("list_hosts", description = "List hosts in inventory")
+        )
+        val unrouted = (1..6).map { i ->
+            ToolStub(
+                name = "aaa_list_hosts_$i",
+                serverLabel = "cmdb",
+                toolset = null,
+                description = "List hosts in inventory"
+            )
+        }
+        router.registerLocalTools(local)
+        router.registerMcpTools(unrouted)
+
+        val names = router.getToolsForQuery(
+            "how many hosts?",
+            listOf(readWriteConfig),
+            tokenSavingMode = TokenSavingMode.TOKEN_SAVER // top-K = 3
+        ).tools.map { it.spec.name }
+
+        assertTrue("list_hosts" in names, "Routed local tool must not be displaced by unrouted MCP; got $names")
+        assertTrue(names.size <= ToolRouter.TOP_K_TOKEN_SAVER)
     }
 }

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -1,6 +1,7 @@
 package io.github.leogallego.ansiblejane.assistant.engine
 
 import io.github.leogallego.ansiblejane.TestOnly
+import io.github.leogallego.ansiblejane.assistant.data.TokenSavingMode
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolStub
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
@@ -73,16 +74,17 @@ class ToolRouterTest {
 
     @Test
     fun `SHOULD select inventory tools WHEN query mentions hosts`() {
-        val inventoryLocal = localTool("list_hosts")
-        val inventoryLocal2 = localTool("list_inventories")
-        val jobLocal = localTool("list_jobs")
+        val inventoryLocal = localTool("list_hosts", description = "List hosts in inventory")
+        val inventoryLocal2 = localTool("list_inventories", description = "List inventories")
+        val jobLocal = localTool("list_jobs", description = "List jobs")
 
         router.registerLocalTools(listOf(inventoryLocal, inventoryLocal2, jobLocal))
         val result = router.getToolsForQuery("list my hosts").tools
         val names = result.map { it.spec.name }
 
         assertTrue("list_hosts" in names)
-        assertTrue("list_inventories" in names)
+        // #330: list_inventories has no name/desc overlap with "hosts" — do not admit via list_ boost
+        assertFalse("list_inventories" in names)
         assertFalse("list_jobs" in names)
     }
 
@@ -296,7 +298,8 @@ class ToolRouterTest {
         val names = result.map { it.spec.name }
 
         assertTrue("hosts_list" in names)
-        assertTrue("inventories_list" in names)
+        // #330: inventories_list has no name/desc overlap with "hosts" once hosts_list matches
+        assertFalse("inventories_list" in names)
         assertFalse("hosts_create" in names)
         assertFalse("hosts_update" in names)
         assertFalse("hosts_delete" in names)
@@ -365,7 +368,8 @@ class ToolRouterTest {
         val names = result.map { it.spec.name }
 
         assertTrue("hosts_list" in names)
-        assertTrue("groups_list" in names)
+        // #330: groups_list no longer admitted via list_ boost alone when hosts_list overlaps
+        assertFalse("groups_list" in names)
         assertFalse("jobs_retrieve" in names)
         assertFalse("users_list" in names)
     }
@@ -422,7 +426,8 @@ class ToolRouterTest {
 
         assertTrue("users_list" in names)
         assertTrue("teams_list" in names)
-        assertTrue("organizations_list" in names)
+        // #330: organizations_list has no user/team overlap once users/teams match
+        assertFalse("organizations_list" in names)
         assertFalse("hosts_list" in names)
     }
 
@@ -456,7 +461,8 @@ class ToolRouterTest {
 
         assertTrue("settings_retrieve" in names)
         assertTrue("projects_list" in names)
-        assertTrue("notification_templates_list" in names)
+        // #330: notification_templates_list has no project/settings overlap
+        assertFalse("notification_templates_list" in names)
         assertFalse("hosts_list" in names)
     }
 
@@ -630,7 +636,8 @@ class ToolRouterTest {
         assertTrue("list_instances" in names)
         assertTrue("get_instance" in names)
         assertTrue("list_instance_groups" in names)
-        assertTrue("ping" in names)
+        // #330: ping has no "instance" overlap once instance tools match
+        assertFalse("ping" in names)
         assertFalse("list_hosts" in names)
     }
 
@@ -772,7 +779,8 @@ class ToolRouterTest {
         val names = result.map { it.spec.name }
 
         assertTrue("get_mesh_topology" in names)
-        assertTrue("list_instances" in names)
+        // #330: list_instances has no mesh/topology overlap once get_mesh_topology matches
+        assertFalse("list_instances" in names)
         assertFalse("list_hosts" in names)
     }
 
@@ -1026,16 +1034,17 @@ class ToolRouterTest {
     @Test
     fun `SHOULD match both INVENTORY and MONITORING via keyword group`() {
         val tools = listOf(
-            localTool("list_hosts"),
-            localTool("list_inventories"),
-            localTool("list_instance_groups")
+            localTool("list_groups", description = "List groups in an inventory"),
+            localTool("list_inventories", description = "List inventories"),
+            localTool("list_instance_groups", description = "List instance groups")
         )
         router.registerLocalTools(tools)
 
         val result = router.getToolsForQuery("show groups").tools
         val names = result.map { it.spec.name }
 
-        assertTrue(names.size >= 2)
+        assertTrue("list_groups" in names || "list_instance_groups" in names)
+        assertTrue(names.size >= 2, "Expected inventory + monitoring group tools, got $names")
     }
 
     // --- Cherry-pick tests ---
@@ -1083,22 +1092,24 @@ class ToolRouterTest {
     }
 
     @Test
-    fun `SHOULD fallback to list tools WHEN no cherry-pick overlap`() {
+    fun `SHOULD soft top-K category fallback WHEN category matches but no name or desc overlap`() {
+        // Category keyword "healthy" matches MONITORING; tool names/descs have no overlap.
+        // Pre-#330 admitted the whole category via list_/ping boost; now soft top-K only.
         val tools = listOf(
-            localTool("list_instances"),
-            localTool("get_instance"),
-            localTool("list_instance_groups"),
-            localTool("ping"),
-            localTool("get_mesh_topology")
+            localTool("list_instances", description = "List controller instances"),
+            localTool("get_instance", description = "Get a controller instance by ID"),
+            localTool("list_instance_groups", description = "List instance groups"),
+            localTool("ping", description = "Ping the controller API"),
+            localTool("get_mesh_topology", description = "Get mesh visualizer topology")
         )
         router.registerLocalTools(tools)
 
-        val result = router.getToolsForQuery("is everything healthy?").tools
-        val names = result.map { it.spec.name }
-
-        assertTrue("list_instances" in names)
-        assertTrue("list_instance_groups" in names)
-        assertTrue("ping" in names)
+        val result = router.getToolsForQuery("is everything healthy?")
+        val names = result.tools.map { it.spec.name }
+        assertTrue(result.categoryMatched)
+        assertTrue(names.isNotEmpty())
+        assertTrue(names.size <= ToolRouter.TOP_K_STANDARD)
+        assertTrue("list_instances" in names || "ping" in names)
     }
 
     @Test
@@ -1184,7 +1195,11 @@ class ToolRouterTest {
         val names = result.map { it.spec.name }
 
         assertTrue("list_platform_services" in names)
-        assertTrue("list_service_clusters" in names)
+        // Soft top-K may drop lower-scoring platform siblings; service_clusters still ranks on "services"
+        assertTrue(
+            "list_service_clusters" in names || names.any { it.startsWith("list_platform_") },
+            "Expected platform/service tools in soft top-K, got $names"
+        )
         assertFalse("list_hosts" in names)
     }
 
@@ -2020,5 +2035,100 @@ class ToolRouterTest {
                 "$name unexpectedly matches WRITE_SUFFIXES — remove from DESTRUCTIVE_LOCAL_TOOL_NAMES"
             )
         }
+    }
+
+    // --- #330 golden queries: require name/desc overlap (no list_/get_ boost-only leakage) ---
+
+    private fun inventoryFixtureTools() = listOf(
+        localTool("list_inventories", description = "List inventories with optional search filter"),
+        localTool("list_hosts", description = "List hosts, optionally filtered by inventory ID or search term"),
+        localTool("get_host_facts", description = "Get Ansible facts for a specific host by ID"),
+        localTool("get_host_job_summaries", description = "Get job host summaries for a host"),
+        localTool("list_groups", description = "List groups in an inventory"),
+        localTool("list_inventory_sources", description = "List inventory sources"),
+        localTool("list_labels", description = "List labels used for tagging templates and other resources"),
+        localTool("search_available_tools", description = "Search available tools by name or description")
+    )
+
+    @Test
+    fun `golden how many hosts SHOULD include list_hosts and exclude zero-overlap list_labels`() {
+        router.registerLocalTools(inventoryFixtureTools())
+
+        val names = router.getToolsForQuery("how many hosts?").tools.map { it.spec.name }
+
+        assertTrue("list_hosts" in names)
+        assertFalse(
+            "list_labels" in names,
+            "list_labels must not enter via list_ boost alone (zero name/desc overlap with hosts)"
+        )
+    }
+
+    @Test
+    fun `golden host facts query SHOULD keep get_host_facts reachable under soft top-K`() {
+        router.registerLocalTools(inventoryFixtureTools())
+
+        val names = router.getToolsForQuery("host facts for web01").tools.map { it.spec.name }
+
+        assertTrue("get_host_facts" in names, "get_host_facts must not be dropped by soft top-K")
+        assertTrue(names.size <= 5, "STANDARD soft top-K should keep candidate set small, got ${names.size}")
+    }
+
+    @Test
+    fun `golden broad inventory query SHOULD return multiple list tools when overlap justifies`() {
+        router.registerLocalTools(inventoryFixtureTools())
+
+        val names = router.getToolsForQuery("show inventory hosts and groups").tools.map { it.spec.name }
+        val listTools = names.filter { it.startsWith("list_") && it != "list_labels" }
+
+        assertTrue(
+            listTools.size >= 2,
+            "Expected multiple overlapping list_ tools, got $names"
+        )
+        assertTrue("list_hosts" in names)
+        assertTrue("list_groups" in names || "list_inventories" in names)
+    }
+
+    @Test
+    fun `golden trivial and discovery paths SHOULD remain unchanged`() {
+        val search = localTool("search_available_tools", description = "Search available tools")
+        val hosts = localTool("list_hosts", description = "List inventory hosts")
+        router.registerLocalTools(listOf(search, hosts))
+
+        val greeting = router.getToolsForQuery("hello")
+        assertFalse(greeting.categoryMatched)
+        assertTrue(greeting.tools.isEmpty())
+
+        val discovery = router.getToolsForQuery("what can you do?")
+        assertFalse(discovery.categoryMatched)
+        assertEquals(listOf("search_available_tools"), discovery.tools.map { it.spec.name })
+    }
+
+    @Test
+    fun `category match with some overlap SHOULD not admit zero-overlap siblings via list_ boost`() {
+        // Contrasts with zero-overlap soft fallback: once list_hosts matches, list_labels stays out
+        router.registerLocalTools(inventoryFixtureTools())
+
+        val names = router.getToolsForQuery("how many hosts?").tools.map { it.spec.name }.toSet()
+        assertTrue("list_hosts" in names)
+        assertFalse("list_labels" in names)
+        assertFalse("list_inventory_sources" in names)
+    }
+
+    @Test
+    fun `TOKEN_SAVER soft top-K SHOULD be tighter than STANDARD`() {
+        router.registerLocalTools(inventoryFixtureTools())
+
+        val standard = router.getToolsForQuery(
+            "show inventory hosts and groups and facts and sources",
+            tokenSavingMode = TokenSavingMode.STANDARD
+        ).tools.size
+        val saver = router.getToolsForQuery(
+            "show inventory hosts and groups and facts and sources",
+            tokenSavingMode = TokenSavingMode.TOKEN_SAVER
+        ).tools.size
+
+        assertTrue(standard >= saver, "STANDARD=$standard should be >= TOKEN_SAVER=$saver")
+        assertTrue(saver <= 3, "TOKEN_SAVER soft top-K expected <= 3, got $saver")
+        assertTrue(standard <= 5, "STANDARD soft top-K expected <= 5, got $standard")
     }
 }

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolDescriptorMappingTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/tools/ToolDescriptorMappingTest.kt
@@ -1,0 +1,107 @@
+package io.github.leogallego.ansiblejane.assistant.tools
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import io.github.leogallego.ansiblejane.assistant.data.TokenSavingMode
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ToolDescriptorMappingTest {
+
+    private fun listHostsSchema(): JsonObject = buildJsonObject {
+        put("type", JsonPrimitive("object"))
+        put("properties", buildJsonObject {
+            put("inventory_id", buildJsonObject {
+                put("type", JsonPrimitive("integer"))
+                put("description", JsonPrimitive("Filter hosts by inventory ID"))
+            })
+            put("search", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("Search term to filter hosts by name"))
+            })
+            put("page", buildJsonObject {
+                put("type", JsonPrimitive("integer"))
+                put("description", JsonPrimitive("Page number (default 1)"))
+            })
+            put("host_id", buildJsonObject {
+                put("type", JsonPrimitive("integer"))
+                put("description", JsonPrimitive("Required host identifier"))
+            })
+        })
+        put("required", buildJsonArray {
+            add(JsonPrimitive("host_id"))
+        })
+    }
+
+    private fun fixtureSpec() = ToolSpec(
+        name = "list_hosts",
+        description = "List hosts, optionally filtered by inventory ID or search term",
+        parametersSchema = listHostsSchema()
+    )
+
+    private fun schemaChars(descriptor: ToolDescriptor): Int =
+        descriptor.name.length + descriptor.description.length +
+            descriptor.requiredParameters.sumOf { p -> p.name.length + p.description.length + 20 } +
+            descriptor.optionalParameters.sumOf { p -> p.name.length + p.description.length + 20 }
+
+    @Test
+    fun `STANDARD SHOULD keep optional parameters as structured fields`() {
+        val descriptor = fixtureSpec().toToolDescriptor(SchemaCompressionLevel.FULL)
+
+        assertEquals(1, descriptor.requiredParameters.size)
+        assertEquals("host_id", descriptor.requiredParameters.single().name)
+        assertTrue(descriptor.optionalParameters.size >= 3)
+        assertTrue(descriptor.optionalParameters.any { it.name == "inventory_id" })
+        assertTrue(descriptor.optionalParameters.any { it.name == "search" })
+    }
+
+    @Test
+    fun `TOKEN_SAVER SHOULD keep required params and fold optionals into description`() {
+        val descriptor = fixtureSpec().toToolDescriptor(SchemaCompressionLevel.STRIPPED)
+
+        assertEquals(1, descriptor.requiredParameters.size)
+        assertEquals("host_id", descriptor.requiredParameters.single().name)
+        assertTrue(
+            descriptor.requiredParameters.single().description.contains("host"),
+            "Required param description must not be gutted"
+        )
+        assertTrue(descriptor.optionalParameters.isEmpty())
+        assertTrue(
+            descriptor.description.contains("Optional:", ignoreCase = true),
+            "Optional param names should be folded into description: ${descriptor.description}"
+        )
+        assertTrue(descriptor.description.contains("inventory_id"))
+        assertTrue(descriptor.description.contains("search"))
+        assertTrue(descriptor.description.contains("page"))
+    }
+
+    @Test
+    fun `TOKEN_SAVER schemas SHOULD be smaller than STANDARD`() {
+        val full = fixtureSpec().toToolDescriptor(SchemaCompressionLevel.FULL)
+        val stripped = fixtureSpec().toToolDescriptor(SchemaCompressionLevel.STRIPPED)
+
+        val fullChars = schemaChars(full)
+        val strippedChars = schemaChars(stripped)
+        assertTrue(
+            strippedChars < fullChars,
+            "STRIPPED ($strippedChars) should be smaller than FULL ($fullChars)"
+        )
+    }
+
+    @Test
+    fun `TokenSavingMode mapping SHOULD treat TOOLS_ONLY like TOKEN_SAVER for schemas`() {
+        assertEquals(SchemaCompressionLevel.FULL, TokenSavingMode.STANDARD.toSchemaCompression())
+        assertEquals(SchemaCompressionLevel.STRIPPED, TokenSavingMode.TOKEN_SAVER.toSchemaCompression())
+        assertEquals(SchemaCompressionLevel.STRIPPED, TokenSavingMode.TOOLS_ONLY.toSchemaCompression())
+    }
+
+    @Test
+    fun `default toToolDescriptor SHOULD remain FULL for backward compatibility`() {
+        val descriptor = fixtureSpec().toToolDescriptor()
+        assertTrue(descriptor.optionalParameters.isNotEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- **Phase A — tighter routing:** Category-matched local + routed MCP now prefer `requireOverlap = true`, so `list_`/`get_` boost alone cannot admit zero-overlap siblings (e.g. `list_labels` for “how many hosts?”). Soft top-K: STANDARD=5, TOKEN_SAVER/TOOLS_ONLY=3. Unrouted MCP still always requires overlap. Zero-overlap category hits fall back to soft top-K (FN-safe for health/jt/ee); empty sets still inject `search_available_tools`.
- **Phase B — schema compression:** `TokenSavingMode` plumbs into `ChatEngine` → `toToolDescriptor(SchemaCompressionLevel)`. STANDARD = full schemas (current). TOKEN_SAVER/TOOLS_ONLY = keep required params, fold optional names into description (`Optional: …`).
- Golden `ToolRouterTest` queries + `ToolDescriptorMappingTest` size assertions.

## FN mitigations
- Soft top-K (not hard top-1); STANDARD stays slightly generous (K=5).
- Overlap-first path only drops zero-overlap noise when *some* tool already matches.
- Category-keyword-only queries (no name/desc overlap) keep a soft top-K boost fallback.
- Meta-search remains for discovery / empty cherry-pick.

## Deferred
- **TOOLS_ONLY / Minimal lazy full-schema path** (2-call: names first, full schema for picked tool) — follow-up PR.
- Out of scope siblings unchanged: #439 cache hints, #450 result compression, #449 ranking, #448 Session 2, #452 extract.

## Test plan
- [x] `:shared:jvmTest` — `ToolRouterTest` (incl. golden queries)
- [x] `:shared:jvmTest` — `ToolDescriptorMappingTest` (STRIPPED < FULL)
- [x] `:shared:jvmTest` — `ChatEngineTest` / `ChatEngineStreamingTest`
- [x] `:composeApp:compileKotlinDesktop`
- [ ] Optional spot-check: ask Jane “how many hosts?” in STANDARD vs TOKEN_SAVER and compare log `toolSchemaChars`

Refs #330

Assisted-by: Cursor (Grok 4.5)