### PR TITLE
refactor: Session 2 — Presentation→Network layer discipline (#448)

### DIFF
--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/data/ToolManifestRepositoryTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/data/ToolManifestRepositoryTest.kt
@@ -7,8 +7,8 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import io.github.leogallego.ansiblejane.model.ServerToolCache
 import io.github.leogallego.ansiblejane.model.ToolManifest
-import io.github.leogallego.ansiblejane.network.mcp.McpServerInfo
-import io.github.leogallego.ansiblejane.network.mcp.McpToolDefinition
+import io.github.leogallego.ansiblejane.model.McpServerInfo
+import io.github.leogallego.ansiblejane.model.McpToolDefinition
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
@@ -4,7 +4,7 @@ import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.model.InstanceInfo
 import io.github.leogallego.ansiblejane.model.McpServerConfig
-import io.github.leogallego.ansiblejane.network.ApiVersion
+import io.github.leogallego.ansiblejane.model.ApiVersion
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
@@ -32,6 +32,7 @@ class FakeTokenManager : ITokenManager {
         existingId: String?
     ): String {
         val id = existingId ?: saveInstanceResult
+        val previous = _instances.value.find { it.id == id }
         val instance = AapInstance(
             id = id,
             baseUrl = baseUrl,
@@ -39,10 +40,22 @@ class FakeTokenManager : ITokenManager {
             alias = alias,
             apiVersion = apiVersion.name,
             trustSelfSigned = trustSelfSigned,
-            certFingerprint = certFingerprint
+            certFingerprint = certFingerprint,
+            mcpServerUrls = previous?.mcpServerUrls,
+            mcpEnabled = previous?.mcpEnabled ?: false,
+            instanceInfo = previous?.instanceInfo,
+            isSuperuser = previous?.isSuperuser ?: false,
+            isSystemAuditor = previous?.isSystemAuditor ?: false,
+            userRoleFetched = previous?.userRoleFetched ?: false
         )
-        _instances.value = _instances.value + instance
-        if (_activeInstance.value == null) _activeInstance.value = instance
+        _instances.value = if (existingId != null) {
+            _instances.value.map { if (it.id == id) instance else it }
+        } else {
+            _instances.value + instance
+        }
+        if (_activeInstance.value == null || _activeInstance.value?.id == id) {
+            _activeInstance.value = instance
+        }
         return id
     }
 

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/network/InstanceDiscoveryTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/network/InstanceDiscoveryTest.kt
@@ -1,5 +1,7 @@
 package io.github.leogallego.ansiblejane.network
 
+import io.github.leogallego.ansiblejane.model.ApiVersion
+
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.model.PlatformType
 import kotlinx.coroutines.test.runTest

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantUiState.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantUiState.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Immutable
 import io.github.leogallego.ansiblejane.assistant.engine.ChatMessage
 import io.github.leogallego.ansiblejane.assistant.engine.ToolUsage
 import io.github.leogallego.ansiblejane.model.AppError
-import io.github.leogallego.ansiblejane.network.mcp.McpConnectionState
+import io.github.leogallego.ansiblejane.model.McpConnectionState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.CompletableDeferred

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -28,7 +28,8 @@ import io.github.leogallego.ansiblejane.assistant.tools.Tool
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.data.IToolManifestRepository
 import io.github.leogallego.ansiblejane.model.ToolManifest
-import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
+import io.github.leogallego.ansiblejane.data.IMcpConnectionRepository
+import io.github.leogallego.ansiblejane.assistant.tools.McpToolInvoker
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 
 import kotlinx.collections.immutable.persistentListOf
@@ -47,7 +48,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class AssistantViewModel(
-    private val mcpServerManager: McpServerManager,
+    private val mcpConnectionRepository: IMcpConnectionRepository,
+    private val mcpToolInvoker: McpToolInvoker,
     private val repository: IAssistantRepository,
     private val tokenManager: ITokenManager,
     private val manifestRepository: IToolManifestRepository,
@@ -104,7 +106,7 @@ class AssistantViewModel(
 
                     if (instance != null) {
                         _uiState.update { AssistantUiState.Loading }
-                        mcpServerManager.disconnectAll()
+                        mcpConnectionRepository.disconnectAll()
 
                         val manifest = manifestRepository.loadManifest(instance.id)
                         if (manifest != null) {
@@ -114,25 +116,25 @@ class AssistantViewModel(
                                 ?.toSet() ?: emptySet()
                             val cachedTools = buildCachedTools(manifest)
                                 .filter { it.serverLabel in configLabels }
-                            mcpServerManager.setCachedTools(cachedTools)
+                            mcpConnectionRepository.setCachedTools(cachedTools)
                             Log.d(TAG, "CACHE: loaded ${cachedTools.size} cached tools for ${instance.id}")
                         }
 
                         _uiState.update {
                             AssistantUiState.Active(
                                 messages = repository.getHistory().toImmutableList(),
-                                connections = mcpServerManager.connections.value
+                                connections = mcpConnectionRepository.connections.value
                             )
                         }
 
                         backgroundConnectJob = viewModelScope.launch {
                             try {
                                 if (manifest != null) {
-                                    mcpServerManager.connectAllWithCache(instance, manifest)
+                                    mcpConnectionRepository.connectAllWithCache(instance, manifest)
                                 } else {
-                                    mcpServerManager.connectAll(instance)
+                                    mcpConnectionRepository.connectAll(instance)
                                 }
-                                mcpServerManager.buildManifest(instance)?.let {
+                                mcpConnectionRepository.buildManifest(instance)?.let {
                                     manifestRepository.saveManifest(instance.id, it)
                                 }
                             } catch (e: CancellationException) {
@@ -142,14 +144,14 @@ class AssistantViewModel(
                             }
                         }
                     } else {
-                        mcpServerManager.disconnectAll()
+                        mcpConnectionRepository.disconnectAll()
                         _uiState.update { AssistantUiState.Idle }
                     }
                 }
         }
 
         viewModelScope.launch {
-            mcpServerManager.connections.collect { connections ->
+            mcpConnectionRepository.connections.collect { connections ->
                 _uiState.update { current ->
                     if (current is AssistantUiState.Active) current.copy(connections = connections)
                     else current
@@ -201,8 +203,8 @@ class AssistantViewModel(
         generateJob = viewModelScope.launch {
             toolRouter.initialize()
 
-            mcpServerManager.refreshConnections()
-            val mcpTools = mcpServerManager.mcpTools.value
+            mcpConnectionRepository.refreshConnections()
+            val mcpTools = mcpConnectionRepository.mcpTools.value
             val activeInstance = tokenManager.activeInstance.value
             val serverConfigs = activeInstance?.mcpServerUrls ?: emptyList()
             // No instance or role not yet fetched → AUDITOR (fail-closed)
@@ -236,7 +238,7 @@ class AssistantViewModel(
             if (queryResult.tools.isEmpty()) {
                 val noCategory = !queryResult.categoryMatched
                 Log.d(TAG, "ROUTE: no tools path — categoryMatched=${queryResult.categoryMatched}")
-                val hasMcp = mcpServerManager.mcpTools.value.isNotEmpty()
+                val hasMcp = mcpConnectionRepository.mcpTools.value.isNotEmpty()
                 val content = if (noCategory) {
                     "I can help you query your AAP instance. Try asking about:\n\n" +
                         "- **Inventory** — hosts, groups, inventories\n" +
@@ -443,7 +445,7 @@ class AssistantViewModel(
                     serverLabel = serverCache.label,
                     toolset = serverCache.toolset,
                     readOnly = serverCache.readOnly,
-                    serverManager = mcpServerManager
+                    toolInvoker = mcpToolInvoker
                 )
             }
         }
@@ -457,7 +459,7 @@ class AssistantViewModel(
         cachedProvider = null
         viewModelScope.launch {
             withContext(NonCancellable + Dispatchers.Default) {
-                mcpServerManager.disconnectAll()
+                mcpConnectionRepository.disconnectAll()
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/ui/AssistantScreen.kt
@@ -71,7 +71,7 @@ import io.github.leogallego.ansiblejane.assistant.engine.Role
 import io.github.leogallego.ansiblejane.assistant.engine.ToolUsage
 import io.github.leogallego.ansiblejane.assistant.presentation.AssistantUiState
 import io.github.leogallego.ansiblejane.assistant.presentation.AssistantViewModel
-import io.github.leogallego.ansiblejane.network.mcp.McpConnectionState
+import io.github.leogallego.ansiblejane.model.McpConnectionState
 import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
 import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.resources.stringResource

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/navigation/AppNavigation.kt
@@ -19,7 +19,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import io.github.leogallego.ansiblejane.data.ITokenManager
-import io.github.leogallego.ansiblejane.network.AuthEvents
+import io.github.leogallego.ansiblejane.data.IAuthRepository
 import io.github.leogallego.ansiblejane.ui.auth.AuthScreen
 import io.github.leogallego.ansiblejane.ui.jobs.JobStatusScreen
 import io.github.leogallego.ansiblejane.ui.main.MainScreen
@@ -37,6 +37,7 @@ fun AppNavigation(
     onHandleDeepLink: ((NavHostController) -> Unit)? = null
 ) {
     val tokenManager: ITokenManager = koinInject()
+    val authRepository: IAuthRepository = koinInject()
 
     val instances by tokenManager.instances.collectAsState()
     LaunchedEffect(instances) {
@@ -54,7 +55,7 @@ fun AppNavigation(
     }
 
     LaunchedEffect(Unit) {
-        AuthEvents.unauthorizedEvent.collect { instanceId ->
+        authRepository.unauthorizedEvent.collect { instanceId ->
             val currentRoute = navController.currentDestination?.route
             if (currentRoute != null && currentRoute.contains("AuthRoute")) {
                 return@collect

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/PresentationModule.kt
@@ -18,10 +18,10 @@ import io.github.leogallego.ansiblejane.presentation.templates.TemplatesViewMode
 import io.github.leogallego.ansiblejane.presentation.workflows.WorkflowJobStatusViewModel
 import io.github.leogallego.ansiblejane.presentation.workflows.WorkflowTemplateDetailViewModel
 import io.github.leogallego.ansiblejane.presentation.workflows.WorkflowTemplatesViewModel
+import io.github.leogallego.ansiblejane.assistant.data.ModelFetcher
 import io.github.leogallego.ansiblejane.assistant.presentation.AssistantViewModel
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.presentation.settings.SettingsViewModel
-import io.github.leogallego.ansiblejane.network.networkJson
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
@@ -52,7 +52,8 @@ val presentationModule = module {
     viewModelOf(::BackupViewModel)
     viewModel {
         AssistantViewModel(
-            mcpServerManager = get(),
+            mcpConnectionRepository = get(),
+            mcpToolInvoker = get(),
             repository = get(),
             tokenManager = get(),
             manifestRepository = get(),
@@ -63,14 +64,14 @@ val presentationModule = module {
     viewModel {
         SettingsViewModel(
             tokenManager = get(),
-            apiProvider = get(),
+            authRepository = get(),
             userPreferences = get(),
             assistantRepository = get(),
-            mcpServerManager = get(),
+            mcpConnectionRepository = get(),
             manifestRepository = get(),
-            instanceDiscovery = get(),
             toolRouter = get(),
-            json = networkJson
+            json = get(),
+            modelFetcher = ModelFetcher(get())
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/PresentationModule.kt
@@ -18,7 +18,6 @@ import io.github.leogallego.ansiblejane.presentation.templates.TemplatesViewMode
 import io.github.leogallego.ansiblejane.presentation.workflows.WorkflowJobStatusViewModel
 import io.github.leogallego.ansiblejane.presentation.workflows.WorkflowTemplateDetailViewModel
 import io.github.leogallego.ansiblejane.presentation.workflows.WorkflowTemplatesViewModel
-import io.github.leogallego.ansiblejane.assistant.data.ModelFetcher
 import io.github.leogallego.ansiblejane.assistant.presentation.AssistantViewModel
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.presentation.settings.SettingsViewModel
@@ -71,7 +70,7 @@ val presentationModule = module {
             manifestRepository = get(),
             toolRouter = get(),
             json = get(),
-            modelFetcher = ModelFetcher(get())
+            modelFetcher = get()
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/dashboard/DashboardViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/dashboard/DashboardViewModel.kt
@@ -12,7 +12,7 @@ import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AppError
 import io.github.leogallego.ansiblejane.model.Job
 import io.github.leogallego.ansiblejane.model.JobStatus
-import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import io.github.leogallego.ansiblejane.data.IEdaActivationRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -35,7 +35,7 @@ class DashboardViewModel(
     private val hostRepository: IHostRepository,
     private val projectRepository: IProjectRepository,
     private val scheduleRepository: IScheduleRepository,
-    private val apiProvider: IAapApiProvider,
+    private val edaActivationRepository: IEdaActivationRepository,
     private val tokenManager: ITokenManager
 ) : ViewModel() {
 
@@ -117,14 +117,8 @@ class DashboardViewModel(
                 projectRepository.getProjects(pageSize = 1)
             }
             val edaDeferred = async {
-                try {
-                    val service = apiProvider.getEdaApiService()
-                    val activations = service.getActivations(pageSize = 200)
-                    val total = activations.count
-                    val running = activations.results.count { it.status == "running" }
-                    Pair(total, running)
-                } catch (_: Exception) {
-                    null
+                edaActivationRepository.getActivations(pageSize = 200).getOrNull()?.let { result ->
+                    result.totalCount to result.activations.count { it.status == "running" }
                 }
             }
             val jobHistoryDeferred = async {

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/BackupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/BackupViewModel.kt
@@ -9,7 +9,7 @@ import io.github.leogallego.ansiblejane.data.backup.BackupDecryptionException
 import io.github.leogallego.ansiblejane.data.backup.BackupEnvelope
 import io.github.leogallego.ansiblejane.data.backup.BackupInstance
 import io.github.leogallego.ansiblejane.data.backup.BackupManager
-import io.github.leogallego.ansiblejane.network.ApiVersion
+import io.github.leogallego.ansiblejane.model.ApiVersion
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
@@ -5,7 +5,7 @@ import io.github.leogallego.ansiblejane.assistant.presentation.ModelFetchState
 import io.github.leogallego.ansiblejane.model.PollInterval
 import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.model.McpServerConfig
-import io.github.leogallego.ansiblejane.network.mcp.McpConnectionState
+import io.github.leogallego.ansiblejane.model.McpConnectionState
 import io.github.leogallego.ansiblejane.ui.components.ThemeMode
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
 

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -9,19 +9,14 @@ import io.github.leogallego.ansiblejane.assistant.presentation.ModelFetchState
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.data.IToolManifestRepository
 import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
+import io.github.leogallego.ansiblejane.data.IAuthRepository
+import io.github.leogallego.ansiblejane.data.IMcpConnectionRepository
 import io.github.leogallego.ansiblejane.model.PollInterval
 import io.github.leogallego.ansiblejane.model.McpServerConfig
-import io.github.leogallego.ansiblejane.network.ApiVersion
-import io.github.leogallego.ansiblejane.network.IAapApiProvider
-import io.github.leogallego.ansiblejane.network.InstanceDiscovery
-import io.github.leogallego.ansiblejane.network.createPlatformHttpClient
-import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
 import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
-import io.ktor.client.HttpClient
-import io.ktor.client.plugins.HttpTimeout
 import io.ktor.http.parseUrl
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -38,14 +33,14 @@ import kotlinx.datetime.TimeZone
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class SettingsViewModel(
     private val tokenManager: ITokenManager,
-    private val apiProvider: IAapApiProvider,
+    private val authRepository: IAuthRepository,
     private val userPreferences: IUserPreferencesRepository,
     private val assistantRepository: IAssistantRepository,
-    private val mcpServerManager: McpServerManager,
+    private val mcpConnectionRepository: IMcpConnectionRepository,
     private val manifestRepository: IToolManifestRepository,
-    private val instanceDiscovery: InstanceDiscovery,
     private val toolRouter: ToolRouter,
-    private val json: Json
+    private val json: Json,
+    private val modelFetcher: ModelFetcher = ModelFetcher(json)
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
@@ -77,7 +72,7 @@ class SettingsViewModel(
                 tokenManager.activeInstance,
                 userPreferences.timezoneId,
                 userPreferences.timeFormat,
-                mcpServerManager.connections
+                mcpConnectionRepository.connections
             ) { instances, active, timezone, timeFormat, connections ->
                 val newZone = timezone?.let {
                     try { TimeZone.of(it) } catch (_: Exception) { null }
@@ -99,7 +94,7 @@ class SettingsViewModel(
                 val preservedExpandedCats = (current as? SettingsUiState.Ready)?.expandedCategories ?: emptySet()
                 val preservedLocalTools = (current as? SettingsUiState.Ready)?.localTools ?: initialLocalTools
 
-                val allMcpTools = mcpServerManager.mcpTools.value
+                val allMcpTools = mcpConnectionRepository.mcpTools.value
                 val mcpServerTools = allMcpTools
                     .groupBy { it.serverLabel }
                     .filterKeys { it != null }
@@ -192,8 +187,7 @@ class SettingsViewModel(
 
     fun removeInstance(instanceId: String) {
         viewModelScope.launch {
-            apiProvider.evictInstance(instanceId)
-            tokenManager.removeInstance(instanceId)
+            authRepository.logoutInstance(instanceId)
         }
     }
 
@@ -216,74 +210,49 @@ class SettingsViewModel(
     ) {
         viewModelScope.launch {
             updateReady { copy(instanceEditSaving = true, instanceEditError = null) }
-            try {
-                val instance = tokenManager.getInstanceById(instanceId)
-                if (instance == null) {
+            val result = authRepository.saveInstanceEdits(
+                instanceId = instanceId,
+                token = token,
+                alias = alias,
+                trustSelfSigned = trustSelfSigned
+            )
+            result.fold(
+                onSuccess = { updated ->
                     updateReady {
                         copy(
-                            instanceEditSaving = false,
-                            instanceEditError = "Instance not found"
+                            selectedInstanceForDetails = updated,
+                            instanceEditSaving = false
                         )
                     }
-                    return@launch
+                },
+                onFailure = { e ->
+                    val updated = tokenManager.instances.value.find { it.id == instanceId }
+                    updateReady {
+                        copy(
+                            selectedInstanceForDetails = updated,
+                            instanceEditSaving = false,
+                            instanceEditError = e.message ?: "Failed to save changes"
+                        )
+                    }
                 }
-                val apiVersion = try {
-                    ApiVersion.valueOf(instance.apiVersion)
-                } catch (_: Exception) {
-                    ApiVersion.CONTROLLER_V2
-                }
-                tokenManager.saveInstance(
-                    baseUrl = instance.baseUrl,
-                    token = token ?: instance.token,
-                    alias = alias,
-                    apiVersion = apiVersion,
-                    trustSelfSigned = trustSelfSigned,
-                    existingId = instanceId
-                )
-                if (token != null || trustSelfSigned != instance.trustSelfSigned) {
-                    apiProvider.evictInstance(instanceId)
-                }
-                val updated = tokenManager.instances.value.find { it.id == instanceId }
-                updateReady {
-                    copy(
-                        selectedInstanceForDetails = updated,
-                        instanceEditSaving = false
-                    )
-                }
-            } catch (e: Exception) {
-                val updated = tokenManager.instances.value.find { it.id == instanceId }
-                updateReady {
-                    copy(
-                        selectedInstanceForDetails = updated,
-                        instanceEditSaving = false,
-                        instanceEditError = e.message ?: "Failed to save changes"
-                    )
-                }
-            }
+            )
         }
     }
 
     fun refreshInstanceInfo(instanceId: String) {
         viewModelScope.launch {
-            val instance = tokenManager.instances.value.find { it.id == instanceId } ?: return@launch
             updateReady { copy(discoveryRefreshing = true, discoveryError = null) }
-            try {
-                val apiVersion = try {
-                    ApiVersion.valueOf(instance.apiVersion)
-                } catch (_: Exception) {
-                    ApiVersion.CONTROLLER_V2
+            val result = authRepository.refreshInstanceInfo(instanceId)
+            result.fold(
+                onSuccess = {
+                    val updated = tokenManager.instances.value.find { it.id == instanceId }
+                    updateReady { copy(selectedInstanceForDetails = updated) }
+                },
+                onFailure = { e ->
+                    updateReady { copy(discoveryError = e.message ?: "Discovery failed") }
                 }
-                val info = instanceDiscovery.discover(
-                    instance.baseUrl, instance.token, apiVersion, instance.trustSelfSigned
-                )
-                tokenManager.updateInstanceInfo(instanceId, info)
-                val updated = tokenManager.instances.value.find { it.id == instanceId }
-                updateReady { copy(selectedInstanceForDetails = updated) }
-            } catch (e: Exception) {
-                updateReady { copy(discoveryError = e.message ?: "Discovery failed") }
-            } finally {
-                updateReady { copy(discoveryRefreshing = false) }
-            }
+            )
+            updateReady { copy(discoveryRefreshing = false) }
         }
     }
 
@@ -344,24 +313,19 @@ class SettingsViewModel(
     fun fetchAvailableModels(baseUrl: String, apiKey: String?) {
         viewModelScope.launch {
             updateReady { copy(modelFetchState = ModelFetchState.Loading) }
-            val client = buildLlmClient()
-            try {
-                val fetcher = ModelFetcher(client, json)
-                when (val result = fetcher.fetchModels(baseUrl, apiKey)) {
-                    is ModelFetcher.Result.Success -> {
-                        updateReady {
-                            copy(
-                                fetchedModels = result.models,
-                                modelFetchState = ModelFetchState.Success(result.models.size)
-                            )
-                        }
-                    }
-                    is ModelFetcher.Result.Error -> {
-                        updateReady { copy(modelFetchState = ModelFetchState.Error(result.message)) }
+            val trustSelfSigned = tokenManager.activeInstance.value?.trustSelfSigned == true
+            when (val result = modelFetcher.fetchModels(baseUrl, apiKey, trustSelfSigned)) {
+                is ModelFetcher.Result.Success -> {
+                    updateReady {
+                        copy(
+                            fetchedModels = result.models,
+                            modelFetchState = ModelFetchState.Success(result.models.size)
+                        )
                     }
                 }
-            } finally {
-                client.close()
+                is ModelFetcher.Result.Error -> {
+                    updateReady { copy(modelFetchState = ModelFetchState.Error(result.message)) }
+                }
             }
         }
     }
@@ -508,7 +472,7 @@ class SettingsViewModel(
 
     fun refreshMcpServer(label: String) {
         viewModelScope.launch {
-            mcpServerManager.reconnectServer(label)
+            mcpConnectionRepository.reconnectServer(label)
         }
     }
 
@@ -518,8 +482,8 @@ class SettingsViewModel(
             try {
                 val instance = tokenManager.activeInstance.value ?: return@launch
                 updateReady { copy(isRefreshingTools = true) }
-                mcpServerManager.connectAllWithCache(instance, forceRefresh = true)
-                mcpServerManager.buildManifest(instance)?.let {
+                mcpConnectionRepository.connectAllWithCache(instance, forceRefresh = true)
+                mcpConnectionRepository.buildManifest(instance)?.let {
                     manifestRepository.saveManifest(instance.id, it)
                 }
             } finally {
@@ -537,16 +501,6 @@ class SettingsViewModel(
 
     // --- Private helpers ---
 
-    private fun buildLlmClient(): HttpClient {
-        val instance = tokenManager.activeInstance.value
-        return createPlatformHttpClient(trustSelfSigned = instance?.trustSelfSigned == true) {
-            install(HttpTimeout) {
-                requestTimeoutMillis = 30_000
-                connectTimeoutMillis = 10_000
-                socketTimeoutMillis = 30_000
-            }
-        }
-    }
 
     private inline fun updateReady(crossinline transform: SettingsUiState.Ready.() -> SettingsUiState.Ready) {
         _uiState.update { current ->

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -40,7 +40,7 @@ class SettingsViewModel(
     private val manifestRepository: IToolManifestRepository,
     private val toolRouter: ToolRouter,
     private val json: Json,
-    private val modelFetcher: ModelFetcher = ModelFetcher(json)
+    private val modelFetcher: ModelFetcher
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/AddMcpServerSheet.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/AddMcpServerSheet.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import aapremotecontrol.composeapp.generated.resources.*
-import io.github.leogallego.ansiblejane.network.mcp.popularMcpServers
+import io.github.leogallego.ansiblejane.model.popularMcpServers
 import io.ktor.http.parseUrl
 
 private data class HeaderEntry(val key: String = "", val value: String = "")

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/McpServerCard.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/McpServerCard.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.leogallego.ansiblejane.model.McpServerConfig
-import io.github.leogallego.ansiblejane.network.mcp.McpConnectionState
+import io.github.leogallego.ansiblejane.model.McpConnectionState
 import io.github.leogallego.ansiblejane.presentation.settings.McpToolUiState
 import org.jetbrains.compose.resources.stringResource
 import aapremotecontrol.composeapp.generated.resources.*

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolsTab.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/ToolsTab.kt
@@ -41,7 +41,7 @@ import org.jetbrains.compose.resources.stringResource
 import aapremotecontrol.composeapp.generated.resources.*
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.model.McpServerConfig
-import io.github.leogallego.ansiblejane.network.mcp.McpConnectionState
+import io.github.leogallego.ansiblejane.model.McpConnectionState
 import io.github.leogallego.ansiblejane.presentation.settings.McpToolUiState
 
 @Composable

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModelTest.kt
@@ -12,13 +12,11 @@ import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
 import io.github.leogallego.ansiblejane.fakes.FakeAssistantRepository
 import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
 import io.github.leogallego.ansiblejane.fakes.FakeToolManifestRepository
-import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
+import io.github.leogallego.ansiblejane.fakes.FakeMcpConnectionRepository
+import io.github.leogallego.ansiblejane.fakes.FakeMcpToolInvoker
 import io.github.leogallego.ansiblejane.setupMainDispatcher
 import io.github.leogallego.ansiblejane.tearDownMainDispatcher
 import io.github.leogallego.ansiblejane.testInstance
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -35,18 +33,14 @@ class AssistantViewModelTest {
 
     private lateinit var fakeAssistantRepo: FakeAssistantRepository
     private lateinit var fakeTokenManager: FakeTokenManager
-    private lateinit var mcpServerManager: McpServerManager
+    private lateinit var mcpConnectionRepository: FakeMcpConnectionRepository
 
     @BeforeTest
     fun setup() {
         setupMainDispatcher()
         fakeAssistantRepo = FakeAssistantRepository()
         fakeTokenManager = FakeTokenManager()
-        mcpServerManager = McpServerManager(
-            ktorClientFactory = { _, _ ->
-                HttpClient(MockEngine) { engine { addHandler { respond("") } } }
-            }
-        )
+        mcpConnectionRepository = FakeMcpConnectionRepository()
     }
 
     @AfterTest
@@ -61,7 +55,8 @@ class AssistantViewModelTest {
     }
 
     private fun createViewModel(localTools: List<LocalTool> = emptyList()) = AssistantViewModel(
-        mcpServerManager = mcpServerManager,
+        mcpConnectionRepository = mcpConnectionRepository,
+        mcpToolInvoker = FakeMcpToolInvoker(),
         repository = fakeAssistantRepo,
         tokenManager = fakeTokenManager,
         manifestRepository = FakeToolManifestRepository(),

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/data/AuthRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/data/AuthRepositoryTest.kt
@@ -1,0 +1,133 @@
+package io.github.leogallego.ansiblejane.data
+
+import io.github.leogallego.ansiblejane.fakes.FakeAapApiProvider
+import io.github.leogallego.ansiblejane.fakes.FakeInstanceDiscovery
+import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
+import io.github.leogallego.ansiblejane.model.AapInstance
+import io.github.leogallego.ansiblejane.model.InstanceInfo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AuthRepositoryTest {
+
+    private lateinit var tokenManager: FakeTokenManager
+    private lateinit var apiProvider: FakeAapApiProvider
+    private lateinit var discovery: FakeInstanceDiscovery
+    private lateinit var repository: AuthRepository
+
+    private val instance = AapInstance(
+        id = "inst-1",
+        baseUrl = "https://aap.example.com",
+        token = "token-1",
+        alias = "Prod",
+        apiVersion = "CONTROLLER_V2",
+        trustSelfSigned = false
+    )
+
+    @BeforeTest
+    fun setup() {
+        tokenManager = FakeTokenManager()
+        apiProvider = FakeAapApiProvider()
+        discovery = FakeInstanceDiscovery()
+        repository = AuthRepository(
+            tokenManager = tokenManager,
+            apiProvider = apiProvider,
+            instanceDiscovery = discovery,
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        )
+    }
+
+    @Test
+    fun `logoutInstance evicts cache and removes instance`() = runTest {
+        tokenManager.setInstances(listOf(instance))
+
+        repository.logoutInstance("inst-1")
+
+        assertEquals(listOf("inst-1"), apiProvider.evictedInstances)
+        assertTrue(tokenManager.instances.value.isEmpty())
+        assertNull(tokenManager.activeInstance.value)
+    }
+
+    @Test
+    fun `saveInstanceEdits updates alias without eviction when auth unchanged`() = runTest {
+        tokenManager.setInstances(listOf(instance))
+
+        val result = repository.saveInstanceEdits(
+            instanceId = "inst-1",
+            token = null,
+            alias = "Lab",
+            trustSelfSigned = false
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals("Lab", result.getOrThrow().alias)
+        assertTrue(apiProvider.evictedInstances.isEmpty())
+    }
+
+    @Test
+    fun `saveInstanceEdits evicts when token changes`() = runTest {
+        tokenManager.setInstances(listOf(instance))
+
+        val result = repository.saveInstanceEdits(
+            instanceId = "inst-1",
+            token = "token-2",
+            alias = "Prod",
+            trustSelfSigned = false
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals("token-2", result.getOrThrow().token)
+        assertEquals(listOf("inst-1"), apiProvider.evictedInstances)
+    }
+
+    @Test
+    fun `saveInstanceEdits fails for unknown instance`() = runTest {
+        val result = repository.saveInstanceEdits(
+            instanceId = "missing",
+            token = null,
+            alias = "X",
+            trustSelfSigned = false
+        )
+
+        assertTrue(result.isFailure)
+        assertEquals("Instance not found", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `refreshInstanceInfo persists discovery result`() = runTest {
+        tokenManager.setInstances(listOf(instance))
+        discovery.nextInfo = InstanceInfo(
+            controllerVersion = "4.7.0",
+            platformType = "AAP",
+            aapVersion = "2.5",
+            components = listOf("CONTROLLER", "EDA")
+        )
+
+        val result = repository.refreshInstanceInfo("inst-1")
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, discovery.discoverCalls)
+        assertEquals("4.7.0", tokenManager.instances.value.single().instanceInfo?.controllerVersion)
+        assertEquals("2.5", tokenManager.instances.value.single().instanceInfo?.aapVersion)
+    }
+
+    @Test
+    fun `refreshInstanceInfo fails when discovery throws`() = runTest {
+        tokenManager.setInstances(listOf(instance))
+        discovery.shouldFail = true
+
+        val result = repository.refreshInstanceInfo("inst-1")
+
+        assertTrue(result.isFailure)
+        assertFalse(result.isSuccess)
+        assertNull(tokenManager.instances.value.single().instanceInfo)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAuthRepository.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAuthRepository.kt
@@ -2,16 +2,28 @@ package io.github.leogallego.ansiblejane.fakes
 
 import io.github.leogallego.ansiblejane.data.CredentialStatus
 import io.github.leogallego.ansiblejane.data.IAuthRepository
+import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.model.User
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 
-class FakeAuthRepository : IAuthRepository {
+class FakeAuthRepository(
+    private val tokenManager: FakeTokenManager? = null
+) : IAuthRepository {
     var validateResult: Result<User>? = null
     var shouldFail = false
     var failureException: Exception = RuntimeException("Test error")
     var existingCredentialsResult: CredentialStatus = CredentialStatus.NoCredentials
+    val removedInstances = mutableListOf<String>()
+    val evictedInstances = mutableListOf<String>()
+    var saveInstanceEditsResult: Result<AapInstance>? = null
+    var refreshInstanceInfoResult: Result<Unit> = Result.success(Unit)
     private val _isLoggedIn = MutableStateFlow(false)
+    private val _unauthorizedEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    override val unauthorizedEvent: SharedFlow<String> = _unauthorizedEvent.asSharedFlow()
 
     override suspend fun validateCredentials(
         baseUrl: String,
@@ -34,6 +46,9 @@ class FakeAuthRepository : IAuthRepository {
     }
 
     override suspend fun logoutInstance(instanceId: String) {
+        evictedInstances.add(instanceId)
+        removedInstances.add(instanceId)
+        tokenManager?.removeInstance(instanceId)
         _isLoggedIn.value = false
     }
 
@@ -43,7 +58,41 @@ class FakeAuthRepository : IAuthRepository {
 
     override fun isLoggedIn(): Flow<Boolean> = _isLoggedIn
 
+    override suspend fun saveInstanceEdits(
+        instanceId: String,
+        token: String?,
+        alias: String?,
+        trustSelfSigned: Boolean
+    ): Result<AapInstance> {
+        saveInstanceEditsResult?.let { return it }
+        val instance = tokenManager?.getInstanceById(instanceId)
+            ?: return Result.failure(Exception("Instance not found"))
+        if (token != null || trustSelfSigned != instance.trustSelfSigned) {
+            evictedInstances.add(instanceId)
+        }
+        // Mirror persistence lightly for UI state tests when a FakeTokenManager is provided.
+        tokenManager?.let { tm ->
+            val updated = instance.copy(
+                token = token ?: instance.token,
+                alias = alias,
+                trustSelfSigned = trustSelfSigned
+            )
+            val list = tm.instances.value.map { if (it.id == instanceId) updated else it }
+            tm.setInstances(list)
+            return Result.success(updated)
+        }
+        return Result.success(instance)
+    }
+
+    override suspend fun refreshInstanceInfo(instanceId: String): Result<Unit> {
+        return refreshInstanceInfoResult
+    }
+
     fun setLoggedIn(loggedIn: Boolean) {
         _isLoggedIn.value = loggedIn
+    }
+
+    fun emitUnauthorized(instanceId: String) {
+        _unauthorizedEvent.tryEmit(instanceId)
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeEdaActivationRepository.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeEdaActivationRepository.kt
@@ -1,0 +1,29 @@
+package io.github.leogallego.ansiblejane.fakes
+
+import io.github.leogallego.ansiblejane.data.EdaActivationListResult
+import io.github.leogallego.ansiblejane.data.IEdaActivationRepository
+import io.github.leogallego.ansiblejane.model.EdaActivation
+
+class FakeEdaActivationRepository : IEdaActivationRepository {
+    var activations = listOf<EdaActivation>()
+    var totalCount: Int? = null
+    var shouldFail = false
+    var failureException: Exception = RuntimeException("Test error")
+
+    override suspend fun getActivations(page: Int, pageSize: Int): Result<EdaActivationListResult> {
+        if (shouldFail) return Result.failure(failureException)
+        return Result.success(
+            EdaActivationListResult(
+                activations = activations,
+                hasMore = false,
+                totalCount = totalCount ?: activations.size
+            )
+        )
+    }
+
+    override suspend fun getActivation(id: Int): Result<EdaActivation> {
+        if (shouldFail) return Result.failure(failureException)
+        return activations.find { it.id == id }?.let { Result.success(it) }
+            ?: Result.failure(NoSuchElementException("Activation $id not found"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeInstanceDiscovery.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeInstanceDiscovery.kt
@@ -1,0 +1,27 @@
+package io.github.leogallego.ansiblejane.fakes
+
+import io.github.leogallego.ansiblejane.model.ApiVersion
+import io.github.leogallego.ansiblejane.model.InstanceInfo
+import io.github.leogallego.ansiblejane.network.IInstanceDiscovery
+
+class FakeInstanceDiscovery : IInstanceDiscovery {
+    var nextInfo: InstanceInfo = InstanceInfo(
+        controllerVersion = "4.6.0",
+        platformType = "AAP",
+        components = listOf("CONTROLLER")
+    )
+    var shouldFail = false
+    var failureException: Exception = RuntimeException("Discovery failed")
+    var discoverCalls = 0
+
+    override suspend fun discover(
+        baseUrl: String,
+        token: String,
+        apiVersion: ApiVersion,
+        trustSelfSigned: Boolean
+    ): InstanceInfo {
+        discoverCalls++
+        if (shouldFail) throw failureException
+        return nextInfo
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeMcpConnectionRepository.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeMcpConnectionRepository.kt
@@ -1,0 +1,61 @@
+package io.github.leogallego.ansiblejane.fakes
+
+import io.github.leogallego.ansiblejane.assistant.tools.Tool
+import io.github.leogallego.ansiblejane.data.IMcpConnectionRepository
+import io.github.leogallego.ansiblejane.model.AapInstance
+import io.github.leogallego.ansiblejane.model.McpConnectionState
+import io.github.leogallego.ansiblejane.model.ToolManifest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakeMcpConnectionRepository : IMcpConnectionRepository {
+    private val _connections = MutableStateFlow<Map<String, McpConnectionState>>(emptyMap())
+    override val connections: StateFlow<Map<String, McpConnectionState>> = _connections.asStateFlow()
+
+    private val _mcpTools = MutableStateFlow<List<Tool>>(emptyList())
+    override val mcpTools: StateFlow<List<Tool>> = _mcpTools.asStateFlow()
+
+    var disconnectAllCalls = 0
+    var connectAllCalls = 0
+    var connectAllWithCacheCalls = 0
+    var refreshConnectionsCalls = 0
+    var reconnectServerCalls = mutableListOf<String>()
+    var lastManifest: ToolManifest? = null
+
+    override suspend fun connectAll(instance: AapInstance) {
+        connectAllCalls++
+    }
+
+    override suspend fun disconnectAll() {
+        disconnectAllCalls++
+        _connections.value = emptyMap()
+        _mcpTools.value = emptyList()
+    }
+
+    override fun setCachedTools(tools: List<Tool>) {
+        _mcpTools.value = tools
+    }
+
+    override suspend fun connectAllWithCache(
+        instance: AapInstance,
+        manifest: ToolManifest?,
+        forceRefresh: Boolean
+    ) {
+        connectAllWithCacheCalls++
+    }
+
+    override suspend fun reconnectServer(label: String) {
+        reconnectServerCalls.add(label)
+    }
+
+    override fun refreshConnections() {
+        refreshConnectionsCalls++
+    }
+
+    override fun buildManifest(instance: AapInstance): ToolManifest? = lastManifest
+
+    fun setConnections(value: Map<String, McpConnectionState>) {
+        _connections.value = value
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeMcpToolInvoker.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeMcpToolInvoker.kt
@@ -1,0 +1,13 @@
+package io.github.leogallego.ansiblejane.fakes
+
+import io.github.leogallego.ansiblejane.assistant.tools.McpToolInvoker
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import kotlinx.serialization.json.JsonObject
+
+class FakeMcpToolInvoker : McpToolInvoker {
+    override suspend fun invokeMcpTool(
+        serverLabel: String,
+        toolName: String,
+        args: JsonObject
+    ): ToolResult = ToolResult(success = true, data = "")
+}

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
@@ -4,7 +4,7 @@ import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.model.InstanceInfo
 import io.github.leogallego.ansiblejane.model.McpServerConfig
-import io.github.leogallego.ansiblejane.network.ApiVersion
+import io.github.leogallego.ansiblejane.model.ApiVersion
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeTokenManager.kt
@@ -32,6 +32,7 @@ class FakeTokenManager : ITokenManager {
         existingId: String?
     ): String {
         val id = existingId ?: saveInstanceResult
+        val previous = _instances.value.find { it.id == id }
         val instance = AapInstance(
             id = id,
             baseUrl = baseUrl,
@@ -39,10 +40,22 @@ class FakeTokenManager : ITokenManager {
             alias = alias,
             apiVersion = apiVersion.name,
             trustSelfSigned = trustSelfSigned,
-            certFingerprint = certFingerprint
+            certFingerprint = certFingerprint,
+            mcpServerUrls = previous?.mcpServerUrls,
+            mcpEnabled = previous?.mcpEnabled ?: false,
+            instanceInfo = previous?.instanceInfo,
+            isSuperuser = previous?.isSuperuser ?: false,
+            isSystemAuditor = previous?.isSystemAuditor ?: false,
+            userRoleFetched = previous?.userRoleFetched ?: false
         )
-        _instances.value = _instances.value + instance
-        if (_activeInstance.value == null) _activeInstance.value = instance
+        _instances.value = if (existingId != null) {
+            _instances.value.map { if (it.id == id) instance else it }
+        } else {
+            _instances.value + instance
+        }
+        if (_activeInstance.value == null || _activeInstance.value?.id == id) {
+            _activeInstance.value = instance
+        }
         return id
     }
 

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/model/ToolManifestSerializationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/model/ToolManifestSerializationTest.kt
@@ -1,7 +1,7 @@
 package io.github.leogallego.ansiblejane.model
 
-import io.github.leogallego.ansiblejane.network.mcp.McpServerInfo
-import io.github.leogallego.ansiblejane.network.mcp.McpToolDefinition
+import io.github.leogallego.ansiblejane.model.McpServerInfo
+import io.github.leogallego.ansiblejane.model.McpToolDefinition
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/dashboard/DashboardViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/dashboard/DashboardViewModelTest.kt
@@ -2,7 +2,7 @@ package io.github.leogallego.ansiblejane.presentation.dashboard
 
 import app.cash.turbine.test
 import io.github.leogallego.ansiblejane.TestData
-import io.github.leogallego.ansiblejane.fakes.FakeAapApiProvider
+import io.github.leogallego.ansiblejane.fakes.FakeEdaActivationRepository
 import io.github.leogallego.ansiblejane.fakes.FakeHostRepository
 import io.github.leogallego.ansiblejane.fakes.FakeInventoryRepository
 import io.github.leogallego.ansiblejane.fakes.FakeJobRepository
@@ -21,7 +21,6 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -33,7 +32,7 @@ class DashboardViewModelTest {
     private lateinit var fakeHostRepo: FakeHostRepository
     private lateinit var fakeProjectRepo: FakeProjectRepository
     private lateinit var fakeScheduleRepo: FakeScheduleRepository
-    private lateinit var fakeApiProvider: FakeAapApiProvider
+    private lateinit var fakeEdaActivationRepo: FakeEdaActivationRepository
     private lateinit var fakeTokenManager: FakeTokenManager
 
     @BeforeTest
@@ -45,7 +44,7 @@ class DashboardViewModelTest {
         fakeHostRepo = FakeHostRepository()
         fakeProjectRepo = FakeProjectRepository()
         fakeScheduleRepo = FakeScheduleRepository()
-        fakeApiProvider = FakeAapApiProvider()
+        fakeEdaActivationRepo = FakeEdaActivationRepository()
         fakeTokenManager = FakeTokenManager()
     }
 
@@ -61,7 +60,7 @@ class DashboardViewModelTest {
         hostRepository = fakeHostRepo,
         projectRepository = fakeProjectRepo,
         scheduleRepository = fakeScheduleRepo,
-        apiProvider = fakeApiProvider,
+        edaActivationRepository = fakeEdaActivationRepo,
         tokenManager = fakeTokenManager,
     )
 
@@ -89,7 +88,8 @@ class DashboardViewModelTest {
             assertEquals(3, success.hostCount)
             assertEquals(1, success.templateCount)
             assertEquals(2, success.projectCount)
-            assertNull(success.edaActivationsCount)
+            assertEquals(0, success.edaActivationsCount)
+            assertEquals(0, success.edaActiveRulebooksCount)
             assertEquals(1, success.upcomingSchedules.size)
             assertEquals("Prod", success.instanceAlias)
         }

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
@@ -1,7 +1,8 @@
 package io.github.leogallego.ansiblejane.presentation.settings
 
 import app.cash.turbine.test
-import io.github.leogallego.ansiblejane.fakes.FakeAapApiProvider
+import io.github.leogallego.ansiblejane.fakes.FakeAuthRepository
+import io.github.leogallego.ansiblejane.fakes.FakeMcpConnectionRepository
 import io.github.leogallego.ansiblejane.fakes.FakeAssistantRepository
 import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
 import io.github.leogallego.ansiblejane.fakes.FakeUserPreferencesRepository
@@ -12,11 +13,7 @@ import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
-import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
 import io.github.leogallego.ansiblejane.ui.components.ThemeMode
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
 import io.github.leogallego.ansiblejane.setupMainDispatcher
 import io.github.leogallego.ansiblejane.tearDownMainDispatcher
 import kotlinx.coroutines.test.runTest
@@ -33,10 +30,10 @@ import kotlin.test.assertTrue
 class SettingsViewModelTest {
 
     private lateinit var fakeTokenManager: FakeTokenManager
-    private lateinit var fakeApiProvider: FakeAapApiProvider
+    private lateinit var fakeAuthRepository: FakeAuthRepository
     private lateinit var fakeUserPreferences: FakeUserPreferencesRepository
     private lateinit var fakeAssistantRepo: FakeAssistantRepository
-    private lateinit var mcpServerManager: McpServerManager
+    private lateinit var mcpConnectionRepository: FakeMcpConnectionRepository
     private val json = Json { ignoreUnknownKeys = true }
 
     private val instance1 = AapInstance(
@@ -57,14 +54,10 @@ class SettingsViewModelTest {
     fun setup() {
         setupMainDispatcher()
         fakeTokenManager = FakeTokenManager()
-        fakeApiProvider = FakeAapApiProvider()
+        fakeAuthRepository = FakeAuthRepository(fakeTokenManager)
         fakeUserPreferences = FakeUserPreferencesRepository()
         fakeAssistantRepo = FakeAssistantRepository()
-        mcpServerManager = McpServerManager(
-            ktorClientFactory = { _, _ ->
-                HttpClient(MockEngine) { engine { addHandler { respond("") } } }
-            }
-        )
+        mcpConnectionRepository = FakeMcpConnectionRepository()
     }
 
     @AfterTest
@@ -80,12 +73,11 @@ class SettingsViewModelTest {
 
     private fun createViewModel(localTools: List<LocalTool> = emptyList()) = SettingsViewModel(
         tokenManager = fakeTokenManager,
-        apiProvider = fakeApiProvider,
+        authRepository = fakeAuthRepository,
         userPreferences = fakeUserPreferences,
         assistantRepository = fakeAssistantRepo,
-        mcpServerManager = mcpServerManager,
+        mcpConnectionRepository = mcpConnectionRepository,
         manifestRepository = io.github.leogallego.ansiblejane.fakes.FakeToolManifestRepository(),
-        instanceDiscovery = io.github.leogallego.ansiblejane.network.InstanceDiscovery(json),
         toolRouter = ToolRouter(initialLocalTools = localTools, repository = fakeAssistantRepo),
         json = json
     )
@@ -156,7 +148,7 @@ class SettingsViewModelTest {
             val updated = awaitItem() as SettingsUiState.Ready
             assertEquals(1, updated.instances.size)
             assertEquals("inst-2", updated.instances[0].id)
-            assertEquals(listOf("inst-1"), fakeApiProvider.evictedInstances)
+            assertEquals(listOf("inst-1"), fakeAuthRepository.evictedInstances)
         }
     }
 

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
@@ -1,21 +1,28 @@
 package io.github.leogallego.ansiblejane.presentation.settings
 
 import app.cash.turbine.test
-import io.github.leogallego.ansiblejane.fakes.FakeAuthRepository
-import io.github.leogallego.ansiblejane.fakes.FakeMcpConnectionRepository
-import io.github.leogallego.ansiblejane.fakes.FakeAssistantRepository
-import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
-import io.github.leogallego.ansiblejane.fakes.FakeUserPreferencesRepository
-import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
+import io.github.leogallego.ansiblejane.assistant.data.ModelFetcher
 import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSpec
 import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
-import io.github.leogallego.ansiblejane.ui.components.ThemeMode
+import io.github.leogallego.ansiblejane.fakes.FakeAssistantRepository
+import io.github.leogallego.ansiblejane.fakes.FakeAuthRepository
+import io.github.leogallego.ansiblejane.fakes.FakeMcpConnectionRepository
+import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
+import io.github.leogallego.ansiblejane.fakes.FakeUserPreferencesRepository
+import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.setupMainDispatcher
 import io.github.leogallego.ansiblejane.tearDownMainDispatcher
+import io.github.leogallego.ansiblejane.ui.components.ThemeMode
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -79,7 +86,20 @@ class SettingsViewModelTest {
         mcpConnectionRepository = mcpConnectionRepository,
         manifestRepository = io.github.leogallego.ansiblejane.fakes.FakeToolManifestRepository(),
         toolRouter = ToolRouter(initialLocalTools = localTools, repository = fakeAssistantRepo),
-        json = json
+        json = json,
+        modelFetcher = ModelFetcher(json) { _ ->
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler {
+                        respond(
+                            content = """{"data":[]}""",
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json")
+                        )
+                    }
+                }
+            }
+        }
     )
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
@@ -11,20 +11,16 @@ import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.runComposeUiTest
 import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
 import io.github.leogallego.ansiblejane.desktopTestKoinModule
-import io.github.leogallego.ansiblejane.fakes.FakeAapApiProvider
+import io.github.leogallego.ansiblejane.fakes.FakeAuthRepository
+import io.github.leogallego.ansiblejane.fakes.FakeMcpConnectionRepository
 import io.github.leogallego.ansiblejane.fakes.FakeAssistantRepository
 import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
 import io.github.leogallego.ansiblejane.fakes.FakeToolManifestRepository
 import io.github.leogallego.ansiblejane.fakes.FakeUserPreferencesRepository
 import io.github.leogallego.ansiblejane.model.AapInstance
-import io.github.leogallego.ansiblejane.network.InstanceDiscovery
-import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
 import io.github.leogallego.ansiblejane.presentation.settings.SettingsViewModel
 import io.github.leogallego.ansiblejane.setupMainDispatcher
 import io.github.leogallego.ansiblejane.tearDownMainDispatcher
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
 import kotlinx.serialization.json.Json
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
@@ -36,15 +32,11 @@ import kotlin.test.Test
 class SettingsScreenTest {
 
     private val fakeTokenManager = FakeTokenManager()
-    private val fakeApiProvider = FakeAapApiProvider()
+    private val fakeAuthRepository = FakeAuthRepository(fakeTokenManager)
     private val fakeUserPreferences = FakeUserPreferencesRepository()
     private val fakeAssistantRepo = FakeAssistantRepository()
     private val json = Json { ignoreUnknownKeys = true }
-    private val mcpServerManager = McpServerManager(
-        ktorClientFactory = { _, _ ->
-            HttpClient(MockEngine) { engine { addHandler { respond("") } } }
-        }
-    )
+    private val mcpConnectionRepository = FakeMcpConnectionRepository()
 
     private val instance1 = AapInstance(
         id = "inst-1",
@@ -74,13 +66,12 @@ class SettingsScreenTest {
 
     private fun createViewModel() = SettingsViewModel(
         tokenManager = fakeTokenManager,
-        apiProvider = fakeApiProvider,
+        authRepository = fakeAuthRepository,
         userPreferences = fakeUserPreferences,
         assistantRepository = fakeAssistantRepo,
-        mcpServerManager = mcpServerManager,
+        mcpConnectionRepository = mcpConnectionRepository,
         manifestRepository = FakeToolManifestRepository(),
-        instanceDiscovery = InstanceDiscovery(json),
-        toolRouter = ToolRouter(repository = fakeAssistantRepo),
+        toolRouter = ToolRouter(initialLocalTools = emptyList(), repository = fakeAssistantRepo),
         json = json
     )
 

--- a/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreenTest.kt
@@ -9,11 +9,12 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.runComposeUiTest
+import io.github.leogallego.ansiblejane.assistant.data.ModelFetcher
 import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
 import io.github.leogallego.ansiblejane.desktopTestKoinModule
+import io.github.leogallego.ansiblejane.fakes.FakeAssistantRepository
 import io.github.leogallego.ansiblejane.fakes.FakeAuthRepository
 import io.github.leogallego.ansiblejane.fakes.FakeMcpConnectionRepository
-import io.github.leogallego.ansiblejane.fakes.FakeAssistantRepository
 import io.github.leogallego.ansiblejane.fakes.FakeTokenManager
 import io.github.leogallego.ansiblejane.fakes.FakeToolManifestRepository
 import io.github.leogallego.ansiblejane.fakes.FakeUserPreferencesRepository
@@ -21,6 +22,12 @@ import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.presentation.settings.SettingsViewModel
 import io.github.leogallego.ansiblejane.setupMainDispatcher
 import io.github.leogallego.ansiblejane.tearDownMainDispatcher
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
 import kotlinx.serialization.json.Json
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
@@ -72,7 +79,20 @@ class SettingsScreenTest {
         mcpConnectionRepository = mcpConnectionRepository,
         manifestRepository = FakeToolManifestRepository(),
         toolRouter = ToolRouter(initialLocalTools = emptyList(), repository = fakeAssistantRepo),
-        json = json
+        json = json,
+        modelFetcher = ModelFetcher(json) { _ ->
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler {
+                        respond(
+                            content = """{"data":[]}""",
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json")
+                        )
+                    }
+                }
+            }
+        }
     )
 
     private fun ComposeUiTest.setUpScreen(viewModel: SettingsViewModel = createViewModel()) {

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -68,6 +68,14 @@ MCP connection lifecycle is exposed through `IMcpConnectionRepository` (implemen
 `IAuthRepository.unauthorizedEvent` (backed by network `AuthEvents`). Presentation and
 UI must use those interfaces — not `network.mcp` / `AuthEvents` directly.
 
+Nav/session bootstrap (`AppNavigation`) may observe `IAuthRepository.unauthorizedEvent`
+and `ITokenManager` instance flows. That is intentional session wiring, not a general
+license for UI to call repositories for feature data.
+
+`IMcpConnectionRepository` intentionally lives in `data/` while
+`McpServerManager` implements it from `network.mcp/`. This is an explicit exception to
+the §2 same-package guideline so presentation never imports `network`.
+
 ---
 
 ## 2. Interface Contracts

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -60,6 +60,14 @@ layers below it. No layer skipping is permitted.
 from user-provided URLs. This is documented and intentional — creating a repository
 for one-shot discovery of external endpoints would be over-engineering.
 
+`ModelFetcher` owns HTTP client creation/teardown internally. ViewModels must not call
+`createPlatformHttpClient` or import `network` for this flow.
+
+MCP connection lifecycle is exposed through `IMcpConnectionRepository` (implemented by
+`McpServerManager`). Unauthorized session events are exposed through
+`IAuthRepository.unauthorizedEvent` (backed by network `AuthEvents`). Presentation and
+UI must use those interfaces — not `network.mcp` / `AuthEvents` directly.
+
 ---
 
 ## 2. Interface Contracts

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/ModelFetcher.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/ModelFetcher.kt
@@ -1,6 +1,8 @@
 package io.github.leogallego.ansiblejane.assistant.data
 
+import io.github.leogallego.ansiblejane.network.createPlatformHttpClient
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
@@ -11,34 +13,58 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
+/**
+ * One-shot LLM `/models` discovery for Settings.
+ *
+ * Owns its HTTP client lifecycle so presentation never calls
+ * [createPlatformHttpClient] directly (service-contracts §1 ModelFetcher exception).
+ *
+ * [clientFactory] is injectable for tests; production uses the default platform client.
+ */
 class ModelFetcher(
-    private val httpClient: HttpClient,
-    private val json: Json
+    private val json: Json,
+    private val clientFactory: (trustSelfSigned: Boolean) -> HttpClient = { trustSelfSigned ->
+        createPlatformHttpClient(trustSelfSigned = trustSelfSigned) {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 30_000
+                connectTimeoutMillis = 10_000
+                socketTimeoutMillis = 30_000
+            }
+        }
+    }
 ) {
     sealed interface Result {
         data class Success(val models: List<String>) : Result
         data class Error(val message: String) : Result
     }
 
-    suspend fun fetchModels(baseUrl: String, apiKey: String?): Result {
+    suspend fun fetchModels(
+        baseUrl: String,
+        apiKey: String?,
+        trustSelfSigned: Boolean = false
+    ): Result {
         val url = "${baseUrl.trimEnd('/')}/models"
-
-        val response = try {
-            httpClient.get(url) {
-                if (!apiKey.isNullOrBlank()) {
-                    header(HttpHeaders.Authorization, "Bearer $apiKey")
+        val client = clientFactory(trustSelfSigned)
+        return try {
+            val response = try {
+                client.get(url) {
+                    if (!apiKey.isNullOrBlank()) {
+                        header(HttpHeaders.Authorization, "Bearer $apiKey")
+                    }
                 }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                return Result.Error("Could not reach server: ${e.message}")
             }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            return Result.Error("Could not reach server: ${e.message}")
-        }
 
-        return when (response.status.value) {
-            in 200..299 -> parseModelsResponse(response.bodyAsText())
-            401, 403 -> Result.Error("Authentication failed — check API key")
-            else -> Result.Error("Server returned ${response.status.value}")
+            when (response.status.value) {
+                in 200..299 -> parseModelsResponse(response.bodyAsText())
+                401, 403 -> Result.Error("Authentication failed — check API key")
+                else -> Result.Error("Server returned ${response.status.value}")
+            }
+        } finally {
+            client.close()
         }
     }
 

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
@@ -6,6 +6,8 @@ import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
 import io.github.leogallego.ansiblejane.assistant.tools.local.*
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.network.createPlatformHttpClient
+import io.github.leogallego.ansiblejane.data.IMcpConnectionRepository
+import io.github.leogallego.ansiblejane.assistant.tools.McpToolInvoker
 import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.sse.SSE
@@ -13,6 +15,7 @@ import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
+import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val sharedAssistantModule = module {
@@ -37,7 +40,7 @@ val sharedAssistantModule = module {
                 }
             }
         )
-    }
+    } binds arrayOf(IMcpConnectionRepository::class, McpToolInvoker::class)
 
     single(named("llm")) {
         createPlatformHttpClient {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
@@ -1,5 +1,6 @@
 package io.github.leogallego.ansiblejane.assistant.di
 
+import io.github.leogallego.ansiblejane.assistant.data.ModelFetcher
 import io.github.leogallego.ansiblejane.assistant.engine.ToolRouter
 import io.github.leogallego.ansiblejane.assistant.engine.toAapRole
 import io.github.leogallego.ansiblejane.assistant.tools.LocalTool
@@ -19,6 +20,8 @@ import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val sharedAssistantModule = module {
+    single { ModelFetcher(json = get()) }
+
     single {
         McpServerManager(
             ktorClientFactory = { instance, serverConfig ->

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/CachedMcpTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/CachedMcpTool.kt
@@ -1,9 +1,7 @@
 package io.github.leogallego.ansiblejane.assistant.tools
 
-import io.modelcontextprotocol.kotlin.sdk.types.TextContent
-import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
+import io.github.leogallego.ansiblejane.model.McpToolDefinition
 import kotlin.coroutines.cancellation.CancellationException
-import io.github.leogallego.ansiblejane.network.mcp.McpToolDefinition
 import kotlinx.serialization.json.JsonObject
 
 class CachedMcpTool(
@@ -11,7 +9,7 @@ class CachedMcpTool(
     override val serverLabel: String,
     override val toolset: String? = null,
     val readOnly: Boolean = false,
-    private val serverManager: McpServerManager
+    private val toolInvoker: McpToolInvoker
 ) : Tool {
 
     override val isDestructive: Boolean =
@@ -25,22 +23,7 @@ class CachedMcpTool(
 
     override suspend fun execute(args: JsonObject): ToolResult {
         return try {
-            val client = serverManager.ensureConnected(serverLabel)
-            val result = client.callTool(mcpToolDef.name, args)
-
-            val text = result.content
-                .filterIsInstance<TextContent>()
-                .joinToString("\n") { it.text }
-
-            if (result.isError == true) {
-                ToolResult(
-                    success = false,
-                    data = text,
-                    errorType = ErrorType.SERVER_ERROR
-                )
-            } else {
-                ToolResult(success = true, data = text)
-            }
+            toolInvoker.invokeMcpTool(serverLabel, mcpToolDef.name, args)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpTool.kt
@@ -2,7 +2,7 @@ package io.github.leogallego.ansiblejane.assistant.tools
 
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
-import io.github.leogallego.ansiblejane.network.mcp.McpToolDefinition
+import io.github.leogallego.ansiblejane.model.McpToolDefinition
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpToolInvoker.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/tools/McpToolInvoker.kt
@@ -1,0 +1,17 @@
+package io.github.leogallego.ansiblejane.assistant.tools
+
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Executes an MCP tool call against a named server connection.
+ *
+ * Presentation-safe: no MCP SDK types. Implemented by
+ * [io.github.leogallego.ansiblejane.network.mcp.McpServerManager].
+ */
+fun interface McpToolInvoker {
+    suspend fun invokeMcpTool(
+        serverLabel: String,
+        toolName: String,
+        args: JsonObject
+    ): ToolResult
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/AuthRepository.kt
@@ -1,9 +1,11 @@
 package io.github.leogallego.ansiblejane.data
 
+import io.github.leogallego.ansiblejane.model.AapInstance
+import io.github.leogallego.ansiblejane.model.ApiVersion
 import io.github.leogallego.ansiblejane.model.User
 import io.github.leogallego.ansiblejane.network.AapApiClient
-import io.github.leogallego.ansiblejane.network.ApiVersion
 import io.github.leogallego.ansiblejane.network.ApiVersionDetector
+import io.github.leogallego.ansiblejane.network.AuthEvents
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import io.github.leogallego.ansiblejane.network.InstanceDiscovery
 import io.github.leogallego.ansiblejane.network.createPlatformHttpClient
@@ -16,6 +18,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 
 class AuthRepository(
@@ -24,6 +27,8 @@ class AuthRepository(
     private val instanceDiscovery: InstanceDiscovery,
     private val scope: CoroutineScope
 ) : IAuthRepository {
+
+    override val unauthorizedEvent: SharedFlow<String> = AuthEvents.unauthorizedEvent
 
     override suspend fun validateCredentials(
         baseUrl: String,
@@ -137,6 +142,7 @@ class AuthRepository(
     }
 
     override suspend fun logoutInstance(instanceId: String) {
+        apiProvider.evictInstance(instanceId)
         tokenManager.removeInstance(instanceId)
     }
 
@@ -145,6 +151,62 @@ class AuthRepository(
     }
 
     override fun isLoggedIn() = tokenManager.isLoggedIn
+
+    override suspend fun saveInstanceEdits(
+        instanceId: String,
+        token: String?,
+        alias: String?,
+        trustSelfSigned: Boolean
+    ): Result<AapInstance> {
+        return try {
+            val instance = tokenManager.getInstanceById(instanceId)
+                ?: return Result.failure(Exception("Instance not found"))
+            val apiVersion = try {
+                ApiVersion.valueOf(instance.apiVersion)
+            } catch (_: Exception) {
+                ApiVersion.CONTROLLER_V2
+            }
+            tokenManager.saveInstance(
+                baseUrl = instance.baseUrl,
+                token = token ?: instance.token,
+                alias = alias,
+                apiVersion = apiVersion,
+                trustSelfSigned = trustSelfSigned,
+                existingId = instanceId
+            )
+            if (token != null || trustSelfSigned != instance.trustSelfSigned) {
+                apiProvider.evictInstance(instanceId)
+            }
+            val updated = tokenManager.instances.value.find { it.id == instanceId }
+                ?: return Result.failure(Exception("Instance not found after save"))
+            Result.success(updated)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun refreshInstanceInfo(instanceId: String): Result<Unit> {
+        return try {
+            val instance = tokenManager.instances.value.find { it.id == instanceId }
+                ?: return Result.failure(Exception("Instance not found"))
+            val apiVersion = try {
+                ApiVersion.valueOf(instance.apiVersion)
+            } catch (_: Exception) {
+                ApiVersion.CONTROLLER_V2
+            }
+            val info = instanceDiscovery.discover(
+                instance.baseUrl, instance.token, apiVersion, instance.trustSelfSigned
+            )
+            tokenManager.updateInstanceInfo(instanceId, info)
+            Result.success(Unit)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 
     private fun launchDiscovery(
         instanceId: String,

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/AuthRepository.kt
@@ -7,7 +7,7 @@ import io.github.leogallego.ansiblejane.network.AapApiClient
 import io.github.leogallego.ansiblejane.network.ApiVersionDetector
 import io.github.leogallego.ansiblejane.network.AuthEvents
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
-import io.github.leogallego.ansiblejane.network.InstanceDiscovery
+import io.github.leogallego.ansiblejane.network.IInstanceDiscovery
 import io.github.leogallego.ansiblejane.network.createPlatformHttpClient
 import io.github.leogallego.ansiblejane.network.networkJson
 import io.ktor.client.plugins.HttpTimeout
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 class AuthRepository(
     private val tokenManager: ITokenManager,
     private val apiProvider: IAapApiProvider,
-    private val instanceDiscovery: InstanceDiscovery,
+    private val instanceDiscovery: IInstanceDiscovery,
     private val scope: CoroutineScope
 ) : IAuthRepository {
 

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IAuthRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IAuthRepository.kt
@@ -1,7 +1,9 @@
 package io.github.leogallego.ansiblejane.data
 
+import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.model.User
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
 
 sealed class CredentialStatus {
     data class Valid(val user: User) : CredentialStatus()
@@ -23,4 +25,21 @@ interface IAuthRepository {
     suspend fun logoutInstance(instanceId: String)
     suspend fun logout()
     fun isLoggedIn(): Flow<Boolean>
+
+    /**
+     * Persist instance edits (token/alias/trust) and evict cached HTTP clients when
+     * auth-affecting fields change.
+     */
+    suspend fun saveInstanceEdits(
+        instanceId: String,
+        token: String?,
+        alias: String?,
+        trustSelfSigned: Boolean
+    ): Result<AapInstance>
+
+    /** Re-run instance discovery and persist [InstanceInfo]. */
+    suspend fun refreshInstanceInfo(instanceId: String): Result<Unit>
+
+    /** 401 unauthorized events emitted by the HTTP layer. */
+    val unauthorizedEvent: SharedFlow<String>
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IMcpConnectionRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/IMcpConnectionRepository.kt
@@ -1,0 +1,31 @@
+package io.github.leogallego.ansiblejane.data
+
+import io.github.leogallego.ansiblejane.assistant.tools.Tool
+import io.github.leogallego.ansiblejane.model.AapInstance
+import io.github.leogallego.ansiblejane.model.McpConnectionState
+import io.github.leogallego.ansiblejane.model.ToolManifest
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Presentation-safe facade over MCP server lifecycle.
+ *
+ * Wraps [io.github.leogallego.ansiblejane.network.mcp.McpServerManager] so ViewModels
+ * do not import the network layer. MCP tool execution uses
+ * [io.github.leogallego.ansiblejane.assistant.tools.McpToolInvoker].
+ */
+interface IMcpConnectionRepository {
+    val connections: StateFlow<Map<String, McpConnectionState>>
+    val mcpTools: StateFlow<List<Tool>>
+
+    suspend fun connectAll(instance: AapInstance)
+    suspend fun disconnectAll()
+    fun setCachedTools(tools: List<Tool>)
+    suspend fun connectAllWithCache(
+        instance: AapInstance,
+        manifest: ToolManifest? = null,
+        forceRefresh: Boolean = false
+    )
+    suspend fun reconnectServer(label: String)
+    fun refreshConnections()
+    fun buildManifest(instance: AapInstance): ToolManifest?
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ITokenManager.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/ITokenManager.kt
@@ -3,7 +3,7 @@ package io.github.leogallego.ansiblejane.data
 import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.model.InstanceInfo
 import io.github.leogallego.ansiblejane.model.McpServerConfig
-import io.github.leogallego.ansiblejane.network.ApiVersion
+import io.github.leogallego.ansiblejane.model.ApiVersion
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/data/TokenManager.kt
@@ -4,7 +4,7 @@ import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.model.InstanceInfo
 import io.github.leogallego.ansiblejane.model.McpServerConfig
-import io.github.leogallego.ansiblejane.network.ApiVersion
+import io.github.leogallego.ansiblejane.model.ApiVersion
 import io.github.leogallego.ansiblejane.platform.DataStoreFactory
 import io.github.leogallego.ansiblejane.platform.SecureKeyStorage
 import androidx.datastore.preferences.core.booleanPreferencesKey

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/di/NetworkModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/di/NetworkModule.kt
@@ -3,9 +3,9 @@ package io.github.leogallego.ansiblejane.di
 import io.github.leogallego.ansiblejane.network.ApiVersionDetector
 import io.github.leogallego.ansiblejane.network.HttpClientFactory
 import io.github.leogallego.ansiblejane.network.IAapApiProvider
+import io.github.leogallego.ansiblejane.network.IInstanceDiscovery
 import io.github.leogallego.ansiblejane.network.InstanceDiscovery
 import io.github.leogallego.ansiblejane.network.networkJson
-import io.ktor.client.plugins.logging.LogLevel
 import kotlinx.serialization.json.Json
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -22,5 +22,5 @@ val sharedNetworkModule = module {
 
     factory { ApiVersionDetector() }
 
-    single { InstanceDiscovery(get()) }
+    single { InstanceDiscovery(get()) } bind IInstanceDiscovery::class
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/di/NetworkModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/di/NetworkModule.kt
@@ -6,18 +6,21 @@ import io.github.leogallego.ansiblejane.network.IAapApiProvider
 import io.github.leogallego.ansiblejane.network.InstanceDiscovery
 import io.github.leogallego.ansiblejane.network.networkJson
 import io.ktor.client.plugins.logging.LogLevel
+import kotlinx.serialization.json.Json
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val sharedNetworkModule = module {
+    single<Json> { networkJson }
+
     single {
         HttpClientFactory(
             tokenManager = get(),
-            json = networkJson
+            json = get()
         )
     } bind IAapApiProvider::class
 
     factory { ApiVersionDetector() }
 
-    single { InstanceDiscovery(networkJson) }
+    single { InstanceDiscovery(get()) }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/ApiVersion.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/ApiVersion.kt
@@ -1,4 +1,4 @@
-package io.github.leogallego.ansiblejane.network
+package io.github.leogallego.ansiblejane.model
 
 enum class ApiVersion(val prefix: String) {
     CONTROLLER_V2("/api/controller/v2/"),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/McpTypes.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/McpTypes.kt
@@ -1,0 +1,30 @@
+package io.github.leogallego.ansiblejane.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+@Serializable
+data class McpToolDefinition(
+    val name: String,
+    val description: String = "",
+    val inputSchema: JsonObject = JsonObject(emptyMap())
+)
+
+@Serializable
+data class McpServerInfo(
+    val name: String,
+    val version: String
+)
+
+sealed interface McpConnectionState {
+    data object Disconnected : McpConnectionState
+    data object Connecting : McpConnectionState
+    data class Connected(
+        val serverInfo: McpServerInfo,
+        val toolCount: Int
+    ) : McpConnectionState
+    data class Error(
+        val message: String,
+        val cause: Throwable? = null
+    ) : McpConnectionState
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/PopularMcpServers.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/PopularMcpServers.kt
@@ -1,4 +1,4 @@
-package io.github.leogallego.ansiblejane.network.mcp
+package io.github.leogallego.ansiblejane.model
 
 data class PopularMcpServer(
     val name: String,

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/ToolManifest.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/model/ToolManifest.kt
@@ -1,7 +1,5 @@
 package io.github.leogallego.ansiblejane.model
 
-import io.github.leogallego.ansiblejane.network.mcp.McpServerInfo
-import io.github.leogallego.ansiblejane.network.mcp.McpToolDefinition
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/ApiVersionDetector.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/ApiVersionDetector.kt
@@ -1,5 +1,7 @@
 package io.github.leogallego.ansiblejane.network
 
+import io.github.leogallego.ansiblejane.model.ApiVersion
+
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/HttpClientFactory.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/HttpClientFactory.kt
@@ -1,5 +1,7 @@
 package io.github.leogallego.ansiblejane.network
 
+import io.github.leogallego.ansiblejane.model.ApiVersion
+
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.ktor.client.HttpClient

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/IInstanceDiscovery.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/IInstanceDiscovery.kt
@@ -1,0 +1,13 @@
+package io.github.leogallego.ansiblejane.network
+
+import io.github.leogallego.ansiblejane.model.ApiVersion
+import io.github.leogallego.ansiblejane.model.InstanceInfo
+
+interface IInstanceDiscovery {
+    suspend fun discover(
+        baseUrl: String,
+        token: String,
+        apiVersion: ApiVersion,
+        trustSelfSigned: Boolean = false
+    ): InstanceInfo
+}

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/InstanceDiscovery.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/InstanceDiscovery.kt
@@ -1,5 +1,7 @@
 package io.github.leogallego.ansiblejane.network
 
+import io.github.leogallego.ansiblejane.model.ApiVersion
+
 import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 import io.github.leogallego.ansiblejane.model.AapComponent
 import io.github.leogallego.ansiblejane.model.InstanceInfo

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/InstanceDiscovery.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/InstanceDiscovery.kt
@@ -25,17 +25,17 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
-class InstanceDiscovery(private val json: Json) {
+class InstanceDiscovery(private val json: Json) : IInstanceDiscovery {
 
     companion object {
         private const val TAG = "InstanceDiscovery"
     }
 
-    suspend fun discover(
+    override suspend fun discover(
         baseUrl: String,
         token: String,
         apiVersion: ApiVersion,
-        trustSelfSigned: Boolean = false
+        trustSelfSigned: Boolean
     ): InstanceInfo {
         val normalizedUrl = baseUrl.trimEnd('/')
         val client = createPlatformHttpClient(trustSelfSigned) {

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManager.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManager.kt
@@ -1,16 +1,24 @@
 package io.github.leogallego.ansiblejane.network.mcp
 
+import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
+import io.github.leogallego.ansiblejane.assistant.tools.ErrorType
 import io.github.leogallego.ansiblejane.assistant.tools.McpTool
+import io.github.leogallego.ansiblejane.assistant.tools.McpToolInvoker
 import io.github.leogallego.ansiblejane.assistant.tools.Tool
+import io.github.leogallego.ansiblejane.assistant.tools.ToolResult
+import io.github.leogallego.ansiblejane.data.IMcpConnectionRepository
 import io.github.leogallego.ansiblejane.model.AapInstance
+import io.github.leogallego.ansiblejane.model.McpConnectionState
 import io.github.leogallego.ansiblejane.model.McpServerConfig
+import io.github.leogallego.ansiblejane.model.McpServerInfo
+import io.github.leogallego.ansiblejane.model.McpToolDefinition
 import io.github.leogallego.ansiblejane.model.ServerToolCache
 import io.github.leogallego.ansiblejane.model.ToolManifest
-import io.github.leogallego.ansiblejane.assistant.engine.DebugLog as Log
 import io.ktor.client.HttpClient
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.client.StreamableHttpClientTransport
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import kotlin.concurrent.Volatile
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
@@ -23,6 +31,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.JsonObject
 
 private data class SdkClientState(
     val client: Client,
@@ -33,19 +42,19 @@ private data class SdkClientState(
 
 class McpServerManager(
     private val ktorClientFactory: (AapInstance, McpServerConfig) -> HttpClient
-) : SynchronizedObject() {
+) : SynchronizedObject(), IMcpConnectionRepository, McpToolInvoker {
     private val _connections = MutableStateFlow<Map<String, McpConnectionState>>(emptyMap())
-    val connections: StateFlow<Map<String, McpConnectionState>> = _connections.asStateFlow()
+    override val connections: StateFlow<Map<String, McpConnectionState>> = _connections.asStateFlow()
 
     private val _mcpTools = MutableStateFlow<List<Tool>>(emptyList())
-    val mcpTools: StateFlow<List<Tool>> = _mcpTools.asStateFlow()
+    override val mcpTools: StateFlow<List<Tool>> = _mcpTools.asStateFlow()
 
     private val clients = mutableMapOf<String, SdkClientState>()
     private val connectionMutexes = mutableMapOf<String, Mutex>()
     @Volatile
     private var currentInstance: AapInstance? = null
 
-    suspend fun connectAll(instance: AapInstance) {
+    override suspend fun connectAll(instance: AapInstance) {
         currentInstance = instance
         disconnectAll()
 
@@ -86,7 +95,7 @@ class McpServerManager(
         }
     }
 
-    suspend fun disconnectAll() {
+    override suspend fun disconnectAll() {
         val states = synchronized(this) {
             val s = clients.values.toList()
             clients.clear()
@@ -105,7 +114,7 @@ class McpServerManager(
     fun getToolsForServer(label: String): List<Tool> =
         _mcpTools.value.filter { it.serverLabel == label }
 
-    fun setCachedTools(tools: List<Tool>) {
+    override fun setCachedTools(tools: List<Tool>) {
         _mcpTools.value = tools
     }
 
@@ -141,10 +150,38 @@ class McpServerManager(
         }
     }
 
-    suspend fun connectAllWithCache(
+
+    override suspend fun invokeMcpTool(
+        serverLabel: String,
+        toolName: String,
+        args: JsonObject
+    ): ToolResult {
+        return try {
+            val client = ensureConnected(serverLabel)
+            val result = client.callTool(toolName, args)
+            val text = result.content
+                .filterIsInstance<TextContent>()
+                .joinToString("\n") { it.text }
+            if (result.isError == true) {
+                ToolResult(success = false, data = text, errorType = ErrorType.SERVER_ERROR)
+            } else {
+                ToolResult(success = true, data = text)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            ToolResult(
+                success = false,
+                data = "Connection error: ${e.message}",
+                errorType = ErrorType.CONNECTION_ERROR
+            )
+        }
+    }
+
+    override suspend fun connectAllWithCache(
         instance: AapInstance,
-        manifest: ToolManifest? = null,
-        forceRefresh: Boolean = false
+        manifest: ToolManifest?,
+        forceRefresh: Boolean
     ) {
         currentInstance = instance
 
@@ -239,7 +276,7 @@ class McpServerManager(
         }
     }
 
-    suspend fun reconnectServer(label: String) {
+    override suspend fun reconnectServer(label: String) {
         val instance = currentInstance ?: return
         val config = instance.mcpServerUrls?.find { it.label == label } ?: return
 
@@ -257,7 +294,7 @@ class McpServerManager(
         connectServer(config, ktorClient)
     }
 
-    fun refreshConnections() {
+    override fun refreshConnections() {
         synchronized(this) { clients.toMap() }.forEach { (label, state) ->
             _connections.update {
                 it + (label to McpConnectionState.Connected(
@@ -268,7 +305,7 @@ class McpServerManager(
         }
     }
 
-    fun buildManifest(instance: AapInstance): ToolManifest? {
+    override fun buildManifest(instance: AapInstance): ToolManifest? {
         val allTools = _mcpTools.value
         if (allTools.isEmpty()) return null
 

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManager.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManager.kt
@@ -118,7 +118,7 @@ class McpServerManager(
         _mcpTools.value = tools
     }
 
-    suspend fun ensureConnected(serverLabel: String): Client {
+    internal suspend fun ensureConnected(serverLabel: String): Client {
         synchronized(this) { clients[serverLabel] }?.let { return it.client }
 
         val mutex = synchronized(this) { connectionMutexes.getOrPut(serverLabel) { Mutex() } }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpTypes.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpTypes.kt
@@ -1,37 +1,10 @@
 package io.github.leogallego.ansiblejane.network.mcp
 
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
-
-@Serializable
-data class McpToolDefinition(
-    val name: String,
-    val description: String = "",
-    val inputSchema: JsonObject = JsonObject(emptyMap())
-)
-
-@Serializable
-data class McpServerInfo(
-    val name: String,
-    val version: String
-)
-
-sealed interface McpConnectionState {
-    data object Disconnected : McpConnectionState
-    data object Connecting : McpConnectionState
-    data class Connected(
-        val serverInfo: McpServerInfo,
-        val toolCount: Int
-    ) : McpConnectionState
-    data class Error(
-        val message: String,
-        val cause: Throwable? = null
-    ) : McpConnectionState
-}
 
 class McpConnectionException(message: String, cause: Throwable? = null) :
     Exception(message, cause)

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/data/ModelFetcherTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/data/ModelFetcherTest.kt
@@ -43,10 +43,11 @@ class ModelFetcherTest {
                 headers = headersOf(HttpHeaders.ContentType, "application/json")
             )
         }
-        val client = HttpClient(engine) {
-            expectSuccess = false
+        return ModelFetcher(json) { _ ->
+            HttpClient(engine) {
+                expectSuccess = false
+            }
         }
-        return ModelFetcher(client, json)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/network/ApiVersionTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/network/ApiVersionTest.kt
@@ -1,5 +1,7 @@
 package io.github.leogallego.ansiblejane.network
 
+import io.github.leogallego.ansiblejane.model.ApiVersion
+
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/shared/src/jvmTest/kotlin/io/github/leogallego/ansiblejane/assistant/tools/CachedMcpToolTest.kt
+++ b/shared/src/jvmTest/kotlin/io/github/leogallego/ansiblejane/assistant/tools/CachedMcpToolTest.kt
@@ -3,7 +3,7 @@ package io.github.leogallego.ansiblejane.assistant.tools
 import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.model.McpServerConfig
 import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
-import io.github.leogallego.ansiblejane.network.mcp.McpToolDefinition
+import io.github.leogallego.ansiblejane.model.McpToolDefinition
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.sse.SSE
@@ -105,7 +105,7 @@ class CachedMcpToolTest {
         val tool = CachedMcpTool(
             mcpToolDef = McpToolDefinition("ping", "Ping"),
             serverLabel = "test-server",
-            serverManager = manager
+            toolInvoker = manager
         )
 
         val result = tool.execute(JsonObject(emptyMap()))
@@ -118,7 +118,7 @@ class CachedMcpToolTest {
         val tool = CachedMcpTool(
             mcpToolDef = McpToolDefinition("ping", "Ping"),
             serverLabel = "nonexistent-server",
-            serverManager = manager
+            toolInvoker = manager
         )
 
         val result = tool.execute(JsonObject(emptyMap()))
@@ -147,7 +147,7 @@ class CachedMcpToolTest {
         val tool = CachedMcpTool(
             mcpToolDef = McpToolDefinition("ping", "Ping"),
             serverLabel = "test-server",
-            serverManager = manager
+            toolInvoker = manager
         )
 
         val result = tool.execute(JsonObject(emptyMap()))
@@ -161,7 +161,7 @@ class CachedMcpToolTest {
         val tool = CachedMcpTool(
             mcpToolDef = McpToolDefinition("ping", "Ping the server"),
             serverLabel = "my-mcp",
-            serverManager = manager
+            toolInvoker = manager
         )
 
         assertTrue(tool.spec.description.startsWith("[my-mcp]"))
@@ -173,14 +173,14 @@ class CachedMcpToolTest {
         val create = CachedMcpTool(
             mcpToolDef = McpToolDefinition("hosts_create", "Create host"),
             serverLabel = "s",
-            serverManager = manager
+            toolInvoker = manager
         )
         assertTrue(create.isDestructive)
 
         val read = CachedMcpTool(
             mcpToolDef = McpToolDefinition("hosts_read", "List hosts"),
             serverLabel = "s",
-            serverManager = manager
+            toolInvoker = manager
         )
         assertFalse(read.isDestructive)
     }
@@ -203,7 +203,7 @@ class CachedMcpToolTest {
         val tool = CachedMcpTool(
             mcpToolDef = McpToolDefinition("ping", "Ping"),
             serverLabel = "test-server",
-            serverManager = manager
+            toolInvoker = manager
         )
 
         val args = buildJsonObject {

--- a/shared/src/jvmTest/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpSdkSpikeTest.kt
+++ b/shared/src/jvmTest/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpSdkSpikeTest.kt
@@ -1,5 +1,8 @@
 package io.github.leogallego.ansiblejane.network.mcp
 
+import io.github.leogallego.ansiblejane.model.McpServerInfo
+import io.github.leogallego.ansiblejane.model.McpToolDefinition
+import io.github.leogallego.ansiblejane.network.createPlatformHttpClient
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.sse.SSE
@@ -8,7 +11,6 @@ import io.modelcontextprotocol.kotlin.sdk.client.StreamableHttpClientTransport
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
-import io.github.leogallego.ansiblejane.network.createPlatformHttpClient
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject

--- a/shared/src/jvmTest/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManagerTest.kt
+++ b/shared/src/jvmTest/kotlin/io/github/leogallego/ansiblejane/network/mcp/McpServerManagerTest.kt
@@ -1,5 +1,8 @@
 package io.github.leogallego.ansiblejane.network.mcp
 
+import io.github.leogallego.ansiblejane.model.McpConnectionState
+import io.github.leogallego.ansiblejane.model.McpServerInfo
+import io.github.leogallego.ansiblejane.model.McpToolDefinition
 import io.github.leogallego.ansiblejane.assistant.tools.McpTool
 import io.github.leogallego.ansiblejane.model.AapInstance
 import io.github.leogallego.ansiblejane.model.McpServerConfig


### PR DESCRIPTION
## Summary
- Clear Presentation→Network and UI→Network layer skips from Session 2 (#448): ViewModels/UI no longer import `network`.
- Move UI-facing types to `model/` (`ApiVersion`, `McpConnectionState`/`McpServerInfo`/`McpToolDefinition`, `popularMcpServers`).
- Route Dashboard EDA stats through `IEdaActivationRepository`; MCP lifecycle through `IMcpConnectionRepository` (+ `McpToolInvoker` for cached tools); Settings instance eviction/discovery/edits through `IAuthRepository`; unauthorized nav via `IAuthRepository.unauthorizedEvent`.
- `ModelFetcher` remains the only documented Settings exception and now owns `createPlatformHttpClient` (ViewModels never build HTTP clients).

## What moved where
| Before | After |
|--------|-------|
| `network.ApiVersion` | `model.ApiVersion` |
| `network.mcp.McpConnectionState` (+ info/tool def) | `model.McpTypes` |
| `network.mcp.popularMcpServers` | `model.PopularMcpServers` |
| Dashboard `IAapApiProvider.getEdaApiService()` | `IEdaActivationRepository` |
| Assistant/Settings `McpServerManager` | `IMcpConnectionRepository` (manager implements + Koin `binds`) |
| Cached tool `ensureConnected(Client)` in VM path | `McpToolInvoker.invokeMcpTool` (no SDK type in presentation) |
| Settings `createPlatformHttpClient` / discovery / evict | `ModelFetcher` / `IAuthRepository` |
| `AppNavigation` → `AuthEvents` | `IAuthRepository.unauthorizedEvent` |
| `PresentationModule` → `networkJson` | Koin `single<Json>` in `sharedNetworkModule` |

## Documented exceptions remaining
- **Only** `SettingsViewModel` → `ModelFetcher` (contracts §1), and ModelFetcher owns client lifecycle.

## Grep proof (composeApp presentation / UI / assistant UI / navigation)
```
rg -n "import .*network" composeApp/.../presentation composeApp/.../ui \
  composeApp/.../assistant/ui composeApp/.../assistant/presentation \
  composeApp/.../navigation
→ (none)

rg -n "createPlatformHttpClient" composeApp
→ (none)
```

## Test plan
- [x] `:shared:compileKotlinJvm` + `:composeApp:compileKotlinDesktop`
- [x] `ModelFetcherTest`, `ApiVersionTest`, `CachedMcpToolTest`
- [x] `SettingsViewModelTest`, `AssistantViewModelTest`, `DashboardViewModelTest`, `AuthViewModelTest`
- [ ] Optional spot-check: Settings Tools MCP refresh + instance edit/remove; Assistant with cached MCP tools; 401 → reauth nav

Closes #448

Assisted-by: Cursor (Grok 4.5)