### PR TITLE
chore: bump version to v0.9.0-alpha.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.experimental.enableScreenshotTest=true
 kotlin.native.ignoreDisabledTargets=true
-appVersionName=0.8.7-alpha.1
-appVersionCode=26080601
+appVersionName=0.9.0-alpha.0
+appVersionCode=26080800


### PR DESCRIPTION
## Summary
- Bump `appVersionName` to `0.9.0-alpha.0` and `appVersionCode` to `26080800`
- Triggers auto-tag + signed APK release for phone testing from current `main`

## Test plan
- [ ] Auto-tag creates `v0.9.0-alpha.0` after merge
- [ ] Release workflow builds signed APK
- [ ] Install APK on phone over previous alpha

Assisted-by: Cursor (Grok 4.5)