### PR TITLE
feat(toolrouter): model-capability tiers for tool filtering (#453)

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -3,11 +3,14 @@ package io.github.leogallego.ansiblejane.assistant.presentation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.github.leogallego.ansiblejane.assistant.data.IAssistantRepository
+import io.github.leogallego.ansiblejane.assistant.data.KnownProvider
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.assistant.data.TokenSavingMode
 import io.github.leogallego.ansiblejane.assistant.engine.ChatEngine
 import io.github.leogallego.ansiblejane.assistant.engine.ChatEvent
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
+import io.github.leogallego.ansiblejane.assistant.engine.ModelCapability
+import io.github.leogallego.ansiblejane.assistant.engine.ModelCapabilityResolver
 import io.github.leogallego.ansiblejane.assistant.engine.ResponseSource
 import io.github.leogallego.ansiblejane.assistant.engine.Role
 import io.github.leogallego.ansiblejane.assistant.engine.TokenUsage
@@ -207,10 +210,27 @@ class AssistantViewModel(
             toolRouter.registerMcpTools(mcpTools)
 
             Log.d(TAG, "ROUTE: query=\"$text\", ${localTools.size} local, ${mcpTools.size} mcp, role=$aapRole")
-            val mode = config.tokenSavingMode
-            val queryResult = toolRouter.getToolsForQuery(text, serverConfigs, aapRole, mode)
-            Log.d(TAG, "ROUTE: categoryMatched=${queryResult.categoryMatched}, " +
-                "${queryResult.tools.size} tools selected, mode=$mode")
+            // #453: capability from active provider/model; Simple raises TokenSavingMode ceiling
+            val capability = ModelCapabilityResolver.resolve(
+                provider = KnownProvider.fromUrl(config.url),
+                model = config.model,
+                onDevice = false, // LiteRT / on-device flag lands with #264
+            )
+            val userMode = config.tokenSavingMode
+            val mode = ModelCapabilityResolver.effectiveTokenSavingMode(capability, userMode)
+            val queryResult = toolRouter.getToolsForQuery(
+                query = text,
+                serverConfigs = serverConfigs,
+                aapRole = aapRole,
+                tokenSavingMode = mode,
+                capability = capability,
+            )
+            Log.d(
+                TAG,
+                "ROUTE: categoryMatched=${queryResult.categoryMatched}, " +
+                    "${queryResult.tools.size} tools selected, capability=$capability, " +
+                    "mode=$userMode→$mode"
+            )
 
             // ToolRouter owns meta-search injection; empty means greetings / no match — do not re-inject
             if (queryResult.tools.isEmpty()) {
@@ -249,10 +269,12 @@ class AssistantViewModel(
                 return@launch
             }
 
-            val mcpLimit = when (mode) {
-                TokenSavingMode.STANDARD -> 10
-                TokenSavingMode.TOKEN_SAVER -> 5
-                TokenSavingMode.TOOLS_ONLY -> 3
+            // #453 Simple: MCP already excluded by ToolRouter; keep budget at 0 as defense in depth
+            val mcpLimit = when {
+                capability == ModelCapability.Simple -> 0
+                mode == TokenSavingMode.STANDARD -> 10
+                mode == TokenSavingMode.TOKEN_SAVER -> 5
+                else -> 3 // TOOLS_ONLY
             }
             val matchedLocal = queryResult.tools.filterIsInstance<LocalTool>()
             val matchedMcp = queryResult.tools.filter { it !is LocalTool }.take(mcpLimit)

--- a/docs/reference/tool-pipeline-architecture.md
+++ b/docs/reference/tool-pipeline-architecture.md
@@ -168,17 +168,31 @@ MCP servers with `readOnly: true` in config have write tools filtered out. Detec
 
 Users can toggle individual tools via Settings → Local Tools and MCP Servers tabs. State persisted via `IAssistantRepository.saveToolState()`.
 
-## Token Optimization
+## Token Optimization (#330)
 
-Three tiers control schema verbosity and tool count:
+Three tiers control schema verbosity and soft top-K tool count:
 
-| TokenSavingMode | Description | MCP Tool Cap | Context Chars |
-|-----------------|------------|-------------|--------------|
-| STANDARD | Full conversation with LLM, tools when relevant | 10 | 16,000 |
-| TOKEN_SAVER | Short replies for general chat, tools when relevant | 5 | 8,000 |
-| TOOLS_ONLY | Tools only — no general conversation | 3 | 4,000 |
+| TokenSavingMode | Schema compression | Soft top-K | MCP Tool Cap (ViewModel) | Context Chars |
+|-----------------|-------------------|------------|--------------------------|--------------|
+| STANDARD | FULL (required + optional params) | 5 | 10 | 16,000 |
+| TOKEN_SAVER | STRIPPED (required only; optionals in description) | 3 | 5 | 8,000 |
+| TOOLS_ONLY | STRIPPED (same as TOKEN_SAVER for schemas) | 3 | 3 | 4,000 |
 
-Schema compaction handled by `ToolDescriptorMapping.compactSchema()`.
+Wired via `TokenSavingMode.toSchemaCompression()` → `ToolSpec.toToolDescriptor(SchemaCompressionLevel)`.
+
+## Model Capability Tiers (#453)
+
+`ModelCapability` adapts tool count/complexity to the active model **before** schemas are sent:
+
+| Tier | Typical sources | ToolRouter policy | TokenSavingMode precedence |
+|------|-----------------|-------------------|----------------------------|
+| **Full** | OpenAI, Gemini, OpenRouter, Groq; large self-hosted (≥32B) | Post-#330 category routing + soft top-K; MCP allowed | Honor user's mode |
+| **Simple** | Small Ollama / unknown self-hosted; `onDevice=true` (#264 stub) | Local only (no MCP); schema-complexity filter; hard cap 10; prefer safe allowlist | Tier ceiling = `TOOLS_ONLY` (user cannot relax) |
+
+Resolution: `ModelCapabilityResolver.resolve(KnownProvider, model, onDevice)`.
+ChatEngine retries once without tools on tool-call parse failures (important for Simple/local models).
+
+LiteRT / on-device inference itself remains #264.
 
 ## Known Issues
 
@@ -186,4 +200,4 @@ Schema compaction handled by `ToolDescriptorMapping.compactSchema()`.
 
 ## Planned Improvements
 
-See issue #120 for the 5-phase improvement plan covering semantic search (Model2Vec), model capability tiers, AAP role filtering, and token optimization. See issue #30 for local LLM backend integration.
+See issue #120 for the broader plan (hybrid ranking / Model2Vec → #449, ToolRouter extract → #452). On-device LiteRT → #264.

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
@@ -536,8 +536,10 @@ class ChatEngine(
         private const val DEFAULT_CONTEXT_CHARS = 16_000
 
         /**
-         * Detects malformed tool-call / JSON parse failures from providers or serializers (#453).
-         * Auth, timeout, and IO errors are intentionally excluded so they surface normally.
+         * Detects malformed **tool-call** parse failures from providers or serializers (#453).
+         * Requires tool/function-call context so unrelated parse/serialization errors
+         * (URL, config, settings) are not silently retried without tools.
+         * Auth, timeout, server, and IO errors are excluded so they surface normally.
          */
         internal fun isToolCallParseFailure(error: Throwable): Boolean {
             if (error is LlmAuthException ||
@@ -550,15 +552,33 @@ class ChatEngine(
             }
             val msg = (error.message ?: "").lowercase()
             val name = error::class.simpleName?.lowercase() ?: ""
-            if ("serialization" in name || "jsondecoding" in name || "jsonparsing" in name) {
-                return true
-            }
-            if ("parse" in msg || "malformed" in msg) return true
-            if ("tool" in msg && ("json" in msg || "invalid" in msg || "unexpected" in msg)) {
-                return true
-            }
-            return false
+            val hasToolContext = TOOL_CALL_CONTEXT_MARKERS.any { it in msg }
+            if (!hasToolContext) return false
+
+            val looksLikeParse = "parse" in msg ||
+                "malformed" in msg ||
+                "json" in msg ||
+                "invalid" in msg ||
+                "unexpected" in msg ||
+                "serialization" in name ||
+                "jsondecoding" in name ||
+                "jsonparsing" in name
+            return looksLikeParse
         }
+
+        private val TOOL_CALL_CONTEXT_MARKERS = listOf(
+            "tool call",
+            "tool_call",
+            "tool-call",
+            "toolcall",
+            "function call",
+            "function_call",
+            "function-call",
+            "tool argument",
+            "tool arguments",
+            "tool args",
+            "arguments for tool",
+        )
 
         const val SYSTEM_PROMPT = """You are a concise AI assistant for Ansible Automation Platform (AAP). Rules:
 - NEVER fabricate, invent, or guess data. Only present information returned by tool calls. If a tool call fails, report the error — do not make up results. If you have no tool to answer a question, say so clearly.

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngine.kt
@@ -1,5 +1,6 @@
 package io.github.leogallego.ansiblejane.assistant.engine
 
+import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.Prompt
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.MessagePart
@@ -74,23 +75,30 @@ class ChatEngine(
             // #439: stable alphabetical order so LLM KV/prefix caches can reuse tool schemas
             // #330: schema compression by TokenSavingMode
             val compression = tokenSavingMode.toSchemaCompression()
-            val toolDescriptors = tools
+            var activeToolDescriptors = tools
                 .sortedBy { it.name }
                 .map { it.toToolDescriptor(compression) }
-            val toolSchemaChars = toolDescriptors.sumOf {
-                it.name.length + it.description.length +
-                    it.requiredParameters.sumOf { p -> p.name.length + p.description.length + 20 } +
-                    it.optionalParameters.sumOf { p -> p.name.length + p.description.length + 20 }
+            fun logPayload(descriptors: List<ToolDescriptor>) {
+                val toolSchemaChars = descriptors.sumOf {
+                    it.name.length + it.description.length +
+                        it.requiredParameters.sumOf { p -> p.name.length + p.description.length + 20 } +
+                        it.optionalParameters.sumOf { p -> p.name.length + p.description.length + 20 }
+                }
+                val msgChars = messages.sumOf { it.content.length }
+                Log.d(
+                    TAG,
+                    "PAYLOAD: ${descriptors.size} tools (~${toolSchemaChars} schema chars), " +
+                        "${messages.size} messages (~${msgChars} msg chars), mode=$tokenSavingMode/$compression, " +
+                        "total ~${toolSchemaChars + msgChars} chars"
+                )
+                Log.d(TAG, "PAYLOAD tools: ${descriptors.map { it.name }}")
             }
-            val msgChars = messages.sumOf { it.content.length }
-            Log.d(TAG, "PAYLOAD: ${tools.size} tools (~${toolSchemaChars} schema chars), " +
-                "${messages.size} messages (~${msgChars} msg chars), mode=$tokenSavingMode/$compression, " +
-                "total ~${toolSchemaChars + msgChars} chars")
-            Log.d(TAG, "PAYLOAD tools: ${tools.map { it.name }}")
+            logPayload(activeToolDescriptors)
             var iterations = 0
             var totalToolCalls = 0
             val toolCallHistory = mutableListOf<List<String>>()
             val softLimit = (contextChars * 0.9).toInt()
+            var retriedWithoutTools = false
 
             loop@ while (iterations < maxIterations) {
                 iterations++
@@ -103,45 +111,64 @@ class ChatEngine(
                 trimMessages(messages, contextChars)
                 val prompt = buildPrompt(messages)
 
-                provider.generateStream(prompt, toolDescriptors, maxTokens).collect { frame ->
-                    Log.d(TAG, "FRAME: ${frame::class.simpleName} " +
-                        when (frame) {
-                            is StreamFrame.TextDelta -> "text=${frame.text.take(50)}"
-                            is StreamFrame.ToolCallDelta -> "id=${frame.id} name=${frame.name} content=${frame.content?.take(50)}"
-                            is StreamFrame.ToolCallComplete -> "id=${frame.id} name=${frame.name} content=${frame.content.take(50)}"
-                            is StreamFrame.End -> ""
-                            else -> frame.toString().take(80)
-                        }
-                    )
-                    when (frame) {
-                        is StreamFrame.TextDelta -> {
-                            textBuilder.append(frame.text)
-                            emit(ChatEvent.TextDelta(frame.text))
-                        }
-                        is StreamFrame.ToolCallDelta -> {
-                            val id = frame.id ?: "tool_${syntheticIdCounter}"
-                            val tc = pendingToolCalls.getOrPut(id) { MutableToolCall(id) }
-                            if (frame.name != null) tc.name = frame.name
-                            if (frame.content != null) tc.args.append(frame.content)
-                        }
-                        is StreamFrame.ToolCallComplete -> {
-                            val id = frame.id ?: "tool_${syntheticIdCounter++}"
-                            val tc = pendingToolCalls.getOrPut(id) { MutableToolCall(id) }
-                            tc.name = frame.name
-                            tc.args.clear()
-                            tc.args.append(frame.content)
-                        }
-                        is StreamFrame.End -> {
-                            val meta = frame.metaInfo
-                            if (meta.totalTokensCount != null) {
-                                accInputTokens += meta.inputTokensCount ?: 0
-                                accOutputTokens += meta.outputTokensCount ?: 0
-                                accTotalTokens += meta.totalTokensCount ?: 0
-                                anyRealUsage = true
+                try {
+                    provider.generateStream(prompt, activeToolDescriptors, maxTokens).collect { frame ->
+                        Log.d(TAG, "FRAME: ${frame::class.simpleName} " +
+                            when (frame) {
+                                is StreamFrame.TextDelta -> "text=${frame.text.take(50)}"
+                                is StreamFrame.ToolCallDelta -> "id=${frame.id} name=${frame.name} content=${frame.content?.take(50)}"
+                                is StreamFrame.ToolCallComplete -> "id=${frame.id} name=${frame.name} content=${frame.content.take(50)}"
+                                is StreamFrame.End -> ""
+                                else -> frame.toString().take(80)
                             }
+                        )
+                        when (frame) {
+                            is StreamFrame.TextDelta -> {
+                                textBuilder.append(frame.text)
+                                emit(ChatEvent.TextDelta(frame.text))
+                            }
+                            is StreamFrame.ToolCallDelta -> {
+                                val id = frame.id ?: "tool_${syntheticIdCounter}"
+                                val tc = pendingToolCalls.getOrPut(id) { MutableToolCall(id) }
+                                if (frame.name != null) tc.name = frame.name
+                                if (frame.content != null) tc.args.append(frame.content)
+                            }
+                            is StreamFrame.ToolCallComplete -> {
+                                val id = frame.id ?: "tool_${syntheticIdCounter++}"
+                                val tc = pendingToolCalls.getOrPut(id) { MutableToolCall(id) }
+                                tc.name = frame.name
+                                tc.args.clear()
+                                tc.args.append(frame.content)
+                            }
+                            is StreamFrame.End -> {
+                                val meta = frame.metaInfo
+                                if (meta.totalTokensCount != null) {
+                                    accInputTokens += meta.inputTokensCount ?: 0
+                                    accOutputTokens += meta.outputTokensCount ?: 0
+                                    accTotalTokens += meta.totalTokensCount ?: 0
+                                    anyRealUsage = true
+                                }
+                            }
+                            else -> { /* ReasoningDelta etc — ignore */ }
                         }
-                        else -> { /* ReasoningDelta etc — ignore */ }
                     }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // #453: small/local models often emit malformed tool-call frames.
+                    // Retry once without tools so the model can answer in plain text.
+                    if (!retriedWithoutTools &&
+                        activeToolDescriptors.isNotEmpty() &&
+                        isToolCallParseFailure(e)
+                    ) {
+                        Log.w(TAG, "Tool-call parse failure — retrying without tools: ${e.message}")
+                        retriedWithoutTools = true
+                        activeToolDescriptors = emptyList()
+                        logPayload(activeToolDescriptors)
+                        iterations-- // do not consume an agentic iteration for the failed attempt
+                        continue@loop
+                    }
+                    throw e
                 }
 
                 val completedCalls = pendingToolCalls.values
@@ -507,6 +534,32 @@ class ChatEngine(
     companion object {
         private const val TAG = "ChatEngine"
         private const val DEFAULT_CONTEXT_CHARS = 16_000
+
+        /**
+         * Detects malformed tool-call / JSON parse failures from providers or serializers (#453).
+         * Auth, timeout, and IO errors are intentionally excluded so they surface normally.
+         */
+        internal fun isToolCallParseFailure(error: Throwable): Boolean {
+            if (error is LlmAuthException ||
+                error is LlmRateLimitException ||
+                error is LlmTimeoutException ||
+                error is LlmServerException ||
+                error is IOException
+            ) {
+                return false
+            }
+            val msg = (error.message ?: "").lowercase()
+            val name = error::class.simpleName?.lowercase() ?: ""
+            if ("serialization" in name || "jsondecoding" in name || "jsonparsing" in name) {
+                return true
+            }
+            if ("parse" in msg || "malformed" in msg) return true
+            if ("tool" in msg && ("json" in msg || "invalid" in msg || "unexpected" in msg)) {
+                return true
+            }
+            return false
+        }
+
         const val SYSTEM_PROMPT = """You are a concise AI assistant for Ansible Automation Platform (AAP). Rules:
 - NEVER fabricate, invent, or guess data. Only present information returned by tool calls. If a tool call fails, report the error — do not make up results. If you have no tool to answer a question, say so clearly.
 - You have local tools (list_jobs, launch_job, etc.) that connect directly to the AAP instance and MCP tools (hosts_list, jobs_retrieve, etc.) for extended capabilities. Prefer local tools when available.

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ModelCapability.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ModelCapability.kt
@@ -1,0 +1,214 @@
+package io.github.leogallego.ansiblejane.assistant.engine
+
+import io.github.leogallego.ansiblejane.assistant.data.KnownProvider
+import io.github.leogallego.ansiblejane.assistant.data.TokenSavingMode
+import io.github.leogallego.ansiblejane.assistant.tools.Tool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * How much tool-schema / tool-count complexity the active model can handle (#453).
+ *
+ * ## Mapping guidelines
+ *
+ * | Source | Typical tier | Notes |
+ * |--------|--------------|-------|
+ * | Frontier cloud (OpenAI, Gemini, OpenRouter, Groq, Claude-class via OpenRouter) | [Full] | Honor the user's [TokenSavingMode]; post-#330 category routing + compression. |
+ * | Self-hosted / Ollama | Heuristic → often [Simple] | Parse size hints from the model id (`7b`, `70b`, …). Unknown → [Simple] (conservative). |
+ * | On-device / LiteRT (#264) | [Simple] | Pass `onDevice = true`. Stub until LiteRT lands; no backend here. |
+ * | Custom / Abbenay (unknown host) | Heuristic on model id; default [Simple] | Prefer Simple when size/capability is unclear. |
+ *
+ * ## TokenSavingMode precedence
+ *
+ * - **Full:** user's [TokenSavingMode] is honored as-is.
+ * - **Simple:** the tier sets a **ceiling** on schema richness / context. Effective mode is at
+ *   least [TokenSavingMode.TOOLS_ONLY] (most aggressive today). The user may only go *more*
+ *   aggressive, never less — so STANDARD/TOKEN_SAVER are raised to TOOLS_ONLY for Simple.
+ *
+ * Schema compression (#330): TOOLS_ONLY and TOKEN_SAVER both map to
+ * [io.github.leogallego.ansiblejane.assistant.tools.SchemaCompressionLevel.STRIPPED].
+ */
+enum class ModelCapability {
+    /** Frontier / large models — full category routing + user TokenSavingMode. */
+    Full,
+
+    /**
+     * Small / local / on-device models — hard-capped local tools, no MCP,
+     * complexity filter, aggressive #330 schema stripping.
+     */
+    Simple,
+}
+
+/**
+ * Resolves [ModelCapability] and effective [TokenSavingMode] for ToolRouter / ChatEngine.
+ */
+object ModelCapabilityResolver {
+
+    /**
+     * Hard cap for tools sent per query on [ModelCapability.Simple] (#264 E4B strategy).
+     * Soft top-K from #330 still applies underneath this ceiling.
+     */
+    const val SIMPLE_HARD_CAP = 10
+
+    /**
+     * Max JSON-schema properties a Simple-tier tool may expose (Kai-style structural filter).
+     * Prefer small list/get tools; reject fat multi-param schemas.
+     */
+    const val SIMPLE_MAX_PARAMS = 4
+
+    /**
+     * Max enum entries allowed on any single parameter for Simple tier.
+     * Large enums blow up tokens and confuse small function-call parsers.
+     */
+    const val SIMPLE_MAX_ENUM_VALUES = 4
+
+    /**
+     * Curated “safe simple” local tools preferred when trimming to [SIMPLE_HARD_CAP].
+     * Not exclusive — other local tools that pass [isSchemaSimpleEnough] may still be sent
+     * if slots remain (FN-safer than Kai’s exclusive allowlist).
+     */
+    val SIMPLE_SAFE_ALLOWLIST: Set<String> = setOf(
+        "ping",
+        "search_available_tools",
+        "list_hosts",
+        "list_inventories",
+        "list_groups",
+        "list_jobs",
+        "list_job_templates",
+        "get_job",
+        "list_workflow_templates",
+        "list_schedules",
+        "list_projects",
+        "list_credentials",
+        "list_credential_types",
+        "list_organizations",
+        "list_users",
+        "list_teams",
+        "list_instances",
+        "list_instance_groups",
+        "get_config",
+        "list_execution_environments",
+        "list_eda_activations",
+        "list_pending_approvals",
+    )
+
+    /**
+     * @param provider Known/frontier vs self-hosted classification from the active URL.
+     * @param model Model id (e.g. `llama3.1:8b`, `gpt-4.1`).
+     * @param onDevice Future LiteRT / on-device flag (#264). When true → always [ModelCapability.Simple].
+     */
+    fun resolve(
+        provider: KnownProvider,
+        model: String,
+        onDevice: Boolean = false,
+    ): ModelCapability {
+        if (onDevice) return ModelCapability.Simple
+
+        return when (provider) {
+            KnownProvider.OPENAI,
+            KnownProvider.GOOGLE_GEMINI,
+            KnownProvider.OPENROUTER,
+            KnownProvider.GROQ -> ModelCapability.Full
+
+            KnownProvider.OLLAMA,
+            KnownProvider.ABBENAY,
+            KnownProvider.CUSTOM -> resolveFromModelHints(model)
+        }
+    }
+
+    /**
+     * Simple tier forces aggressive saving; Full honors the user setting.
+     *
+     * Precedence: for Simple, tier ceiling = [TokenSavingMode.TOOLS_ONLY]. User mode cannot
+     * relax that (STANDARD / TOKEN_SAVER are raised). There is nothing more aggressive than
+     * TOOLS_ONLY today, so Simple always resolves to TOOLS_ONLY.
+     */
+    fun effectiveTokenSavingMode(
+        capability: ModelCapability,
+        userMode: TokenSavingMode,
+    ): TokenSavingMode = when (capability) {
+        ModelCapability.Full -> userMode
+        ModelCapability.Simple -> TokenSavingMode.TOOLS_ONLY
+    }
+
+    /**
+     * Structural “simple enough” check for tool JSON schemas (Kai-inspired).
+     * Empty / missing properties count as simple.
+     */
+    fun isSchemaSimpleEnough(spec: ToolSpec): Boolean {
+        val schema = spec.parametersSchema
+        val properties = schema["properties"]?.jsonObject ?: return true
+        if (properties.size > SIMPLE_MAX_PARAMS) return false
+
+        for ((_, value) in properties) {
+            val prop = value.jsonObject
+            val type = prop["type"]?.jsonPrimitive?.content
+            if (type == "object") return false
+            if (type == "array") {
+                val items = prop["items"]?.jsonObject
+                val itemType = items?.get("type")?.jsonPrimitive?.content
+                if (itemType == "object") return false
+            }
+            val enumValues = prop["enum"]?.jsonArray
+            if (enumValues != null && enumValues.size > SIMPLE_MAX_ENUM_VALUES) return false
+            // Nested object under properties without type:object (some MCP schemas)
+            if (prop.containsKey("properties")) return false
+        }
+        return true
+    }
+
+    /**
+     * Prefer allowlisted tools, then preserve relative order of the rest, hard-capped.
+     */
+    fun preferAllowlistAndCap(tools: List<Tool>): List<Tool> {
+        if (tools.size <= SIMPLE_HARD_CAP) {
+            val preferred = tools.filter { it.spec.name in SIMPLE_SAFE_ALLOWLIST }
+            val others = tools.filter { it.spec.name !in SIMPLE_SAFE_ALLOWLIST }
+            return preferred + others
+        }
+        val preferred = tools.filter { it.spec.name in SIMPLE_SAFE_ALLOWLIST }
+        val others = tools.filter { it.spec.name !in SIMPLE_SAFE_ALLOWLIST }
+        return (preferred + others).take(SIMPLE_HARD_CAP)
+    }
+
+    /**
+     * Size / family heuristics for self-hosted model ids.
+     * Large parameter counts → Full; small/unknown → Simple (conservative).
+     */
+    internal fun resolveFromModelHints(model: String): ModelCapability {
+        val normalized = model.trim().lowercase()
+        if (normalized.isEmpty()) return ModelCapability.Simple
+
+        // Explicit small / local family markers (boundary-aware — avoid "2b" matching inside "72b")
+        val simpleFamily = listOf("tiny", "mini", "nano", "phi", "litert", "e2b", "e4b")
+        if (simpleFamily.any { it in normalized }) return ModelCapability.Simple
+
+        val paramBillions = extractParamBillions(normalized)
+        if (paramBillions != null) {
+            // ≥32B class can usually handle richer schemas; below that stay Simple.
+            return if (paramBillions >= 32) ModelCapability.Full else ModelCapability.Simple
+        }
+
+        // Frontier model names served via a custom / Abbenay proxy
+        val frontierHints = listOf(
+            "gpt-4", "gpt-5", "o1", "o3", "o4",
+            "claude", "gemini-2", "gemini-1.5", "gemini-pro",
+            "command-r-plus", "deepseek-v3", "qwen2.5-72b", "qwen3-72b",
+        )
+        if (frontierHints.any { it in normalized }) return ModelCapability.Full
+
+        return ModelCapability.Simple
+    }
+
+    /**
+     * Parses `70b`, `8b`, `120b-a12b`, `llama3.1:70b-instruct-q4` → billions of params.
+     */
+    internal fun extractParamBillions(normalizedModel: String): Int? {
+        val match = Regex("""(?:^|[^a-z0-9])(\d{1,3})\s*b(?:[^a-z0-9]|$)""")
+            .find(normalizedModel)
+            ?: return null
+        return match.groupValues[1].toIntOrNull()
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ModelCapability.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ModelCapability.kt
@@ -174,41 +174,78 @@ object ModelCapabilityResolver {
     }
 
     /**
-     * Size / family heuristics for self-hosted model ids.
+     * Size / family heuristics for self-hosted / proxy model ids.
      * Large parameter counts → Full; small/unknown → Simple (conservative).
+     *
+     * Order matters: frontier-name hints run **before** simple markers so Abbenay/CUSTOM
+     * proxies for `gpt-4o-mini` / `o4-mini` stay Full (not tripped by substring "mini").
      */
     internal fun resolveFromModelHints(model: String): ModelCapability {
         val normalized = model.trim().lowercase()
         if (normalized.isEmpty()) return ModelCapability.Simple
 
-        // Explicit small / local family markers (boundary-aware — avoid "2b" matching inside "72b")
-        val simpleFamily = listOf("tiny", "mini", "nano", "phi", "litert", "e2b", "e4b")
-        if (simpleFamily.any { it in normalized }) return ModelCapability.Simple
+        // Frontier model names served via a custom / Abbenay / Ollama proxy — before "mini"/"nano"
+        if (matchesFrontierHint(normalized)) return ModelCapability.Full
+
+        val moeBillions = extractMoeParamBillions(normalized)
+        if (moeBillions != null) {
+            return if (moeBillions >= FULL_PARAM_BILLIONS_THRESHOLD) {
+                ModelCapability.Full
+            } else {
+                ModelCapability.Simple
+            }
+        }
 
         val paramBillions = extractParamBillions(normalized)
         if (paramBillions != null) {
-            // ≥32B class can usually handle richer schemas; below that stay Simple.
-            return if (paramBillions >= 32) ModelCapability.Full else ModelCapability.Simple
+            return if (paramBillions >= FULL_PARAM_BILLIONS_THRESHOLD) {
+                ModelCapability.Full
+            } else {
+                ModelCapability.Simple
+            }
         }
 
-        // Frontier model names served via a custom / Abbenay proxy
-        val frontierHints = listOf(
-            "gpt-4", "gpt-5", "o1", "o3", "o4",
-            "claude", "gemini-2", "gemini-1.5", "gemini-pro",
-            "command-r-plus", "deepseek-v3", "qwen2.5-72b", "qwen3-72b",
-        )
-        if (frontierHints.any { it in normalized }) return ModelCapability.Full
+        // Small / local family markers (after frontier + size, so gpt-4o-mini is not Simple)
+        val simpleFamily = listOf("tiny", "mini", "nano", "phi", "litert", "e2b", "e4b")
+        if (simpleFamily.any { it in normalized }) return ModelCapability.Simple
 
         return ModelCapability.Simple
     }
 
+    /** ≥ this many (approx) billions → Full for self-hosted / MoE heuristics. */
+    internal const val FULL_PARAM_BILLIONS_THRESHOLD = 32
+
+    private val FRONTIER_HINTS = listOf(
+        "gpt-4", "gpt-5", "o1", "o3", "o4",
+        "claude", "gemini-2", "gemini-1.5", "gemini-pro",
+        "command-r-plus", "deepseek-v3", "qwen2.5-72b", "qwen3-72b",
+    )
+
+    internal fun matchesFrontierHint(normalizedModel: String): Boolean =
+        FRONTIER_HINTS.any { it in normalizedModel }
+
     /**
-     * Parses `70b`, `8b`, `120b-a12b`, `llama3.1:70b-instruct-q4` → billions of params.
+     * Parses dense size tags: `70b`, `8b`, `120b-a12b`, `llama3.1:70b-instruct-q4`.
+     * Boundary-aware so `2b` is not matched inside `72b`.
      */
     internal fun extractParamBillions(normalizedModel: String): Int? {
         val match = Regex("""(?:^|[^a-z0-9])(\d{1,3})\s*b(?:[^a-z0-9]|$)""")
             .find(normalizedModel)
             ?: return null
         return match.groupValues[1].toIntOrNull()
+    }
+
+    /**
+     * Parses MoE tags like `mixtral-8x7b` / `8x22b` as experts × expert-size (approx total).
+     * `8x7` → 56, `8x22` → 176 — both ≥ [FULL_PARAM_BILLIONS_THRESHOLD] → Full.
+     */
+    internal fun extractMoeParamBillions(normalizedModel: String): Int? {
+        val match = Regex("""(?:^|[^a-z0-9])(\d{1,3})\s*x\s*(\d{1,3})\s*b(?:[^a-z0-9]|$)""")
+            .find(normalizedModel)
+            ?: return null
+        val experts = match.groupValues[1].toIntOrNull() ?: return null
+        val expertBillions = match.groupValues[2].toIntOrNull() ?: return null
+        if (experts < 2 || expertBillions < 1) return null
+        return experts * expertBillions
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouter.kt
@@ -542,19 +542,33 @@ class ToolRouter(
         /** Default OPERATOR for callers that omit role; pass explicit role from the active instance. Unknown/`null` fail-closes. */
         aapRole: AapRole? = AapRole.OPERATOR,
         /** Soft top-K after overlap scoring (#330). STANDARD stays slightly generous. */
-        tokenSavingMode: TokenSavingMode = TokenSavingMode.STANDARD
+        tokenSavingMode: TokenSavingMode = TokenSavingMode.STANDARD,
+        /**
+         * Model capability tier (#453). [ModelCapability.Simple] excludes MCP, applies
+         * schema-complexity filtering, and hard-caps tool count. Callers should pass
+         * [ModelCapabilityResolver.effectiveTokenSavingMode] for [tokenSavingMode].
+         */
+        capability: ModelCapability = ModelCapability.Full,
     ): QueryResult = synchronized(this) {
         lastRoutingContext = RoutingContext(serverConfigs, aapRole)
+        val effectiveMode = ModelCapabilityResolver.effectiveTokenSavingMode(capability, tokenSavingMode)
         val queryWords = tokenizeQuery(query)
         val stemmedQuery = stemQueryTokens(queryWords)
-        Log.d(TAG, "QUERY: words=$queryWords, stemmed=$stemmedQuery, role=$aapRole, mode=$tokenSavingMode")
+        Log.d(
+            TAG,
+            "QUERY: words=$queryWords, stemmed=$stemmedQuery, role=$aapRole, " +
+                "mode=$tokenSavingMode→$effectiveMode, capability=$capability"
+        )
 
         val matchedCategories = Category.entries.filter { category ->
             category.stemmedKeywords.any { it in stemmedQuery }
         }
 
         if (matchedCategories.isEmpty()) {
-            return@synchronized noCategoryMatchFallback(queryWords, stemmedQuery, serverConfigs, aapRole)
+            val fallback = noCategoryMatchFallback(
+                queryWords, stemmedQuery, serverConfigs, aapRole, capability
+            )
+            return@synchronized applyCapabilityPolicy(fallback, capability)
         }
         Log.d(TAG, "QUERY: matched categories=${matchedCategories.map { it.name }}")
 
@@ -574,26 +588,29 @@ class ToolRouter(
         val routedMcp = mutableListOf<Tool>()
         val unroutedMcp = mutableListOf<Tool>()
 
-        for (tool in mcpTools) {
-            if (!isToolEnabled(tool.spec.name, ToolSource.MCP, tool.serverLabel)) continue
-            if (!passesRoleFilter(tool, aapRole)) continue
+        // #453 Simple: local tools only — never send MCP schemas to small/local models
+        if (capability != ModelCapability.Simple) {
+            for (tool in mcpTools) {
+                if (!isToolEnabled(tool.spec.name, ToolSource.MCP, tool.serverLabel)) continue
+                if (!passesRoleFilter(tool, aapRole)) continue
 
-            val passesReadOnly = tool.serverLabel !in readOnlyLabels ||
-                WRITE_ACTIONS.none { action -> tool.spec.name.endsWith(action) }
-            if (!passesReadOnly) continue
+                val passesReadOnly = tool.serverLabel !in readOnlyLabels ||
+                    WRITE_ACTIONS.none { action -> tool.spec.name.endsWith(action) }
+                if (!passesReadOnly) continue
 
-            val toolToolset = tool.toolset
-            val toolsetCategories = toolToolset?.let { TOOLSET_CATEGORY_MAP[it] }
-            when {
-                toolsetCategories != null && matchedCategories.any { it in toolsetCategories } ->
-                    routedMcp.add(tool)
-                toolsetCategories != null -> { }
-                toolToolset != null -> {
-                    Log.d(TAG, "FILTER: unknown toolset '${toolToolset}' for ${tool.spec.name}, treating as unrouted")
-                    unroutedMcp.add(tool)
+                val toolToolset = tool.toolset
+                val toolsetCategories = toolToolset?.let { TOOLSET_CATEGORY_MAP[it] }
+                when {
+                    toolsetCategories != null && matchedCategories.any { it in toolsetCategories } ->
+                        routedMcp.add(tool)
+                    toolsetCategories != null -> { }
+                    toolToolset != null -> {
+                        Log.d(TAG, "FILTER: unknown toolset '${toolToolset}' for ${tool.spec.name}, treating as unrouted")
+                        unroutedMcp.add(tool)
+                    }
+                    else ->
+                        unroutedMcp.add(tool)
                 }
-                else ->
-                    unroutedMcp.add(tool)
             }
         }
 
@@ -603,7 +620,13 @@ class ToolRouter(
         // Within a category: when any tool overlaps, list_/get_ boost alone cannot admit
         // zero-overlap siblings (e.g. list_labels). Unrouted MCP always requires overlap.
         // Soft top-K prefers routed tools so unrouted MCP cannot crowd them out.
-        val topK = softTopK(tokenSavingMode)
+        val topK = softTopK(effectiveMode).let { k ->
+            if (capability == ModelCapability.Simple) {
+                minOf(k, ModelCapabilityResolver.SIMPLE_HARD_CAP)
+            } else {
+                k
+            }
+        }
         val routedBest = linkedMapOf<String, ScoredTool>()
         for (category in matchedCategories) {
             val localForCat = filteredLocal.filter { it.spec.name in category.localToolNames }
@@ -638,12 +661,37 @@ class ToolRouter(
             val meta = findMetaSearchTool(aapRole)
             if (meta != null) {
                 Log.d(TAG, "META: category match but empty cherry-pick — inject ${meta.spec.name}")
-                return@synchronized QueryResult(listOf(meta), categoryMatched = true)
+                return@synchronized applyCapabilityPolicy(
+                    QueryResult(listOf(meta), categoryMatched = true),
+                    capability
+                )
             }
             return@synchronized QueryResult(emptyList(), categoryMatched = true)
         }
 
-        QueryResult(cherryPicked, categoryMatched = true)
+        applyCapabilityPolicy(QueryResult(cherryPicked, categoryMatched = true), capability)
+    }
+
+    /**
+     * #453 Simple-tier post-filter: local-only (already enforced upstream), drop complex
+     * schemas, prefer allowlisted tools, hard-cap at [ModelCapabilityResolver.SIMPLE_HARD_CAP].
+     * Full tier is a no-op.
+     */
+    private fun applyCapabilityPolicy(
+        result: QueryResult,
+        capability: ModelCapability,
+    ): QueryResult {
+        if (capability != ModelCapability.Simple || result.tools.isEmpty()) return result
+
+        val localOnly = result.tools.filterIsInstance<LocalTool>()
+        val simpleEnough = localOnly.filter { ModelCapabilityResolver.isSchemaSimpleEnough(it.spec) }
+        val capped = ModelCapabilityResolver.preferAllowlistAndCap(simpleEnough)
+        Log.d(
+            TAG,
+            "SIMPLE: ${result.tools.size} → local=${localOnly.size} → " +
+                "schemaOk=${simpleEnough.size} → capped=${capped.size} [${capped.map { it.spec.name }}]"
+        )
+        return result.copy(tools = capped)
     }
 
     /** Prefer category-routed tools when filling soft top-K; unrouted fills remaining slots only. */
@@ -697,7 +745,8 @@ class ToolRouter(
         queryWords: Set<String>,
         stemmedQuery: Set<String>,
         serverConfigs: List<McpServerConfig>,
-        aapRole: AapRole?
+        aapRole: AapRole?,
+        capability: ModelCapability = ModelCapability.Full,
     ): QueryResult {
         Log.d(TAG, "QUERY: no categories matched — meta-search fallback")
 
@@ -717,7 +766,7 @@ class ToolRouter(
 
         if (stemmedQuery.isNotEmpty()) {
             val searched = cherryPick(
-                collectEnabledTools(serverConfigs, aapRole),
+                collectEnabledTools(serverConfigs, aapRole, capability),
                 stemmedQuery,
                 requireOverlap = true
             ).take(MAX_META_SEARCH_RESULTS)
@@ -756,7 +805,8 @@ class ToolRouter(
 
     private fun collectEnabledTools(
         serverConfigs: List<McpServerConfig>,
-        aapRole: AapRole?
+        aapRole: AapRole?,
+        capability: ModelCapability = ModelCapability.Full,
     ): List<Tool> {
         val readOnlyLabels = serverConfigs
             .filter { it.readOnly }
@@ -765,6 +815,7 @@ class ToolRouter(
         val enabledLocal = localTools.filter {
             isToolEnabled(it.spec.name, ToolSource.LOCAL) && passesRoleFilter(it, aapRole)
         }
+        if (capability == ModelCapability.Simple) return enabledLocal
         val enabledMcp = mcpTools.filter { tool ->
             isToolEnabled(tool.spec.name, ToolSource.MCP, tool.serverLabel) &&
                 passesRoleFilter(tool, aapRole) &&

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(TestOnly::class)
@@ -161,6 +162,50 @@ class ChatEngineTest {
             provider.lastToolNames
         )
     }
+
+    @Test
+    fun `tool-call parse failure SHOULD retry once without tools`() = runTest {
+        val provider = ParseFailureThenTextProvider()
+        val tools = listOf(
+            io.github.leogallego.ansiblejane.assistant.tools.ToolSpec(
+                "list_hosts", "List hosts", kotlinx.serialization.json.JsonObject(emptyMap())
+            )
+        )
+        val engine = ChatEngine(provider, ToolExecutor(emptyList()))
+
+        engine.processMessage("how many hosts?", emptyList(), tools).test {
+            val delta = awaitItem()
+            assertTrue(delta is ChatEvent.TextDelta)
+            assertEquals("Plain text fallback", (delta as ChatEvent.TextDelta).text)
+
+            val tokenReport = awaitItem()
+            assertTrue(tokenReport is ChatEvent.TokenUsageReport)
+
+            val msg = awaitItem()
+            assertTrue(msg is ChatEvent.AssistantMessage)
+            assertEquals("Plain text fallback", (msg as ChatEvent.AssistantMessage).fullText)
+            awaitComplete()
+        }
+
+        assertEquals(2, provider.callCount)
+        assertEquals(listOf(1, 0), provider.toolCountsPerCall)
+    }
+
+    @Test
+    fun `isToolCallParseFailure SHOULD detect parse errors and ignore auth IO`() {
+        assertTrue(ChatEngine.isToolCallParseFailure(IllegalArgumentException("Failed to parse tool call JSON")))
+        assertTrue(ChatEngine.isToolCallParseFailure(RuntimeException("malformed tool arguments")))
+        assertFalse(
+            ChatEngine.isToolCallParseFailure(
+                io.github.leogallego.ansiblejane.assistant.llm.LlmAuthException("bad key")
+            )
+        )
+        assertFalse(
+            ChatEngine.isToolCallParseFailure(
+                kotlinx.io.IOException("connection reset")
+            )
+        )
+    }
 }
 
 private class CapturingLlmProvider : LlmProvider {
@@ -211,6 +256,30 @@ private class FakeLlmProvider(
                 content = tc.arguments
             ))
         }
+        emit(StreamFrame.End(finishReason = "stop"))
+    }
+
+    override fun isAvailable(): Boolean = true
+    override fun modelInfo(): ModelInfo = ModelInfo("fake-model")
+    override fun close() {}
+}
+
+/** First call with tools throws a parse-like error; second call (no tools) returns text. */
+private class ParseFailureThenTextProvider : LlmProvider {
+    var callCount = 0
+    val toolCountsPerCall = mutableListOf<Int>()
+
+    override fun generateStream(
+        prompt: Prompt,
+        tools: List<ToolDescriptor>,
+        maxTokens: Int?
+    ): Flow<StreamFrame> = flow {
+        toolCountsPerCall.add(tools.size)
+        callCount++
+        if (callCount == 1 && tools.isNotEmpty()) {
+            throw IllegalArgumentException("Failed to parse tool call JSON")
+        }
+        emit(StreamFrame.TextDelta("Plain text fallback"))
         emit(StreamFrame.End(finishReason = "stop"))
     }
 

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ChatEngineTest.kt
@@ -206,7 +206,35 @@ class ChatEngineTest {
             )
         )
     }
+
+    @Test
+    fun `isToolCallParseFailure SHOULD ignore non-tool parse and serialization errors`() {
+        assertFalse(
+            ChatEngine.isToolCallParseFailure(
+                IllegalArgumentException("Failed to parse config file")
+            )
+        )
+        assertFalse(
+            ChatEngine.isToolCallParseFailure(
+                RuntimeException("JSON serialization of settings failed")
+            )
+        )
+        assertFalse(
+            ChatEngine.isToolCallParseFailure(
+                FakeJsonDecodingException("Unexpected token in URL path")
+            )
+        )
+        // Tool context + parse still matches
+        assertTrue(
+            ChatEngine.isToolCallParseFailure(
+                FakeJsonDecodingException("Unexpected token in tool_call arguments")
+            )
+        )
+    }
 }
+
+/** Name ends with JsonDecodingException so simpleName matches the detector's class check. */
+private class FakeJsonDecodingException(message: String) : Exception(message)
 
 private class CapturingLlmProvider : LlmProvider {
     var lastToolNames: List<String> = emptyList()

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ModelCapabilityTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ModelCapabilityTest.kt
@@ -68,6 +68,42 @@ class ModelCapabilityTest {
     }
 
     @Test
+    fun `Abbenay CUSTOM frontier mini nano models SHOULD resolve to Full not Simple`() {
+        // Regression: "mini"/"nano" must not win over frontier name hints
+        assertEquals(
+            ModelCapability.Full,
+            ModelCapabilityResolver.resolve(KnownProvider.ABBENAY, "gpt-4o-mini")
+        )
+        assertEquals(
+            ModelCapability.Full,
+            ModelCapabilityResolver.resolve(KnownProvider.CUSTOM, "o4-mini")
+        )
+        assertEquals(
+            ModelCapability.Full,
+            ModelCapabilityResolver.resolve(KnownProvider.ABBENAY, "openai/gpt-4.1-nano")
+        )
+        // True small local family still Simple
+        assertEquals(
+            ModelCapability.Simple,
+            ModelCapabilityResolver.resolve(KnownProvider.OLLAMA, "phi3:mini")
+        )
+    }
+
+    @Test
+    fun `Mixtral MoE size tags SHOULD resolve to Full on Ollama`() {
+        assertEquals(
+            ModelCapability.Full,
+            ModelCapabilityResolver.resolve(KnownProvider.OLLAMA, "mixtral-8x7b")
+        )
+        assertEquals(
+            ModelCapability.Full,
+            ModelCapabilityResolver.resolve(KnownProvider.OLLAMA, "mixtral:8x22b-instruct")
+        )
+        assertEquals(56, ModelCapabilityResolver.extractMoeParamBillions("mixtral-8x7b"))
+        assertEquals(176, ModelCapabilityResolver.extractMoeParamBillions("mixtral:8x22b-instruct"))
+    }
+
+    @Test
     fun `onDevice flag SHOULD force Simple`() {
         assertEquals(
             ModelCapability.Simple,

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ModelCapabilityTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ModelCapabilityTest.kt
@@ -1,0 +1,245 @@
+package io.github.leogallego.ansiblejane.assistant.engine
+
+import io.github.leogallego.ansiblejane.assistant.data.KnownProvider
+import io.github.leogallego.ansiblejane.assistant.data.TokenSavingMode
+import io.github.leogallego.ansiblejane.assistant.tools.SchemaCompressionLevel
+import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
+import io.github.leogallego.ansiblejane.assistant.tools.toSchemaCompression
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ModelCapabilityTest {
+
+    @Test
+    fun `frontier providers SHOULD resolve to Full`() {
+        assertEquals(
+            ModelCapability.Full,
+            ModelCapabilityResolver.resolve(KnownProvider.OPENAI, "gpt-4.1")
+        )
+        assertEquals(
+            ModelCapability.Full,
+            ModelCapabilityResolver.resolve(KnownProvider.GOOGLE_GEMINI, "gemini-2.5-flash")
+        )
+        assertEquals(
+            ModelCapability.Full,
+            ModelCapabilityResolver.resolve(KnownProvider.OPENROUTER, "anthropic/claude-sonnet-4")
+        )
+        assertEquals(
+            ModelCapability.Full,
+            ModelCapabilityResolver.resolve(KnownProvider.GROQ, "llama-3.3-70b-versatile")
+        )
+    }
+
+    @Test
+    fun `unknown small Ollama model SHOULD resolve to Simple`() {
+        assertEquals(
+            ModelCapability.Simple,
+            ModelCapabilityResolver.resolve(KnownProvider.OLLAMA, "llama3.1:8b")
+        )
+        assertEquals(
+            ModelCapability.Simple,
+            ModelCapabilityResolver.resolve(KnownProvider.OLLAMA, "phi3:mini")
+        )
+        assertEquals(
+            ModelCapability.Simple,
+            ModelCapabilityResolver.resolve(KnownProvider.OLLAMA, "mystery-model")
+        )
+        assertEquals(
+            ModelCapability.Simple,
+            ModelCapabilityResolver.resolve(KnownProvider.CUSTOM, "")
+        )
+    }
+
+    @Test
+    fun `large self-hosted model SHOULD resolve to Full`() {
+        assertEquals(
+            ModelCapability.Full,
+            ModelCapabilityResolver.resolve(KnownProvider.OLLAMA, "llama3.1:70b")
+        )
+        assertEquals(
+            ModelCapability.Full,
+            ModelCapabilityResolver.resolve(KnownProvider.ABBENAY, "qwen2.5:72b-instruct")
+        )
+    }
+
+    @Test
+    fun `onDevice flag SHOULD force Simple`() {
+        assertEquals(
+            ModelCapability.Simple,
+            ModelCapabilityResolver.resolve(
+                KnownProvider.OPENAI,
+                "gpt-4.1",
+                onDevice = true
+            )
+        )
+    }
+
+    @Test
+    fun `Simple effective mode SHOULD force TOOLS_ONLY ceiling`() {
+        assertEquals(
+            TokenSavingMode.TOOLS_ONLY,
+            ModelCapabilityResolver.effectiveTokenSavingMode(
+                ModelCapability.Simple,
+                TokenSavingMode.STANDARD
+            )
+        )
+        assertEquals(
+            TokenSavingMode.TOOLS_ONLY,
+            ModelCapabilityResolver.effectiveTokenSavingMode(
+                ModelCapability.Simple,
+                TokenSavingMode.TOKEN_SAVER
+            )
+        )
+        assertEquals(
+            TokenSavingMode.TOOLS_ONLY,
+            ModelCapabilityResolver.effectiveTokenSavingMode(
+                ModelCapability.Simple,
+                TokenSavingMode.TOOLS_ONLY
+            )
+        )
+    }
+
+    @Test
+    fun `Full effective mode SHOULD honor user TokenSavingMode`() {
+        assertEquals(
+            TokenSavingMode.STANDARD,
+            ModelCapabilityResolver.effectiveTokenSavingMode(
+                ModelCapability.Full,
+                TokenSavingMode.STANDARD
+            )
+        )
+        assertEquals(
+            TokenSavingMode.TOKEN_SAVER,
+            ModelCapabilityResolver.effectiveTokenSavingMode(
+                ModelCapability.Full,
+                TokenSavingMode.TOKEN_SAVER
+            )
+        )
+    }
+
+    @Test
+    fun `Simple path SHOULD request aggressive #330 schema compression`() {
+        val mode = ModelCapabilityResolver.effectiveTokenSavingMode(
+            ModelCapability.Simple,
+            TokenSavingMode.STANDARD
+        )
+        assertEquals(TokenSavingMode.TOOLS_ONLY, mode)
+        assertEquals(SchemaCompressionLevel.STRIPPED, mode.toSchemaCompression())
+    }
+
+    @Test
+    fun `isSchemaSimpleEnough SHOULD reject many params enums and nested objects`() {
+        val simple = ToolSpec(
+            name = "list_hosts",
+            description = "List hosts",
+            parametersSchema = JsonObject(
+                mapOf(
+                    "type" to JsonPrimitive("object"),
+                    "properties" to JsonObject(
+                        mapOf(
+                            "search" to JsonObject(
+                                mapOf("type" to JsonPrimitive("string"))
+                            ),
+                            "page" to JsonObject(
+                                mapOf("type" to JsonPrimitive("integer"))
+                            ),
+                        )
+                    )
+                )
+            )
+        )
+        assertTrue(ModelCapabilityResolver.isSchemaSimpleEnough(simple))
+
+        val tooManyParams = ToolSpec(
+            name = "fat_tool",
+            description = "Too many params",
+            parametersSchema = JsonObject(
+                mapOf(
+                    "properties" to JsonObject(
+                        (1..5).associate { i ->
+                            "p$i" to JsonObject(mapOf("type" to JsonPrimitive("string")))
+                        }
+                    )
+                )
+            )
+        )
+        assertFalse(ModelCapabilityResolver.isSchemaSimpleEnough(tooManyParams))
+
+        val fatEnum = ToolSpec(
+            name = "enum_tool",
+            description = "Wide enum",
+            parametersSchema = JsonObject(
+                mapOf(
+                    "properties" to JsonObject(
+                        mapOf(
+                            "status" to JsonObject(
+                                mapOf(
+                                    "type" to JsonPrimitive("string"),
+                                    "enum" to JsonArray(
+                                        listOf("a", "b", "c", "d", "e").map { JsonPrimitive(it) }
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        assertFalse(ModelCapabilityResolver.isSchemaSimpleEnough(fatEnum))
+
+        val nested = ToolSpec(
+            name = "nested_tool",
+            description = "Nested object",
+            parametersSchema = JsonObject(
+                mapOf(
+                    "properties" to JsonObject(
+                        mapOf(
+                            "filter" to JsonObject(
+                                mapOf(
+                                    "type" to JsonPrimitive("object"),
+                                    "properties" to JsonObject(
+                                        mapOf(
+                                            "name" to JsonObject(
+                                                mapOf("type" to JsonPrimitive("string"))
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        assertFalse(ModelCapabilityResolver.isSchemaSimpleEnough(nested))
+    }
+
+    @Test
+    fun `preferAllowlistAndCap SHOULD enforce hard cap of 10`() {
+        val tools = (1..15).map { i ->
+            object : io.github.leogallego.ansiblejane.assistant.tools.LocalTool {
+                override val spec = ToolSpec("tool_$i", "t$i", JsonObject(emptyMap()))
+                override val isDestructive = false
+                override suspend fun execute(args: JsonObject) =
+                    io.github.leogallego.ansiblejane.assistant.tools.ToolResult(success = true)
+            }
+        }
+        // Sprinkle allowlisted names
+        val mixed = listOf(
+            object : io.github.leogallego.ansiblejane.assistant.tools.LocalTool {
+                override val spec = ToolSpec("list_hosts", "hosts", JsonObject(emptyMap()))
+                override val isDestructive = false
+                override suspend fun execute(args: JsonObject) =
+                    io.github.leogallego.ansiblejane.assistant.tools.ToolResult(success = true)
+            }
+        ) + tools
+        val capped = ModelCapabilityResolver.preferAllowlistAndCap(mixed)
+        assertEquals(ModelCapabilityResolver.SIMPLE_HARD_CAP, capped.size)
+        assertEquals("list_hosts", capped.first().spec.name)
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/engine/ToolRouterTest.kt
@@ -2186,4 +2186,132 @@ class ToolRouterTest {
         assertTrue("list_hosts" in names, "Routed local tool must not be displaced by unrouted MCP; got $names")
         assertTrue(names.size <= ToolRouter.TOP_K_TOKEN_SAVER)
     }
+
+    // --- #453 ModelCapability Simple tier ---
+
+    private fun localToolWithSchema(
+        name: String,
+        description: String,
+        schema: JsonObject,
+    ) = object : LocalTool {
+        override val spec = ToolSpec(name, description, schema)
+        override val isDestructive = false
+        override suspend fun execute(args: JsonObject) = ToolResult(success = true)
+    }
+
+    private fun fatSchema(): JsonObject = JsonObject(
+        mapOf(
+            "type" to kotlinx.serialization.json.JsonPrimitive("object"),
+            "properties" to JsonObject(
+                (1..6).associate { i ->
+                    "param_$i" to JsonObject(
+                        mapOf("type" to kotlinx.serialization.json.JsonPrimitive("string"))
+                    )
+                }
+            )
+        )
+    )
+
+    @Test
+    fun `Simple capability SHOULD exclude MCP tools`() {
+        router.registerLocalTools(
+            listOf(localTool("list_hosts", description = "List hosts in inventory"))
+        )
+        router.registerMcpTools(
+            listOf(
+                mcpTool("hosts_list", toolset = "inventory_management"),
+                mcpTool("inventories_list", toolset = "inventory_management"),
+            )
+        )
+
+        val full = router.getToolsForQuery(
+            "how many hosts?",
+            listOf(readWriteConfig),
+            capability = ModelCapability.Full,
+        ).tools.map { it.spec.name }
+        val simple = router.getToolsForQuery(
+            "how many hosts?",
+            listOf(readWriteConfig),
+            capability = ModelCapability.Simple,
+        ).tools
+
+        assertTrue(simple.all { it is LocalTool }, "Simple must be local-only; got ${simple.map { it.spec.name }}")
+        assertFalse(simple.any { it.spec.name == "hosts_list" })
+        // Full may include MCP when routed; at least local remains
+        assertTrue("list_hosts" in full || "list_hosts" in simple.map { it.spec.name })
+    }
+
+    @Test
+    fun `Simple capability SHOULD filter complex-schema tools`() {
+        val simpleHost = localToolWithSchema(
+            "list_hosts",
+            "List hosts in inventory",
+            JsonObject(emptyMap())
+        )
+        val fatFacts = localToolWithSchema(
+            "get_host_facts",
+            "Get host facts for hosts",
+            fatSchema()
+        )
+        router.registerLocalTools(listOf(simpleHost, fatFacts))
+
+        val names = router.getToolsForQuery(
+            "show hosts facts",
+            capability = ModelCapability.Simple,
+        ).tools.map { it.spec.name }
+
+        assertTrue("list_hosts" in names || names.isEmpty() || "get_host_facts" !in names)
+        assertFalse("get_host_facts" in names, "Complex-schema tool must be filtered for Simple; got $names")
+    }
+
+    @Test
+    fun `Simple capability SHOULD hard-cap meta-search results at 10`() {
+        // Meta-search can return up to MAX_META_SEARCH_RESULTS (20); Simple must hard-cap at 10.
+        // Avoid category keywords (host/job/…) so we hit no-category description overlap.
+        val metaOnly = (1..15).map { i ->
+            localTool("widget_frobulator_$i", description = "widget frobulator zinger utility $i")
+        }
+        router.registerLocalTools(metaOnly)
+
+        val result = router.getToolsForQuery(
+            "widget frobulator zinger",
+            capability = ModelCapability.Simple,
+        )
+        assertTrue(result.tools.isNotEmpty(), "Expected meta-search hits for Simple hard-cap test")
+        assertTrue(
+            result.tools.size <= ModelCapabilityResolver.SIMPLE_HARD_CAP,
+            "Simple hard cap expected <= 10, got ${result.tools.size}"
+        )
+        assertTrue(result.tools.all { it is LocalTool })
+    }
+
+    @Test
+    fun `Full capability SHOULD not regress post-330 host cherry-pick`() {
+        router.registerLocalTools(inventoryFixtureTools())
+
+        val names = router.getToolsForQuery(
+            "how many hosts?",
+            tokenSavingMode = TokenSavingMode.STANDARD,
+            capability = ModelCapability.Full,
+        ).tools.map { it.spec.name }.toSet()
+
+        assertTrue("list_hosts" in names)
+        assertFalse("list_labels" in names)
+        assertTrue(names.size <= ToolRouter.TOP_K_STANDARD)
+    }
+
+    @Test
+    fun `Simple capability with STANDARD user mode SHOULD still use aggressive top-K`() {
+        router.registerLocalTools(inventoryFixtureTools())
+
+        val names = router.getToolsForQuery(
+            "show inventory hosts and groups and facts and sources",
+            tokenSavingMode = TokenSavingMode.STANDARD,
+            capability = ModelCapability.Simple,
+        ).tools
+
+        assertTrue(names.size <= ToolRouter.TOP_K_TOKEN_SAVER)
+        assertTrue(names.size <= ModelCapabilityResolver.SIMPLE_HARD_CAP)
+        assertTrue(names.all { it is LocalTool })
+    }
 }


### PR DESCRIPTION
## Summary
- Add explicit `ModelCapability` (`Full` / `Simple`) resolved from provider + model hints (frontier → Full; unknown/small Ollama → Simple; `onDevice` stub → Simple for #264).
- **Simple** ToolRouter policy: local tools only (no MCP), Kai-style schema-complexity filter, prefer safe allowlist, hard cap 10 — never unbounded full-category schemas.
- Wire Simple → #330 aggressive compression via `effectiveTokenSavingMode` ceiling (`TOOLS_ONLY`); Full honors user `TokenSavingMode`.
- ChatEngine retries once without tools on tool-call parse failure (important for small/local models).

## TokenSavingMode precedence
- **Full:** user mode as-is.
- **Simple:** tier sets ceiling = `TOOLS_ONLY` (user cannot relax to STANDARD/TOKEN_SAVER). Schema path uses #330 `STRIPPED` via `toSchemaCompression()`.

## FN / safety notes
- **Too aggressive (FN risk):** Simple drops MCP and complex-schema local tools; allowlist is preference-only (not exclusive) to reduce FNs vs Kai. Soft top-K from #330 still applies under the hard cap.
- **Too loose (FP risk):** Unknown custom/Abbenay hosts default Simple (conservative). Large self-hosted (≥32B) maps Full — may still struggle if the model is weak despite size.
- Parse-failure retry is once-only and skips auth/timeout/IO so real outages still surface.

## Test plan
- [x] `:shared:jvmTest` — `ModelCapabilityTest`, `ToolRouterTest` (incl. Simple MCP/complexity/cap + Full non-regression), `ChatEngineTest` (parse-failure retry)
- [x] `:composeApp:compileKotlinDesktop`
- [ ] Optional: point Jane at a small Ollama model and confirm logs show `capability=Simple`, `mode=…→TOOLS_ONLY`, no MCP tools in `PAYLOAD tools`

Closes #453
Refs #330 #264

Assisted-by: Cursor (Grok 4.5)