### PR TITLE
fix(assistant): LiteRT download timeouts, resume, import UI (#469)

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.android.kt
@@ -1,0 +1,61 @@
+package io.github.leogallego.ansiblejane.ui.settings
+
+import android.content.Context
+import android.net.Uri
+import android.os.Environment
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import java.io.File
+import java.io.FileOutputStream
+
+@Composable
+actual fun rememberLocalModelImportLauncher(
+    onPickedAbsolutePath: (absolutePath: String) -> Unit,
+): () -> Unit {
+    val context = LocalContext.current
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri: Uri? ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        val path = copyUriToCache(context, uri) ?: return@rememberLauncherForActivityResult
+        onPickedAbsolutePath(path)
+    }
+    return remember(launcher) {
+        {
+            launcher.launch(
+                arrayOf(
+                    "application/octet-stream",
+                    "*/*",
+                ),
+            )
+        }
+    }
+}
+
+actual fun findCatalogModelInDownloads(fileName: String): String? {
+    val downloads = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+    val candidate = File(downloads, fileName)
+    return if (candidate.isFile && candidate.canRead() && candidate.length() > 0L) {
+        candidate.absolutePath
+    } else {
+        null
+    }
+}
+
+private fun copyUriToCache(context: Context, uri: Uri): String? {
+    return try {
+        val cacheDir = File(context.cacheDir, "litert_import").apply { mkdirs() }
+        val target = File(cacheDir, "import-${System.currentTimeMillis()}.litertlm")
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            FileOutputStream(target).use { output ->
+                input.copyTo(output, bufferSize = 64 * 1024)
+            }
+        } ?: return null
+        target.absolutePath
+    } catch (_: Exception) {
+        null
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.android.kt
@@ -7,30 +7,69 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import java.io.File
 import java.io.FileOutputStream
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
-actual fun rememberLocalModelImportLauncher(
-    onPickedAbsolutePath: (absolutePath: String) -> Unit,
-): () -> Unit {
+actual fun rememberLocalModelImportController(
+    onPreparing: () -> Unit,
+    onResult: (LocalModelImportPick) -> Unit,
+): LocalModelImportController {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val state = remember { PrepareState() }
+
     val launcher = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenDocument()
     ) { uri: Uri? ->
-        if (uri == null) return@rememberLauncherForActivityResult
-        val path = copyUriToCache(context, uri) ?: return@rememberLauncherForActivityResult
-        onPickedAbsolutePath(path)
+        if (uri == null) {
+            onResult(LocalModelImportPick.Cancelled)
+            return@rememberLauncherForActivityResult
+        }
+        state.job?.cancel()
+        onPreparing()
+        state.job = scope.launch {
+            try {
+                val path = withContext(Dispatchers.IO) {
+                    copyUriToCacheCancellable(context, uri)
+                }
+                if (path != null) {
+                    onResult(LocalModelImportPick.Success(path))
+                } else {
+                    onResult(LocalModelImportPick.Failure)
+                }
+            } catch (_: CancellationException) {
+                onResult(LocalModelImportPick.Cancelled)
+            } finally {
+                state.job = null
+            }
+        }
     }
-    return remember(launcher) {
-        {
-            launcher.launch(
-                arrayOf(
-                    "application/octet-stream",
-                    "*/*",
-                ),
-            )
+
+    return remember(launcher, onPreparing, onResult) {
+        object : LocalModelImportController {
+            override fun launch() {
+                launcher.launch(
+                    arrayOf(
+                        "application/octet-stream",
+                        "*/*",
+                    ),
+                )
+            }
+
+            override fun cancelPrepare() {
+                state.job?.cancel()
+                state.job = null
+            }
         }
     }
 }
@@ -45,17 +84,36 @@ actual fun findCatalogModelInDownloads(fileName: String): String? {
     }
 }
 
-private fun copyUriToCache(context: Context, uri: Uri): String? {
+private class PrepareState {
+    var job: Job? = null
+}
+
+private suspend fun copyUriToCacheCancellable(context: Context, uri: Uri): String? {
+    val cacheDir = File(context.cacheDir, "litert_import").apply { mkdirs() }
+    val target = File(cacheDir, "import-${System.currentTimeMillis()}.litertlm")
     return try {
-        val cacheDir = File(context.cacheDir, "litert_import").apply { mkdirs() }
-        val target = File(cacheDir, "import-${System.currentTimeMillis()}.litertlm")
         context.contentResolver.openInputStream(uri)?.use { input ->
             FileOutputStream(target).use { output ->
-                input.copyTo(output, bufferSize = 64 * 1024)
+                val buffer = ByteArray(64 * 1024)
+                while (true) {
+                    currentCoroutineContext().ensureActive()
+                    val read = input.read(buffer)
+                    if (read < 0) break
+                    if (read == 0) continue
+                    output.write(buffer, 0, read)
+                }
             }
         } ?: return null
+        if (!target.isFile || target.length() <= 0L) {
+            target.delete()
+            return null
+        }
         target.absolutePath
+    } catch (e: CancellationException) {
+        target.delete()
+        throw e
     } catch (_: Exception) {
+        target.delete()
         null
     }
 }

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -368,7 +368,8 @@
     <string name="agent_local_size_gb">%1$s GB</string>
     <string name="agent_local_import">Import file</string>
     <string name="agent_local_use_existing">Use existing file</string>
-    <string name="agent_local_importing">Importing…</string>
+    <string name="agent_local_importing">Importing… %1$s</string>
+    <string name="agent_local_import_failed">Could not read the selected model file.</string>
 
     <!-- ToolsTab.kt -->
     <string name="tools_section_mcp_servers">MCP Servers</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -361,9 +361,14 @@
     <string name="agent_local_disk_insufficient">Not enough free disk space to download this model.</string>
     <string name="agent_local_hash_mismatch">Downloaded file failed integrity check. Delete and try again.</string>
     <string name="agent_local_download_failed">Download failed. Try again.</string>
+    <string name="agent_local_download_timeout">Download timed out. Tap Download to resume.</string>
+    <string name="agent_local_download_network">Network error during download. Tap Download to resume.</string>
     <string name="agent_local_loading_model">Loading model…</string>
-    <string name="agent_local_download_progress">Downloading… %1$d%%</string>
-    <string name="agent_local_size_gb">%1$.1f GB</string>
+    <string name="agent_local_download_progress">Downloading… %1$s</string>
+    <string name="agent_local_size_gb">%1$s GB</string>
+    <string name="agent_local_import">Import file</string>
+    <string name="agent_local_use_existing">Use existing file</string>
+    <string name="agent_local_importing">Importing…</string>
 
     <!-- ToolsTab.kt -->
     <string name="tools_section_mcp_servers">MCP Servers</string>

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUi.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUi.kt
@@ -3,17 +3,21 @@ package io.github.leogallego.ansiblejane.presentation.settings
 import aapremotecontrol.composeapp.generated.resources.Res
 import aapremotecontrol.composeapp.generated.resources.agent_local_disk_insufficient
 import aapremotecontrol.composeapp.generated.resources.agent_local_download_failed
+import aapremotecontrol.composeapp.generated.resources.agent_local_download_network
+import aapremotecontrol.composeapp.generated.resources.agent_local_download_timeout
 import aapremotecontrol.composeapp.generated.resources.agent_local_hash_mismatch
 import io.github.leogallego.ansiblejane.assistant.local.DevicePerformance
 import io.github.leogallego.ansiblejane.assistant.local.LocalModel
 import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadErrorKind
 import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadState
 import org.jetbrains.compose.resources.StringResource
+import kotlin.math.round
 
 /** Presentation-layer catalog row for on-device models (UI must not import repository types). */
 data class LocalModelUi(
     val id: String,
     val displayName: String,
+    val fileName: String,
     val sizeBytes: Long,
     val isRecommended: Boolean,
 )
@@ -44,6 +48,7 @@ sealed interface LocalModelDownloadUiState {
 fun LocalModel.toUi(): LocalModelUi = LocalModelUi(
     id = id,
     displayName = displayName,
+    fileName = fileName,
     sizeBytes = sizeBytes,
     isRecommended = isRecommended,
 )
@@ -71,7 +76,14 @@ fun LocalModelDownloadState.toUi(): LocalModelDownloadUiState = when (this) {
 fun LocalModelDownloadErrorKind.toUiMessage(): StringResource = when (this) {
     LocalModelDownloadErrorKind.DISK -> Res.string.agent_local_disk_insufficient
     LocalModelDownloadErrorKind.HASH -> Res.string.agent_local_hash_mismatch
-    LocalModelDownloadErrorKind.NETWORK,
-    LocalModelDownloadErrorKind.OTHER,
-    -> Res.string.agent_local_download_failed
+    LocalModelDownloadErrorKind.TIMEOUT -> Res.string.agent_local_download_timeout
+    LocalModelDownloadErrorKind.NETWORK -> Res.string.agent_local_download_network
+    LocalModelDownloadErrorKind.OTHER -> Res.string.agent_local_download_failed
+}
+
+/** CMP-safe size label (composeResources does not support `%1$.1f`). */
+fun formatLocalModelSizeGb(sizeBytes: Long): String {
+    val gb = sizeBytes.toDouble() / (1024.0 * 1024.0 * 1024.0)
+    val tenths = round(gb * 10.0).toInt().coerceAtLeast(0)
+    return "${tenths / 10}.${tenths % 10}"
 }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUi.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUi.kt
@@ -6,6 +6,7 @@ import aapremotecontrol.composeapp.generated.resources.agent_local_download_fail
 import aapremotecontrol.composeapp.generated.resources.agent_local_download_network
 import aapremotecontrol.composeapp.generated.resources.agent_local_download_timeout
 import aapremotecontrol.composeapp.generated.resources.agent_local_hash_mismatch
+import aapremotecontrol.composeapp.generated.resources.agent_local_import_failed
 import io.github.leogallego.ansiblejane.assistant.local.DevicePerformance
 import io.github.leogallego.ansiblejane.assistant.local.LocalModel
 import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadErrorKind
@@ -35,6 +36,7 @@ sealed interface LocalModelDownloadUiState {
         val modelId: String,
         val bytesReceived: Long,
         val totalBytes: Long,
+        val isImport: Boolean = false,
     ) : LocalModelDownloadUiState
 
     data class Succeeded(val modelId: String) : LocalModelDownloadUiState
@@ -65,6 +67,7 @@ fun LocalModelDownloadState.toUi(): LocalModelDownloadUiState = when (this) {
         modelId = modelId,
         bytesReceived = bytesReceived,
         totalBytes = totalBytes,
+        isImport = isImport,
     )
     is LocalModelDownloadState.Succeeded -> LocalModelDownloadUiState.Succeeded(modelId)
     is LocalModelDownloadState.Error -> LocalModelDownloadUiState.Error(
@@ -78,6 +81,7 @@ fun LocalModelDownloadErrorKind.toUiMessage(): StringResource = when (this) {
     LocalModelDownloadErrorKind.HASH -> Res.string.agent_local_hash_mismatch
     LocalModelDownloadErrorKind.TIMEOUT -> Res.string.agent_local_download_timeout
     LocalModelDownloadErrorKind.NETWORK -> Res.string.agent_local_download_network
+    LocalModelDownloadErrorKind.IMPORT -> Res.string.agent_local_import_failed
     LocalModelDownloadErrorKind.OTHER -> Res.string.agent_local_download_failed
 }
 

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -372,6 +372,13 @@ class SettingsViewModel(
         localModelRepository.cancelDownload()
     }
 
+    fun importLocalModel(modelId: String, absolutePath: String) {
+        viewModelScope.launch {
+            localModelRepository.importFromPath(modelId, absolutePath)
+            refreshLocalReadyIds()
+        }
+    }
+
     fun deleteLocalModel(modelId: String) {
         viewModelScope.launch {
             localModelRepository.delete(modelId)

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import io.github.leogallego.ansiblejane.assistant.data.KnownProvider
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.assistant.data.ModelFetcher
 import io.github.leogallego.ansiblejane.assistant.local.ILocalModelRepository
+import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadErrorKind
 import io.github.leogallego.ansiblejane.assistant.presentation.ModelFetchState
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.data.IToolManifestRepository
@@ -377,6 +378,14 @@ class SettingsViewModel(
             localModelRepository.importFromPath(modelId, absolutePath)
             refreshLocalReadyIds()
         }
+    }
+
+    fun markLocalModelImportPreparing(modelId: String) {
+        localModelRepository.markImportPreparing(modelId)
+    }
+
+    fun reportLocalModelImportPickFailed(modelId: String) {
+        localModelRepository.notifyTransferError(modelId, LocalModelDownloadErrorKind.IMPORT)
     }
 
     fun deleteLocalModel(modelId: String) {

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/AgentTab.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/AgentTab.kt
@@ -62,6 +62,8 @@ fun AgentTab(
     onDeleteLocalModel: (String) -> Unit = {},
     onSelectLocalModel: (String) -> Unit = {},
     onImportLocalModel: (modelId: String, absolutePath: String) -> Unit = { _, _ -> },
+    onImportLocalModelPreparing: (modelId: String) -> Unit = {},
+    onImportLocalModelPickFailed: (modelId: String) -> Unit = {},
     onClearHistory: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -122,6 +124,8 @@ fun AgentTab(
                         onSelectLocalModel(modelId)
                     },
                     onImportFromPath = onImportLocalModel,
+                    onImportPreparing = onImportLocalModelPreparing,
+                    onImportPickFailed = onImportLocalModelPickFailed,
                 )
             } else {
                 val providerConfig = savedConfigs[provider.name] as? LlmProviderConfig.OpenAiCompatible

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/AgentTab.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/AgentTab.kt
@@ -61,6 +61,7 @@ fun AgentTab(
     onCancelLocalModelDownload: () -> Unit = {},
     onDeleteLocalModel: (String) -> Unit = {},
     onSelectLocalModel: (String) -> Unit = {},
+    onImportLocalModel: (modelId: String, absolutePath: String) -> Unit = { _, _ -> },
     onClearHistory: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -119,7 +120,8 @@ fun AgentTab(
                     onSelect = { modelId ->
                         expandedProvider = null
                         onSelectLocalModel(modelId)
-                    }
+                    },
+                    onImportFromPath = onImportLocalModel,
                 )
             } else {
                 val providerConfig = savedConfigs[provider.name] as? LlmProviderConfig.OpenAiCompatible

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.kt
@@ -1,0 +1,19 @@
+package io.github.leogallego.ansiblejane.ui.settings
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Platform file picker for `.litertlm` import (#469).
+ * Invoking the returned lambda launches the picker; [onPickedAbsolutePath] receives a
+ * filesystem path Jane can stream-copy (Android may copy the SAF Uri into cache first).
+ */
+@Composable
+expect fun rememberLocalModelImportLauncher(
+    onPickedAbsolutePath: (absolutePath: String) -> Unit,
+): () -> Unit
+
+/**
+ * Best-effort lookup of a catalog filename under the user Downloads folder.
+ * Returns an absolute path when readable; null when missing or inaccessible.
+ */
+expect fun findCatalogModelInDownloads(fileName: String): String?

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.kt
@@ -2,18 +2,32 @@ package io.github.leogallego.ansiblejane.ui.settings
 
 import androidx.compose.runtime.Composable
 
+/** Result of a platform `.litertlm` file pick (#469). */
+sealed interface LocalModelImportPick {
+    data class Success(val absolutePath: String) : LocalModelImportPick
+    data object Failure : LocalModelImportPick
+    data object Cancelled : LocalModelImportPick
+}
+
+/** Launches a pick/prepare flow and can cancel an in-flight SAF/cache copy. */
+interface LocalModelImportController {
+    fun launch()
+    fun cancelPrepare()
+}
+
 /**
- * Platform file picker for `.litertlm` import (#469).
- * Invoking the returned lambda launches the picker; [onPickedAbsolutePath] receives a
- * filesystem path Jane can stream-copy (Android may copy the SAF Uri into cache first).
+ * Platform file picker for `.litertlm` import.
+ * [onPreparing] fires before any multi-GB copy so the UI can show Importing + Cancel.
+ * Heavy copy work must run off the main thread and be abortable via [LocalModelImportController.cancelPrepare].
  */
 @Composable
-expect fun rememberLocalModelImportLauncher(
-    onPickedAbsolutePath: (absolutePath: String) -> Unit,
-): () -> Unit
+expect fun rememberLocalModelImportController(
+    onPreparing: () -> Unit,
+    onResult: (LocalModelImportPick) -> Unit,
+): LocalModelImportController
 
 /**
  * Best-effort lookup of a catalog filename under the user Downloads folder.
- * Returns an absolute path when readable; null when missing or inaccessible.
+ * Call from a background dispatcher — may touch the filesystem.
  */
 expect fun findCatalogModelInDownloads(fileName: String): String?

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/OnDeviceProviderCard.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/OnDeviceProviderCard.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -44,6 +45,7 @@ import aapremotecontrol.composeapp.generated.resources.agent_local_cancel
 import aapremotecontrol.composeapp.generated.resources.agent_local_delete
 import aapremotecontrol.composeapp.generated.resources.agent_local_download
 import aapremotecontrol.composeapp.generated.resources.agent_local_download_progress
+import aapremotecontrol.composeapp.generated.resources.agent_local_import
 import aapremotecontrol.composeapp.generated.resources.agent_local_not_downloaded
 import aapremotecontrol.composeapp.generated.resources.agent_local_performance_good
 import aapremotecontrol.composeapp.generated.resources.agent_local_performance_ok
@@ -52,6 +54,7 @@ import aapremotecontrol.composeapp.generated.resources.agent_local_ready
 import aapremotecontrol.composeapp.generated.resources.agent_local_recommended
 import aapremotecontrol.composeapp.generated.resources.agent_local_size_gb
 import aapremotecontrol.composeapp.generated.resources.agent_local_title
+import aapremotecontrol.composeapp.generated.resources.agent_local_use_existing
 import aapremotecontrol.composeapp.generated.resources.agent_not_configured
 import aapremotecontrol.composeapp.generated.resources.cd_collapse
 import aapremotecontrol.composeapp.generated.resources.cd_expand
@@ -60,6 +63,7 @@ import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.presentation.settings.DevicePerformanceUi
 import io.github.leogallego.ansiblejane.presentation.settings.LocalModelDownloadUiState
 import io.github.leogallego.ansiblejane.presentation.settings.LocalModelUi
+import io.github.leogallego.ansiblejane.presentation.settings.formatLocalModelSizeGb
 import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
 import org.jetbrains.compose.resources.stringResource
 
@@ -79,6 +83,7 @@ internal fun LocalProviderCard(
     onCancelDownload: () -> Unit,
     onDelete: (String) -> Unit,
     onSelect: (String) -> Unit,
+    onImportFromPath: (modelId: String, absolutePath: String) -> Unit,
 ) {
     val border = if (isActive) {
         BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
@@ -177,6 +182,7 @@ internal fun LocalProviderCard(
                             onCancelDownload = onCancelDownload,
                             onDelete = { onDelete(model.id) },
                             onSelect = { onSelect(model.id) },
+                            onImportFromPath = { path -> onImportFromPath(model.id, path) },
                         )
                     }
                 }
@@ -197,11 +203,17 @@ internal fun LocalModelRow(
     onCancelDownload: () -> Unit,
     onDelete: () -> Unit,
     onSelect: () -> Unit,
+    onImportFromPath: (absolutePath: String) -> Unit,
 ) {
     val downloading = downloadState as? LocalModelDownloadUiState.Downloading
     val isDownloadingThis = downloading?.modelId == model.id
     val error = downloadState as? LocalModelDownloadUiState.Error
     val errorForThis = error?.takeIf { it.modelId == model.id }
+    val existingPath = remember(model.fileName, isReady) {
+        if (isReady) null else findCatalogModelInDownloads(model.fileName)
+    }
+    val launchImport = rememberLocalModelImportLauncher(onPickedAbsolutePath = onImportFromPath)
+    val sizeLabel = remember(model.sizeBytes) { formatLocalModelSizeGb(model.sizeBytes) }
 
     Column(
         modifier = Modifier
@@ -238,12 +250,10 @@ internal fun LocalModelRow(
                     }
                 }
                 Text(
-                    text = stringResource(
-                        Res.string.agent_local_size_gb,
-                        model.sizeBytes / (1024.0 * 1024.0 * 1024.0)
-                    ),
+                    text = stringResource(Res.string.agent_local_size_gb, sizeLabel),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("text_local_size_${model.id}")
                 )
                 Text(
                     text = when (performance) {
@@ -274,7 +284,7 @@ internal fun LocalModelRow(
             }
         }
 
-        if (isDownloadingThis && downloading != null) {
+        if (downloading != null && downloading.modelId == model.id) {
             val progress = if (downloading.totalBytes > 0) {
                 (downloading.bytesReceived.toFloat() / downloading.totalBytes.toFloat())
                     .coerceIn(0f, 1f)
@@ -283,9 +293,10 @@ internal fun LocalModelRow(
             }
             val percent = (progress * 100).toInt()
             Text(
-                text = stringResource(Res.string.agent_local_download_progress, percent),
+                text = stringResource(Res.string.agent_local_download_progress, "$percent%"),
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.testTag("text_local_progress_${model.id}")
             )
             LinearProgressIndicator(
                 progress = { progress },
@@ -345,17 +356,32 @@ internal fun LocalModelRow(
                     }
                 }
                 else -> {
+                    val busy = downloadState is LocalModelDownloadUiState.Downloading
                     Button(
                         onClick = onDownload,
-                        enabled = actionsEnabled &&
-                            downloadState !is LocalModelDownloadUiState.Downloading,
+                        enabled = actionsEnabled && !busy,
                         modifier = Modifier.testTag("button_local_download_${model.id}")
                     ) {
                         Text(stringResource(Res.string.agent_local_download))
+                    }
+                    OutlinedButton(
+                        onClick = launchImport,
+                        enabled = actionsEnabled && !busy,
+                        modifier = Modifier.testTag("button_local_import_${model.id}")
+                    ) {
+                        Text(stringResource(Res.string.agent_local_import))
+                    }
+                    if (existingPath != null) {
+                        OutlinedButton(
+                            onClick = { onImportFromPath(existingPath) },
+                            enabled = actionsEnabled && !busy,
+                            modifier = Modifier.testTag("button_local_use_existing_${model.id}")
+                        ) {
+                            Text(stringResource(Res.string.agent_local_use_existing))
+                        }
                     }
                 }
             }
         }
     }
 }
-

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/OnDeviceProviderCard.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/OnDeviceProviderCard.kt
@@ -30,7 +30,11 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -46,6 +50,7 @@ import aapremotecontrol.composeapp.generated.resources.agent_local_delete
 import aapremotecontrol.composeapp.generated.resources.agent_local_download
 import aapremotecontrol.composeapp.generated.resources.agent_local_download_progress
 import aapremotecontrol.composeapp.generated.resources.agent_local_import
+import aapremotecontrol.composeapp.generated.resources.agent_local_importing
 import aapremotecontrol.composeapp.generated.resources.agent_local_not_downloaded
 import aapremotecontrol.composeapp.generated.resources.agent_local_performance_good
 import aapremotecontrol.composeapp.generated.resources.agent_local_performance_ok
@@ -65,6 +70,8 @@ import io.github.leogallego.ansiblejane.presentation.settings.LocalModelDownload
 import io.github.leogallego.ansiblejane.presentation.settings.LocalModelUi
 import io.github.leogallego.ansiblejane.presentation.settings.formatLocalModelSizeGb
 import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -84,6 +91,8 @@ internal fun LocalProviderCard(
     onDelete: (String) -> Unit,
     onSelect: (String) -> Unit,
     onImportFromPath: (modelId: String, absolutePath: String) -> Unit,
+    onImportPreparing: (modelId: String) -> Unit,
+    onImportPickFailed: (modelId: String) -> Unit,
 ) {
     val border = if (isActive) {
         BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
@@ -183,6 +192,8 @@ internal fun LocalProviderCard(
                             onDelete = { onDelete(model.id) },
                             onSelect = { onSelect(model.id) },
                             onImportFromPath = { path -> onImportFromPath(model.id, path) },
+                            onImportPreparing = { onImportPreparing(model.id) },
+                            onImportPickFailed = { onImportPickFailed(model.id) },
                         )
                     }
                 }
@@ -204,15 +215,33 @@ internal fun LocalModelRow(
     onDelete: () -> Unit,
     onSelect: () -> Unit,
     onImportFromPath: (absolutePath: String) -> Unit,
+    onImportPreparing: () -> Unit,
+    onImportPickFailed: () -> Unit,
 ) {
     val downloading = downloadState as? LocalModelDownloadUiState.Downloading
     val isDownloadingThis = downloading?.modelId == model.id
     val error = downloadState as? LocalModelDownloadUiState.Error
     val errorForThis = error?.takeIf { it.modelId == model.id }
-    val existingPath = remember(model.fileName, isReady) {
-        if (isReady) null else findCatalogModelInDownloads(model.fileName)
+    var existingPath by remember(model.fileName) { mutableStateOf<String?>(null) }
+    LaunchedEffect(model.fileName, isReady) {
+        existingPath = if (isReady) {
+            null
+        } else {
+            withContext(Dispatchers.IO) {
+                findCatalogModelInDownloads(model.fileName)
+            }
+        }
     }
-    val launchImport = rememberLocalModelImportLauncher(onPickedAbsolutePath = onImportFromPath)
+    val importController = rememberLocalModelImportController(
+        onPreparing = onImportPreparing,
+        onResult = { pick ->
+            when (pick) {
+                is LocalModelImportPick.Success -> onImportFromPath(pick.absolutePath)
+                LocalModelImportPick.Failure -> onImportPickFailed()
+                LocalModelImportPick.Cancelled -> onCancelDownload()
+            }
+        },
+    )
     val sizeLabel = remember(model.sizeBytes) { formatLocalModelSizeGb(model.sizeBytes) }
 
     Column(
@@ -292,8 +321,13 @@ internal fun LocalModelRow(
                 0f
             }
             val percent = (progress * 100).toInt()
+            val progressLabel = if (downloading.isImport) {
+                stringResource(Res.string.agent_local_importing, "$percent%")
+            } else {
+                stringResource(Res.string.agent_local_download_progress, "$percent%")
+            }
             Text(
-                text = stringResource(Res.string.agent_local_download_progress, "$percent%"),
+                text = progressLabel,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.testTag("text_local_progress_${model.id}")
@@ -323,7 +357,10 @@ internal fun LocalModelRow(
             when {
                 isDownloadingThis -> {
                     OutlinedButton(
-                        onClick = onCancelDownload,
+                        onClick = {
+                            importController.cancelPrepare()
+                            onCancelDownload()
+                        },
                         enabled = actionsEnabled,
                         modifier = Modifier.testTag("button_local_cancel")
                     ) {
@@ -365,15 +402,16 @@ internal fun LocalModelRow(
                         Text(stringResource(Res.string.agent_local_download))
                     }
                     OutlinedButton(
-                        onClick = launchImport,
+                        onClick = importController::launch,
                         enabled = actionsEnabled && !busy,
                         modifier = Modifier.testTag("button_local_import_${model.id}")
                     ) {
                         Text(stringResource(Res.string.agent_local_import))
                     }
-                    if (existingPath != null) {
+                    val adoptPath = existingPath
+                    if (adoptPath != null) {
                         OutlinedButton(
-                            onClick = { onImportFromPath(existingPath) },
+                            onClick = { onImportFromPath(adoptPath) },
                             enabled = actionsEnabled && !busy,
                             modifier = Modifier.testTag("button_local_use_existing_${model.id}")
                         ) {

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/OnDeviceProviderCard.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/OnDeviceProviderCard.kt
@@ -232,13 +232,28 @@ internal fun LocalModelRow(
             }
         }
     }
+    var importPrepareStarted by remember { mutableStateOf(false) }
     val importController = rememberLocalModelImportController(
-        onPreparing = onImportPreparing,
+        onPreparing = {
+            importPrepareStarted = true
+            onImportPreparing()
+        },
         onResult = { pick ->
             when (pick) {
-                is LocalModelImportPick.Success -> onImportFromPath(pick.absolutePath)
-                LocalModelImportPick.Failure -> onImportPickFailed()
-                LocalModelImportPick.Cancelled -> onCancelDownload()
+                is LocalModelImportPick.Success -> {
+                    importPrepareStarted = false
+                    onImportFromPath(pick.absolutePath)
+                }
+                LocalModelImportPick.Failure -> {
+                    importPrepareStarted = false
+                    onImportPickFailed()
+                }
+                LocalModelImportPick.Cancelled -> {
+                    if (importPrepareStarted) {
+                        importPrepareStarted = false
+                        onCancelDownload()
+                    }
+                }
             }
         },
     )

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
@@ -85,6 +85,8 @@ fun SettingsScreen(
                     onImportLocalModel = { modelId, path ->
                         viewModel.importLocalModel(modelId, path)
                     },
+                    onImportLocalModelPreparing = { viewModel.markLocalModelImportPreparing(it) },
+                    onImportLocalModelPickFailed = { viewModel.reportLocalModelImportPickFailed(it) },
                     onToggleMcp = { viewModel.toggleMcpEnabled(it) },
                     onAddMcpServer = { url, label, toolset, headers, useInstanceAuth ->
                         viewModel.addMcpServer(url, label, toolset, headers, useInstanceAuth)
@@ -135,6 +137,8 @@ private fun SettingsContent(
     onDeleteLocalModel: (String) -> Unit,
     onSelectLocalModel: (String) -> Unit,
     onImportLocalModel: (modelId: String, absolutePath: String) -> Unit,
+    onImportLocalModelPreparing: (modelId: String) -> Unit,
+    onImportLocalModelPickFailed: (modelId: String) -> Unit,
     onToggleMcp: (Boolean) -> Unit,
     onAddMcpServer: (String, String, String?, Map<String, String>, Boolean) -> Unit,
     onRemoveMcpServer: (String) -> Unit,
@@ -206,6 +210,8 @@ private fun SettingsContent(
                 onDeleteLocalModel = onDeleteLocalModel,
                 onSelectLocalModel = onSelectLocalModel,
                 onImportLocalModel = onImportLocalModel,
+                onImportLocalModelPreparing = onImportLocalModelPreparing,
+                onImportLocalModelPickFailed = onImportLocalModelPickFailed,
                 onClearHistory = onClearHistory,
                 modifier = Modifier.weight(1f)
             )

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
@@ -82,6 +82,9 @@ fun SettingsScreen(
                     onCancelLocalModelDownload = { viewModel.cancelLocalModelDownload() },
                     onDeleteLocalModel = { viewModel.deleteLocalModel(it) },
                     onSelectLocalModel = { viewModel.selectLocalModel(it) },
+                    onImportLocalModel = { modelId, path ->
+                        viewModel.importLocalModel(modelId, path)
+                    },
                     onToggleMcp = { viewModel.toggleMcpEnabled(it) },
                     onAddMcpServer = { url, label, toolset, headers, useInstanceAuth ->
                         viewModel.addMcpServer(url, label, toolset, headers, useInstanceAuth)
@@ -131,6 +134,7 @@ private fun SettingsContent(
     onCancelLocalModelDownload: () -> Unit,
     onDeleteLocalModel: (String) -> Unit,
     onSelectLocalModel: (String) -> Unit,
+    onImportLocalModel: (modelId: String, absolutePath: String) -> Unit,
     onToggleMcp: (Boolean) -> Unit,
     onAddMcpServer: (String, String, String?, Map<String, String>, Boolean) -> Unit,
     onRemoveMcpServer: (String) -> Unit,
@@ -201,6 +205,7 @@ private fun SettingsContent(
                 onCancelLocalModelDownload = onCancelLocalModelDownload,
                 onDeleteLocalModel = onDeleteLocalModel,
                 onSelectLocalModel = onSelectLocalModel,
+                onImportLocalModel = onImportLocalModel,
                 onClearHistory = onClearHistory,
                 modifier = Modifier.weight(1f)
             )

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeLocalModelRepository.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeLocalModelRepository.kt
@@ -4,6 +4,7 @@ import io.github.leogallego.ansiblejane.assistant.local.DevicePerformance
 import io.github.leogallego.ansiblejane.assistant.local.ILocalModelRepository
 import io.github.leogallego.ansiblejane.assistant.local.LOCAL_MODEL_CATALOG
 import io.github.leogallego.ansiblejane.assistant.local.LocalModel
+import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadErrorKind
 import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -58,6 +59,19 @@ class FakeLocalModelRepository(
         importCalls = importCalls + (modelId to sourceAbsolutePath)
         ready.add(modelId)
         _downloadState.value = LocalModelDownloadState.Succeeded(modelId)
+    }
+
+    override fun notifyTransferError(modelId: String, kind: LocalModelDownloadErrorKind) {
+        _downloadState.value = LocalModelDownloadState.Error(modelId, kind)
+    }
+
+    override fun markImportPreparing(modelId: String) {
+        _downloadState.value = LocalModelDownloadState.Downloading(
+            modelId = modelId,
+            bytesReceived = 0L,
+            totalBytes = 1L,
+            isImport = true,
+        )
     }
 
     override fun devicePerformance(modelId: String, contextTokens: Int): DevicePerformance =

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeLocalModelRepository.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeLocalModelRepository.kt
@@ -25,6 +25,8 @@ class FakeLocalModelRepository(
         private set
     var deleteCalls: List<String> = emptyList()
         private set
+    var importCalls: List<Pair<String, String>> = emptyList()
+        private set
 
     override fun catalog(): List<LocalModel> = models
 
@@ -50,6 +52,12 @@ class FakeLocalModelRepository(
         if (_downloadState.value.let { it is LocalModelDownloadState.Succeeded && it.modelId == modelId }) {
             _downloadState.value = LocalModelDownloadState.Idle
         }
+    }
+
+    override suspend fun importFromPath(modelId: String, sourceAbsolutePath: String) {
+        importCalls = importCalls + (modelId to sourceAbsolutePath)
+        ready.add(modelId)
+        _downloadState.value = LocalModelDownloadState.Succeeded(modelId)
     }
 
     override fun devicePerformance(modelId: String, contextTokens: Int): DevicePerformance =

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUiMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUiMapperTest.kt
@@ -6,12 +6,14 @@ import aapremotecontrol.composeapp.generated.resources.agent_local_download_fail
 import aapremotecontrol.composeapp.generated.resources.agent_local_download_network
 import aapremotecontrol.composeapp.generated.resources.agent_local_download_timeout
 import aapremotecontrol.composeapp.generated.resources.agent_local_hash_mismatch
+import aapremotecontrol.composeapp.generated.resources.agent_local_import_failed
 import io.github.leogallego.ansiblejane.assistant.local.DevicePerformance
 import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadErrorKind
 import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadState
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class LocalModelUiMapperTest {
 
@@ -34,6 +36,10 @@ class LocalModelUiMapperTest {
             LocalModelDownloadErrorKind.NETWORK.toUiMessage(),
         )
         assertEquals(
+            Res.string.agent_local_import_failed,
+            LocalModelDownloadErrorKind.IMPORT.toUiMessage(),
+        )
+        assertEquals(
             Res.string.agent_local_download_failed,
             LocalModelDownloadErrorKind.OTHER.toUiMessage(),
         )
@@ -45,9 +51,11 @@ class LocalModelUiMapperTest {
             modelId = "gemma-4-e4b-it",
             bytesReceived = 50,
             totalBytes = 100,
+            isImport = true,
         ).toUi()
         assertIs<LocalModelDownloadUiState.Downloading>(downloading)
         assertEquals(50, downloading.bytesReceived)
+        assertTrue(downloading.isImport)
 
         val error = LocalModelDownloadState.Error(
             modelId = "gemma-4-e4b-it",

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUiMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUiMapperTest.kt
@@ -3,6 +3,8 @@ package io.github.leogallego.ansiblejane.presentation.settings
 import aapremotecontrol.composeapp.generated.resources.Res
 import aapremotecontrol.composeapp.generated.resources.agent_local_disk_insufficient
 import aapremotecontrol.composeapp.generated.resources.agent_local_download_failed
+import aapremotecontrol.composeapp.generated.resources.agent_local_download_network
+import aapremotecontrol.composeapp.generated.resources.agent_local_download_timeout
 import aapremotecontrol.composeapp.generated.resources.agent_local_hash_mismatch
 import io.github.leogallego.ansiblejane.assistant.local.DevicePerformance
 import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadErrorKind
@@ -24,7 +26,11 @@ class LocalModelUiMapperTest {
             LocalModelDownloadErrorKind.HASH.toUiMessage(),
         )
         assertEquals(
-            Res.string.agent_local_download_failed,
+            Res.string.agent_local_download_timeout,
+            LocalModelDownloadErrorKind.TIMEOUT.toUiMessage(),
+        )
+        assertEquals(
+            Res.string.agent_local_download_network,
             LocalModelDownloadErrorKind.NETWORK.toUiMessage(),
         )
         assertEquals(
@@ -56,5 +62,12 @@ class LocalModelUiMapperTest {
         assertEquals(DevicePerformanceUi.GOOD, DevicePerformance.GOOD.toUi())
         assertEquals(DevicePerformanceUi.OK, DevicePerformance.OK.toUi())
         assertEquals(DevicePerformanceUi.POOR, DevicePerformance.POOR.toUi())
+    }
+
+    @Test
+    fun `formatLocalModelSizeGb uses one decimal without printf placeholders`() {
+        assertEquals("3.4", formatLocalModelSizeGb(3_659_530_240L))
+        assertEquals("6.1", formatLocalModelSizeGb(6_547_589_312L))
+        assertEquals("0.0", formatLocalModelSizeGb(0L))
     }
 }

--- a/composeApp/src/desktopMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.desktop.kt
@@ -2,26 +2,37 @@ package io.github.leogallego.ansiblejane.ui.settings
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import java.io.File
 import javax.swing.JFileChooser
+import javax.swing.SwingUtilities
 import javax.swing.filechooser.FileNameExtensionFilter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
 
 @Composable
-actual fun rememberLocalModelImportLauncher(
-    onPickedAbsolutePath: (absolutePath: String) -> Unit,
-): () -> Unit {
-    return remember(onPickedAbsolutePath) {
-        {
-            val chooser = JFileChooser().apply {
-                fileFilter = FileNameExtensionFilter("LiteRT models (*.litertlm)", "litertlm")
-                isAcceptAllFileFilterUsed = true
-            }
-            val result = chooser.showOpenDialog(null)
-            if (result == JFileChooser.APPROVE_OPTION) {
-                val file = chooser.selectedFile
-                if (file != null && file.isFile) {
-                    onPickedAbsolutePath(file.absolutePath)
+actual fun rememberLocalModelImportController(
+    onPreparing: () -> Unit,
+    onResult: (LocalModelImportPick) -> Unit,
+): LocalModelImportController {
+    val scope = rememberCoroutineScope()
+    return remember(onPreparing, onResult) {
+        object : LocalModelImportController {
+            override fun launch() {
+                scope.launch {
+                    val pick = pickFileOnEdt()
+                    if (pick is LocalModelImportPick.Success) {
+                        onPreparing()
+                    }
+                    onResult(pick)
                 }
+            }
+
+            override fun cancelPrepare() {
+                // Desktop has no multi-GB prepare copy; dialog is modal.
             }
         }
     }
@@ -36,3 +47,31 @@ actual fun findCatalogModelInDownloads(fileName: String): String? {
         null
     }
 }
+
+private suspend fun pickFileOnEdt(): LocalModelImportPick =
+    withContext(Dispatchers.IO) {
+        suspendCancellableCoroutine { cont ->
+            val show = Runnable {
+                val chooser = JFileChooser().apply {
+                    fileFilter = FileNameExtensionFilter(
+                        "LiteRT models (*.litertlm)",
+                        "litertlm",
+                    )
+                    isAcceptAllFileFilterUsed = true
+                }
+                val result = chooser.showOpenDialog(null)
+                val pick = when {
+                    result != JFileChooser.APPROVE_OPTION -> LocalModelImportPick.Cancelled
+                    chooser.selectedFile?.isFile == true ->
+                        LocalModelImportPick.Success(chooser.selectedFile.absolutePath)
+                    else -> LocalModelImportPick.Failure
+                }
+                if (cont.isActive) cont.resume(pick)
+            }
+            if (SwingUtilities.isEventDispatchThread()) {
+                show.run()
+            } else {
+                SwingUtilities.invokeLater(show)
+            }
+        }
+    }

--- a/composeApp/src/desktopMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.desktop.kt
@@ -1,0 +1,38 @@
+package io.github.leogallego.ansiblejane.ui.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import java.io.File
+import javax.swing.JFileChooser
+import javax.swing.filechooser.FileNameExtensionFilter
+
+@Composable
+actual fun rememberLocalModelImportLauncher(
+    onPickedAbsolutePath: (absolutePath: String) -> Unit,
+): () -> Unit {
+    return remember(onPickedAbsolutePath) {
+        {
+            val chooser = JFileChooser().apply {
+                fileFilter = FileNameExtensionFilter("LiteRT models (*.litertlm)", "litertlm")
+                isAcceptAllFileFilterUsed = true
+            }
+            val result = chooser.showOpenDialog(null)
+            if (result == JFileChooser.APPROVE_OPTION) {
+                val file = chooser.selectedFile
+                if (file != null && file.isFile) {
+                    onPickedAbsolutePath(file.absolutePath)
+                }
+            }
+        }
+    }
+}
+
+actual fun findCatalogModelInDownloads(fileName: String): String? {
+    val home = System.getProperty("user.home") ?: return null
+    val candidate = File(home, "Downloads${File.separator}$fileName")
+    return if (candidate.isFile && candidate.canRead() && candidate.length() > 0L) {
+        candidate.absolutePath
+    } else {
+        null
+    }
+}

--- a/docs/superpowers/plans/2026-08-08-issue-469-litert-download.md
+++ b/docs/superpowers/plans/2026-08-08-issue-469-litert-download.md
@@ -1,0 +1,92 @@
+# Plan: LiteRT model download timeouts, progress UI, import/resume (#469)
+
+**Date:** 2026-08-08  
+**Branch:** `fix/469-litert-download` (from `origin/main`)  
+**Scope:** medium — single PR (no stack)
+
+## Research verdict
+
+| Checkpoint | Result |
+|------------|--------|
+| OkHttp/`llm` timeouts | Confirmed: `named("llm")` has **no** `HttpTimeout`. Android OkHttp defaults ~10s read → mid-stream stall → `OTHER`. |
+| HF CDN resume | Confirmed: Hub + CDN `Accept-Ranges: bytes`; `Range: bytes=0-0` → **206** + `Content-Range`. Resume on original Hub URL (follow redirects). |
+| CMP float format | Confirmed broken: `%1$.1f GB`. Use `%1$s` + Kotlin-formatted size (issue-293). `%1$d%%` progress likely OK. |
+| SAF / disk | Stream copy; ~2× free space if Uri→temp then import. Prefer stream into `.partial` when possible. |
+
+## Out of scope
+
+- #468 AICore / Gemini Nano  
+- #264 PR2 async / OnDeviceLarge  
+- Kai private `filesDir`, E2B catalog, Play Asset Delivery  
+
+## Implementation (ordered commits)
+
+### A — Timeouts, strings, richer errors
+
+1. **`AssistantDiModule`**: add `single(named("litertDownload"))` with  
+   `requestTimeoutMillis = INFINITE`, `connectTimeoutMillis = 30_000`, `socketTimeoutMillis = 120_000`. Wire `LocalModelRepository` to it (keep `llm` unchanged).
+2. **`LocalModelDownloadErrorKind`**: add `TIMEOUT`; map `SocketTimeoutException` / timeout messages → TIMEOUT; HTTP non-2xx → NETWORK; keep DISK/HASH/OTHER. Log via `DebugLog.e`.
+3. **Strings + UI**:  
+   - `agent_local_size_gb` → `%1$s GB` (or full preformatted `%1$s`)  
+   - Format size in Kotlin (`"%.1f".format(...)`) before `stringResource`  
+   - Distinct strings for TIMEOUT / NETWORK  
+4. **Tests**: DI wiring smoke (client qualifier used), error-kind mapping; string formatting unit test where practical.
+
+### B — Resume
+
+1. **`LocalModelFiles.openSink(path, append)`** (android + jvm).  
+2. **`runDownload`**: if `.partial` exists with `length > 0`, hash existing bytes, send `Range: bytes={n}-`.  
+   - **206**: append; continue hash.  
+   - **200**: discard partial, rewrite from 0.  
+   - Other: NETWORK error (keep partial).  
+3. **Cancel / network fail**: **keep** `.partial` (behavior change); Idle on cancel; do not delete on timeout/network.  
+4. Delete `.partial` only on HASH fail or after successful rename.  
+5. **Tests**: MockEngine 206 resume; 200 restart; cancel leaves partial.
+
+### C — Import + optional Downloads scan
+
+1. **`ILocalModelRepository.importFromPath(modelId, absolutePath)`** — stream copy + SHA; DISK check; Ready on success.  
+2. **UI**: Import button on not-downloaded rows; Android `OpenDocument` (stream Uri → temp under cache/model root, then `importFromPath`); desktop file chooser via existing platform patterns if cheap, else Android-first.  
+3. **Optional Downloads scan**: `expect`/`actual` or Android-only helper looks for catalog `fileName` under public Downloads; if found + readable, show “Use existing file” → `importFromPath`. Best-effort (no new dangerous permissions).  
+4. **Tests**: import hash OK/fail; fake repo methods for VM.
+
+## File list
+
+| File | Change |
+|------|--------|
+| `shared/.../di/AssistantDiModule.kt` | `litertDownload` client |
+| `shared/.../local/ILocalModelRepository.kt` | TIMEOUT, `importFromPath` |
+| `shared/.../local/LocalModelRepository.kt` | timeouts path, resume, import, logging |
+| `shared/.../local/LocalModelFiles*.kt` | append sink; optional openSource |
+| `composeApp/.../LocalModelUi.kt` | TIMEOUT message map |
+| `composeApp/.../OnDeviceProviderCard.kt` | size format, import/use-existing UI |
+| `composeApp/.../AgentTab.kt` / `SettingsViewModel.kt` / `SettingsScreen.kt` | wire import + scan |
+| `composeApp/.../strings.xml` | size/progress/error/import strings |
+| `composeApp/.../fakes/FakeLocalModelRepository.kt` | new API |
+| `shared/.../LocalModelRepositoryTest.kt` | resume/import/timeout tests |
+| Android-only import/scan helpers under `composeApp/androidMain` or `shared/androidMain` | SAF + Downloads |
+
+## Test plan
+
+```bash
+./gradlew --no-daemon :shared:jvmTest --tests '*LocalModelRepositoryTest*'
+./gradlew --no-daemon :composeApp:desktopTest --tests '*LocalModelUiMapperTest*'
+```
+
+Manual smoke (PR checklist): Wi‑Fi E4B download on phone; cancel+resume; size/progress labels; SAF import; optional Downloads adopt.
+
+## Acceptance mapping
+
+| Criterion | Task |
+|-----------|------|
+| No spurious mid-stream timeout / clear kind | A |
+| Resume after cancel/blip | B |
+| Size GB + progress % | A |
+| SAF import + hash | C |
+| Optional Downloads | C |
+| Unit tests | A–C |
+| PR smoke checklist | PR body |
+
+## No migration needed
+
+Existing partials from older builds are unused (old code deleted them on cancel/fail). New resume is forward-compatible.

--- a/shared/src/androidMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelFiles.android.kt
+++ b/shared/src/androidMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelFiles.android.kt
@@ -1,6 +1,7 @@
 package io.github.leogallego.ansiblejane.assistant.local
 
 import java.io.File
+import java.io.FileInputStream
 import java.io.FileOutputStream
 
 internal actual object LocalModelFiles {
@@ -32,10 +33,10 @@ internal actual object LocalModelFiles {
         }
     }
 
-    actual fun openSink(path: String): ModelFileSink {
+    actual fun openSink(path: String, append: Boolean): ModelFileSink {
         val file = File(path)
         file.parentFile?.mkdirs()
-        val out = FileOutputStream(file)
+        val out = FileOutputStream(file, append)
         return object : ModelFileSink {
             override fun write(bytes: ByteArray, offset: Int, length: Int) {
                 out.write(bytes, offset, length)
@@ -43,6 +44,18 @@ internal actual object LocalModelFiles {
 
             override fun close() {
                 out.close()
+            }
+        }
+    }
+
+    actual fun openSource(path: String): ModelFileSource {
+        val input = FileInputStream(File(path))
+        return object : ModelFileSource {
+            override fun read(bytes: ByteArray, offset: Int, length: Int): Int =
+                input.read(bytes, offset, length)
+
+            override fun close() {
+                input.close()
             }
         }
     }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
@@ -15,6 +15,8 @@ import io.github.leogallego.ansiblejane.network.mcp.McpServerManager
 import io.github.leogallego.ansiblejane.platform.IDeviceResources
 import io.github.leogallego.ansiblejane.platform.asIDeviceResources
 import io.github.leogallego.ansiblejane.platform.DeviceResources
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.HttpTimeoutConfig
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.sse.SSE
 import io.ktor.client.request.header
@@ -33,7 +35,7 @@ val sharedAssistantModule = module {
     single {
         LocalModelRepository(
             deviceResources = get(),
-            httpClient = get(named("llm")),
+            httpClient = get(named("litertDownload")),
             scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
         )
     } bind ILocalModelRepository::class
@@ -66,6 +68,21 @@ val sharedAssistantModule = module {
     single(named("llm")) {
         createPlatformHttpClient {
             expectSuccess = false
+        }
+    }
+
+    /**
+     * Long-running HF model downloads. Must not reuse [llm] — OkHttp's default
+     * ~10s read timeout aborts multi-GB streams on brief mobile stalls (#469).
+     */
+    single(named("litertDownload")) {
+        createPlatformHttpClient {
+            expectSuccess = false
+            install(HttpTimeout) {
+                requestTimeoutMillis = HttpTimeoutConfig.INFINITE_TIMEOUT_MS
+                connectTimeoutMillis = 30_000
+                socketTimeoutMillis = 120_000
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/ILocalModelRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/ILocalModelRepository.kt
@@ -10,6 +10,11 @@ interface ILocalModelRepository {
     suspend fun download(modelId: String)
     fun cancelDownload()
     suspend fun delete(modelId: String)
+    /**
+     * Copy [sourceAbsolutePath] into Jane model storage, verify SHA-256 against the catalog,
+     * and mark the model ready on success.
+     */
+    suspend fun importFromPath(modelId: String, sourceAbsolutePath: String)
     fun devicePerformance(modelId: String, contextTokens: Int): DevicePerformance
     fun hasAvx2Support(): Boolean
 }
@@ -17,6 +22,7 @@ interface ILocalModelRepository {
 enum class LocalModelDownloadErrorKind {
     DISK,
     NETWORK,
+    TIMEOUT,
     HASH,
     OTHER,
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/ILocalModelRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/ILocalModelRepository.kt
@@ -12,9 +12,13 @@ interface ILocalModelRepository {
     suspend fun delete(modelId: String)
     /**
      * Copy [sourceAbsolutePath] into Jane model storage, verify SHA-256 against the catalog,
-     * and mark the model ready on success.
+     * and mark the model ready on success. Runs on the repository transfer job (cancellable).
      */
     suspend fun importFromPath(modelId: String, sourceAbsolutePath: String)
+    /** Surface a picker/IO failure that never reached [importFromPath]. */
+    fun notifyTransferError(modelId: String, kind: LocalModelDownloadErrorKind)
+    /** Show Importing progress while a platform prepare/copy runs before [importFromPath]. */
+    fun markImportPreparing(modelId: String)
     fun devicePerformance(modelId: String, contextTokens: Int): DevicePerformance
     fun hasAvx2Support(): Boolean
 }
@@ -24,6 +28,8 @@ enum class LocalModelDownloadErrorKind {
     NETWORK,
     TIMEOUT,
     HASH,
+    /** Picker/SAF could not read the selected file into a streamable path. */
+    IMPORT,
     OTHER,
 }
 
@@ -34,6 +40,8 @@ sealed interface LocalModelDownloadState {
         val modelId: String,
         val bytesReceived: Long,
         val totalBytes: Long,
+        /** True when copying/verifying a local file rather than downloading from the network. */
+        val isImport: Boolean = false,
     ) : LocalModelDownloadState
     data class Succeeded(val modelId: String) : LocalModelDownloadState
     data class Error(

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelFiles.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelFiles.kt
@@ -5,6 +5,12 @@ internal interface ModelFileSink {
     fun close()
 }
 
+internal interface ModelFileSource {
+    /** Reads up to [length] bytes into [bytes] at [offset]. Returns count, or -1 at EOF. */
+    fun read(bytes: ByteArray, offset: Int, length: Int): Int
+    fun close()
+}
+
 /** Thin multiplatform file helpers for model download paths. */
 internal expect object LocalModelFiles {
     fun ensureDirectory(path: String)
@@ -12,6 +18,7 @@ internal expect object LocalModelFiles {
     fun length(path: String): Long
     fun deleteRecursively(path: String)
     fun rename(from: String, to: String)
-    fun openSink(path: String): ModelFileSink
+    fun openSink(path: String, append: Boolean = false): ModelFileSink
+    fun openSource(path: String): ModelFileSource
     fun join(parent: String, vararg parts: String): String
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepository.kt
@@ -1,18 +1,22 @@
 package io.github.leogallego.ansiblejane.assistant.local
 
+import io.github.leogallego.ansiblejane.assistant.engine.DebugLog
 import io.github.leogallego.ansiblejane.platform.IDeviceResources
 import io.ktor.client.HttpClient
+import io.ktor.client.request.header
 import io.ktor.client.request.prepareGet
 import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.readAvailable
 import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.launch
 
 class LocalModelRepository(
@@ -94,6 +98,82 @@ class LocalModelRepository(
         }
     }
 
+    override suspend fun importFromPath(modelId: String, sourceAbsolutePath: String) {
+        val model = catalog.find { it.id == modelId }
+        if (model == null) {
+            _downloadState.value =
+                LocalModelDownloadState.Error(modelId, LocalModelDownloadErrorKind.OTHER)
+            return
+        }
+        if (!LocalModelFiles.exists(sourceAbsolutePath)) {
+            DebugLog.e(TAG, "Import source missing: $sourceAbsolutePath")
+            _downloadState.value =
+                LocalModelDownloadState.Error(modelId, LocalModelDownloadErrorKind.OTHER)
+            return
+        }
+
+        val root = modelRoot()
+        LocalModelFiles.ensureDirectory(root)
+        val sourceLength = LocalModelFiles.length(sourceAbsolutePath)
+        val requiredBytes = sourceLength + DISK_BUFFER_BYTES
+        val freeBytes = deviceResources.freeDiskBytes(root)
+        if (freeBytes < requiredBytes) {
+            _downloadState.value = LocalModelDownloadState.Error(
+                modelId,
+                LocalModelDownloadErrorKind.DISK,
+            )
+            return
+        }
+
+        val targetPath = LocalModelFiles.join(root, model.id, model.fileName)
+        val tempPath = "$targetPath.partial"
+        LocalModelFiles.ensureDirectory(LocalModelFiles.join(root, model.id))
+        LocalModelFiles.deleteRecursively(tempPath)
+
+        _downloadState.value = LocalModelDownloadState.Downloading(
+            modelId = model.id,
+            bytesReceived = 0L,
+            totalBytes = sourceLength.coerceAtLeast(1L),
+        )
+
+        try {
+            val hasher = Sha256Hasher()
+            var received = 0L
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            val source = LocalModelFiles.openSource(sourceAbsolutePath)
+            val sink = LocalModelFiles.openSink(tempPath, append = false)
+            try {
+                while (true) {
+                    val read = source.read(buffer, 0, buffer.size)
+                    if (read < 0) break
+                    if (read == 0) continue
+                    sink.write(buffer, 0, read)
+                    hasher.update(buffer, 0, read)
+                    received += read
+                    _downloadState.value = LocalModelDownloadState.Downloading(
+                        modelId = model.id,
+                        bytesReceived = received,
+                        totalBytes = sourceLength.coerceAtLeast(1L),
+                    )
+                }
+            } finally {
+                sink.close()
+                source.close()
+            }
+
+            finalizeVerifiedFile(model, tempPath, targetPath, hasher.digestHex())
+        } catch (e: CancellationException) {
+            LocalModelFiles.deleteRecursively(tempPath)
+            _downloadState.value = LocalModelDownloadState.Idle
+            throw e
+        } catch (e: Exception) {
+            LocalModelFiles.deleteRecursively(tempPath)
+            val kind = classifyTransferError(e)
+            DebugLog.e(TAG, "Import failed for ${model.id} ($kind)", e)
+            _downloadState.value = LocalModelDownloadState.Error(model.id, kind)
+        }
+    }
+
     override fun devicePerformance(modelId: String, contextTokens: Int): DevicePerformance {
         val model = catalog.find { it.id == modelId }
             ?: return DevicePerformance.POOR
@@ -106,28 +186,77 @@ class LocalModelRepository(
     private suspend fun runDownload(model: LocalModel, root: String) {
         val targetPath = LocalModelFiles.join(root, model.id, model.fileName)
         val tempPath = "$targetPath.partial"
-        LocalModelFiles.deleteRecursively(tempPath)
         LocalModelFiles.ensureDirectory(LocalModelFiles.join(root, model.id))
+
+        var resumeFrom = if (LocalModelFiles.exists(tempPath)) {
+            LocalModelFiles.length(tempPath)
+        } else {
+            0L
+        }
+        if (resumeFrom > model.sizeBytes) {
+            DebugLog.w(TAG, "Partial larger than catalog size for ${model.id}; restarting")
+            LocalModelFiles.deleteRecursively(tempPath)
+            resumeFrom = 0L
+        }
+
+        var hasher = Sha256Hasher()
+        if (resumeFrom > 0L) {
+            hashExistingFile(tempPath, hasher)
+        }
 
         _downloadState.value = LocalModelDownloadState.Downloading(
             modelId = model.id,
-            bytesReceived = 0L,
+            bytesReceived = resumeFrom,
             totalBytes = model.sizeBytes,
         )
 
-        try {
-            val hasher = Sha256Hasher()
-            var received = 0L
+        if (resumeFrom == model.sizeBytes && resumeFrom > 0L) {
+            finalizeVerifiedFile(model, tempPath, targetPath, hasher.digestHex())
+            return
+        }
 
-            httpClient.prepareGet(model.downloadUrl).execute { response ->
-                if (!response.status.isSuccess()) {
-                    throw IllegalStateException(
-                        "Download failed with HTTP ${response.status.value}",
-                    )
+        try {
+            var received = resumeFrom
+            httpClient.prepareGet(model.downloadUrl) {
+                if (resumeFrom > 0L) {
+                    header(HttpHeaders.Range, "bytes=$resumeFrom-")
                 }
+            }.execute { response ->
+                val status = response.status
+                var append = resumeFrom > 0L
+
+                when {
+                    status == HttpStatusCode.PartialContent && resumeFrom > 0L -> {
+                        // Resume from existing bytes; hasher already covers them.
+                    }
+                    status.isSuccess() -> {
+                        if (resumeFrom > 0L) {
+                            DebugLog.w(
+                                TAG,
+                                "Server ignored Range for ${model.id} (HTTP ${status.value}); restarting",
+                            )
+                            LocalModelFiles.deleteRecursively(tempPath)
+                            resumeFrom = 0L
+                            received = 0L
+                            append = false
+                            hasher = Sha256Hasher()
+                            _downloadState.value = LocalModelDownloadState.Downloading(
+                                modelId = model.id,
+                                bytesReceived = 0L,
+                                totalBytes = model.sizeBytes,
+                            )
+                        }
+                    }
+                    else -> {
+                        throw IllegalStateException(
+                            "Download failed with HTTP ${status.value}",
+                        )
+                    }
+                }
+
                 val channel = response.bodyAsChannel()
                 val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-                val sink = LocalModelFiles.openSink(tempPath)
+                val sink = LocalModelFiles.openSink(tempPath, append = append)
                 try {
                     while (!channel.isClosedForRead) {
                         val read = channel.readAvailable(buffer, 0, buffer.size)
@@ -146,38 +275,60 @@ class LocalModelRepository(
                 } finally {
                     sink.close()
                 }
+
+                finalizeVerifiedFile(model, tempPath, targetPath, hasher.digestHex())
             }
-
-            val actualSha = hasher.digestHex()
-            if (!actualSha.equals(model.sha256, ignoreCase = true)) {
-                LocalModelFiles.deleteRecursively(tempPath)
-                _downloadState.value = LocalModelDownloadState.Error(
-                    model.id,
-                    LocalModelDownloadErrorKind.HASH,
-                )
-                return
-            }
-
-            LocalModelFiles.deleteRecursively(targetPath)
-            LocalModelFiles.rename(tempPath, targetPath)
-
-            _downloadState.value = LocalModelDownloadState.Succeeded(model.id)
         } catch (e: CancellationException) {
-            LocalModelFiles.deleteRecursively(tempPath)
+            val kept = partialLength(tempPath)
+            DebugLog.w(TAG, "Download cancelled for ${model.id}; keeping partial ($kept bytes)")
             _downloadState.value = LocalModelDownloadState.Idle
             throw e
         } catch (e: Exception) {
-            LocalModelFiles.deleteRecursively(tempPath)
-            val kind = if (e is IllegalStateException &&
-                e.message?.startsWith("Download failed with HTTP") == true
-            ) {
-                LocalModelDownloadErrorKind.NETWORK
-            } else {
-                LocalModelDownloadErrorKind.OTHER
+            val kind = classifyTransferError(e)
+            DebugLog.e(TAG, "Download failed for ${model.id} ($kind)", e)
+            if (kind == LocalModelDownloadErrorKind.HASH) {
+                LocalModelFiles.deleteRecursively(tempPath)
             }
             _downloadState.value = LocalModelDownloadState.Error(model.id, kind)
         }
     }
+
+    private fun finalizeVerifiedFile(
+        model: LocalModel,
+        tempPath: String,
+        targetPath: String,
+        actualSha: String,
+    ) {
+        if (!actualSha.equals(model.sha256, ignoreCase = true)) {
+            LocalModelFiles.deleteRecursively(tempPath)
+            DebugLog.e(TAG, "Hash mismatch for ${model.id}: $actualSha")
+            _downloadState.value = LocalModelDownloadState.Error(
+                model.id,
+                LocalModelDownloadErrorKind.HASH,
+            )
+            return
+        }
+        LocalModelFiles.deleteRecursively(targetPath)
+        LocalModelFiles.rename(tempPath, targetPath)
+        _downloadState.value = LocalModelDownloadState.Succeeded(model.id)
+    }
+
+    private fun hashExistingFile(path: String, hasher: Sha256Hasher) {
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        val source = LocalModelFiles.openSource(path)
+        try {
+            while (true) {
+                val read = source.read(buffer, 0, buffer.size)
+                if (read < 0) break
+                if (read > 0) hasher.update(buffer, 0, read)
+            }
+        } finally {
+            source.close()
+        }
+    }
+
+    private fun partialLength(tempPath: String): Long =
+        if (LocalModelFiles.exists(tempPath)) LocalModelFiles.length(tempPath) else 0L
 
     private fun modelRoot(): String = modelRootOverride ?: deviceResources.modelStorageDirectory()
 
@@ -187,7 +338,43 @@ class LocalModelRepository(
     }
 
     companion object {
+        private const val TAG = "LocalModelRepo"
         private const val DISK_BUFFER_BYTES = 500L * 1024 * 1024
         private const val DEFAULT_BUFFER_SIZE = 64 * 1024
+
+        internal fun classifyTransferError(error: Throwable): LocalModelDownloadErrorKind {
+            val chain = generateSequence(error) { it.cause }.toList()
+            for (e in chain) {
+                val name = e::class.simpleName.orEmpty()
+                val msg = e.message.orEmpty()
+                when {
+                    e is IllegalStateException &&
+                        msg.startsWith("Download failed with HTTP") ->
+                        return LocalModelDownloadErrorKind.NETWORK
+                    name.contains("SocketTimeout", ignoreCase = true) ||
+                        name.contains("HttpRequestTimeout", ignoreCase = true) ||
+                        msg.contains("SocketTimeout", ignoreCase = true) ||
+                        msg.contains("timed out", ignoreCase = true) ||
+                        (
+                            msg.contains("timeout", ignoreCase = true) &&
+                                (
+                                    name.contains("Timeout", ignoreCase = true) ||
+                                        msg.contains("socket", ignoreCase = true) ||
+                                        msg.contains("request", ignoreCase = true)
+                                    )
+                            ) ->
+                        return LocalModelDownloadErrorKind.TIMEOUT
+                    msg.contains("ENOSPC", ignoreCase = true) ||
+                        msg.contains("No space", ignoreCase = true) ->
+                        return LocalModelDownloadErrorKind.DISK
+                    name.contains("UnknownHost", ignoreCase = true) ||
+                        name.contains("ConnectException", ignoreCase = true) ||
+                        name.contains("SSLException", ignoreCase = true) ||
+                        name.contains("IOException", ignoreCase = true) ->
+                        return LocalModelDownloadErrorKind.NETWORK
+                }
+            }
+            return LocalModelDownloadErrorKind.OTHER
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepository.kt
@@ -14,6 +14,8 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -31,8 +33,8 @@ class LocalModelRepository(
         MutableStateFlow<LocalModelDownloadState>(LocalModelDownloadState.Idle)
     override val downloadState: StateFlow<LocalModelDownloadState> = _downloadState.asStateFlow()
 
-    private val downloadJobLock = Any()
-    private var downloadJob: Job? = null
+    private val transferJobLock = Any()
+    private var transferJob: Job? = null
 
     override fun catalog(): List<LocalModel> = catalog
 
@@ -56,8 +58,11 @@ class LocalModelRepository(
 
         val root = modelRoot()
         LocalModelFiles.ensureDirectory(root)
-
-        val requiredBytes = model.sizeBytes + DISK_BUFFER_BYTES
+        val targetPath = LocalModelFiles.join(root, model.id, model.fileName)
+        val tempPath = "$targetPath.partial"
+        val resumeFrom = clampedPartialLength(tempPath, model.sizeBytes)
+        val remainingBytes = (model.sizeBytes - resumeFrom).coerceAtLeast(0L)
+        val requiredBytes = remainingBytes + DISK_BUFFER_BYTES
         val freeBytes = deviceResources.freeDiskBytes(root)
         if (freeBytes < requiredBytes) {
             _downloadState.value = LocalModelDownloadState.Error(
@@ -67,26 +72,23 @@ class LocalModelRepository(
             return
         }
 
-        val job = synchronized(downloadJobLock) {
-            downloadJob?.cancel()
-            scope.launch {
-                runDownload(model, root)
-            }.also { downloadJob = it }
-        }
-        try {
-            job.join()
-        } finally {
-            synchronized(downloadJobLock) {
-                if (downloadJob === job) {
-                    downloadJob = null
-                }
-            }
+        runExclusiveTransfer {
+            runDownload(model, root)
         }
     }
 
     override fun cancelDownload() {
-        synchronized(downloadJobLock) {
-            downloadJob?.cancel()
+        val job = synchronized(transferJobLock) {
+            val current = transferJob
+            transferJob?.cancel()
+            current
+        }
+        // SAF prepare copy runs outside transferJob but still shows Importing UI.
+        if (job == null) {
+            val state = _downloadState.value
+            if (state is LocalModelDownloadState.Downloading && state.isImport) {
+                _downloadState.value = LocalModelDownloadState.Idle
+            }
         }
     }
 
@@ -125,6 +127,57 @@ class LocalModelRepository(
             return
         }
 
+        runExclusiveTransfer {
+            runImport(model, root, sourceAbsolutePath, sourceLength)
+        }
+    }
+
+    override fun notifyTransferError(modelId: String, kind: LocalModelDownloadErrorKind) {
+        _downloadState.value = LocalModelDownloadState.Error(modelId, kind)
+    }
+
+    override fun markImportPreparing(modelId: String) {
+        _downloadState.value = LocalModelDownloadState.Downloading(
+            modelId = modelId,
+            bytesReceived = 0L,
+            totalBytes = 1L,
+            isImport = true,
+        )
+    }
+
+    override fun devicePerformance(modelId: String, contextTokens: Int): DevicePerformance {
+        val model = catalog.find { it.id == modelId }
+            ?: return DevicePerformance.POOR
+        val estimated = estimateGpuMemoryMb(model, contextTokens)
+        return calculateDevicePerformance(deviceResources.totalMemoryBytes(), estimated)
+    }
+
+    override fun hasAvx2Support(): Boolean = deviceResources.hasAvx2Support()
+
+    private suspend fun runExclusiveTransfer(block: suspend () -> Unit) {
+        val job = synchronized(transferJobLock) {
+            transferJob?.cancel()
+            scope.launch {
+                block()
+            }.also { transferJob = it }
+        }
+        try {
+            job.join()
+        } finally {
+            synchronized(transferJobLock) {
+                if (transferJob === job) {
+                    transferJob = null
+                }
+            }
+        }
+    }
+
+    private suspend fun runImport(
+        model: LocalModel,
+        root: String,
+        sourceAbsolutePath: String,
+        sourceLength: Long,
+    ) {
         val targetPath = LocalModelFiles.join(root, model.id, model.fileName)
         val tempPath = "$targetPath.partial"
         LocalModelFiles.ensureDirectory(LocalModelFiles.join(root, model.id))
@@ -134,6 +187,7 @@ class LocalModelRepository(
             modelId = model.id,
             bytesReceived = 0L,
             totalBytes = sourceLength.coerceAtLeast(1L),
+            isImport = true,
         )
 
         try {
@@ -144,6 +198,7 @@ class LocalModelRepository(
             val sink = LocalModelFiles.openSink(tempPath, append = false)
             try {
                 while (true) {
+                    currentCoroutineContext().ensureActive()
                     val read = source.read(buffer, 0, buffer.size)
                     if (read < 0) break
                     if (read == 0) continue
@@ -154,6 +209,7 @@ class LocalModelRepository(
                         modelId = model.id,
                         bytesReceived = received,
                         totalBytes = sourceLength.coerceAtLeast(1L),
+                        isImport = true,
                     )
                 }
             } finally {
@@ -168,36 +224,26 @@ class LocalModelRepository(
             throw e
         } catch (e: Exception) {
             LocalModelFiles.deleteRecursively(tempPath)
-            val kind = classifyTransferError(e)
+            val classified = classifyTransferError(e)
+            val kind = when (classified) {
+                LocalModelDownloadErrorKind.DISK,
+                LocalModelDownloadErrorKind.HASH,
+                -> classified
+                else -> LocalModelDownloadErrorKind.IMPORT
+            }
             DebugLog.e(TAG, "Import failed for ${model.id} ($kind)", e)
             _downloadState.value = LocalModelDownloadState.Error(model.id, kind)
+        } finally {
+            maybeDeleteTransientImportSource(sourceAbsolutePath)
         }
     }
-
-    override fun devicePerformance(modelId: String, contextTokens: Int): DevicePerformance {
-        val model = catalog.find { it.id == modelId }
-            ?: return DevicePerformance.POOR
-        val estimated = estimateGpuMemoryMb(model, contextTokens)
-        return calculateDevicePerformance(deviceResources.totalMemoryBytes(), estimated)
-    }
-
-    override fun hasAvx2Support(): Boolean = deviceResources.hasAvx2Support()
 
     private suspend fun runDownload(model: LocalModel, root: String) {
         val targetPath = LocalModelFiles.join(root, model.id, model.fileName)
         val tempPath = "$targetPath.partial"
         LocalModelFiles.ensureDirectory(LocalModelFiles.join(root, model.id))
 
-        var resumeFrom = if (LocalModelFiles.exists(tempPath)) {
-            LocalModelFiles.length(tempPath)
-        } else {
-            0L
-        }
-        if (resumeFrom > model.sizeBytes) {
-            DebugLog.w(TAG, "Partial larger than catalog size for ${model.id}; restarting")
-            LocalModelFiles.deleteRecursively(tempPath)
-            resumeFrom = 0L
-        }
+        var resumeFrom = clampedPartialLength(tempPath, model.sizeBytes)
 
         var hasher = Sha256Hasher()
         if (resumeFrom > 0L) {
@@ -208,6 +254,7 @@ class LocalModelRepository(
             modelId = model.id,
             bytesReceived = resumeFrom,
             totalBytes = model.sizeBytes,
+            isImport = false,
         )
 
         if (resumeFrom == model.sizeBytes && resumeFrom > 0L) {
@@ -244,6 +291,7 @@ class LocalModelRepository(
                                 modelId = model.id,
                                 bytesReceived = 0L,
                                 totalBytes = model.sizeBytes,
+                                isImport = false,
                             )
                         }
                     }
@@ -259,6 +307,7 @@ class LocalModelRepository(
                 val sink = LocalModelFiles.openSink(tempPath, append = append)
                 try {
                     while (!channel.isClosedForRead) {
+                        currentCoroutineContext().ensureActive()
                         val read = channel.readAvailable(buffer, 0, buffer.size)
                         if (read == -1) break
                         if (read > 0) {
@@ -269,6 +318,7 @@ class LocalModelRepository(
                                 modelId = model.id,
                                 bytesReceived = received,
                                 totalBytes = model.sizeBytes,
+                                isImport = false,
                             )
                         }
                     }
@@ -327,8 +377,26 @@ class LocalModelRepository(
         }
     }
 
+    private fun clampedPartialLength(tempPath: String, sizeBytes: Long): Long {
+        if (!LocalModelFiles.exists(tempPath)) return 0L
+        val length = LocalModelFiles.length(tempPath)
+        if (length > sizeBytes) {
+            DebugLog.w(TAG, "Partial larger than catalog size; restarting")
+            LocalModelFiles.deleteRecursively(tempPath)
+            return 0L
+        }
+        return length
+    }
+
     private fun partialLength(tempPath: String): Long =
         if (LocalModelFiles.exists(tempPath)) LocalModelFiles.length(tempPath) else 0L
+
+    private fun maybeDeleteTransientImportSource(path: String) {
+        // Android SAF copies land under cacheDir/litert_import/ — drop after import attempt.
+        if (path.contains("/litert_import/") || path.contains("\\litert_import\\")) {
+            LocalModelFiles.deleteRecursively(path)
+        }
+    }
 
     private fun modelRoot(): String = modelRootOverride ?: deviceResources.modelStorageDirectory()
 

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepositoryTest.kt
@@ -85,7 +85,7 @@ class LocalModelRepositoryTest {
     }
 
     @Test
-    fun cancelDownload_abortsInFlightDownload() = runTest {
+    fun cancelDownload_keepsPartialForResume() = runTest {
         val model = testModel(sha256 = payloadSha256, sizeBytes = payload.size.toLong())
         val root = newRoot()
         val engine = MockEngine {
@@ -126,7 +126,8 @@ class LocalModelRepositoryTest {
         assertFalse(repo.isReady(model.id))
         val expectedPath = LocalModelFiles.join(root, model.id, model.fileName)
         assertFalse(LocalModelFiles.exists(expectedPath))
-        assertFalse(LocalModelFiles.exists("$expectedPath.partial"))
+        // No bytes written before cancel (engine still delaying) — partial may be absent.
+        // Behavior under test: cancel leaves Idle and does not mark ready.
     }
 
     @Test
@@ -146,6 +147,165 @@ class LocalModelRepositoryTest {
         assertIs<LocalModelDownloadState.Error>(state)
         assertEquals(LocalModelDownloadErrorKind.DISK, state.kind)
         assertFalse(repo.isReady(model.id))
+    }
+
+    @Test
+    fun download_resumesPartialWithHttp206() = runTest {
+        val full = "hello".encodeToByteArray()
+        val prefix = full.copyOfRange(0, 2)
+        val suffix = full.copyOfRange(2, full.size)
+        val model = testModel(sha256 = payloadSha256, sizeBytes = full.size.toLong())
+        val root = newRoot()
+        val tempPath = LocalModelFiles.join(root, model.id, model.fileName) + ".partial"
+        LocalModelFiles.ensureDirectory(LocalModelFiles.join(root, model.id))
+        val sink = LocalModelFiles.openSink(tempPath, append = false)
+        sink.write(prefix, 0, prefix.size)
+        sink.close()
+
+        var sawRange = false
+        val engine = MockEngine { request ->
+            val range = request.headers[HttpHeaders.Range]
+            sawRange = range == "bytes=2-"
+            respond(
+                content = suffix,
+                status = HttpStatusCode.PartialContent,
+                headers = headersOf(
+                    HttpHeaders.ContentType to listOf("application/octet-stream"),
+                    HttpHeaders.ContentRange to listOf("bytes 2-4/${full.size}"),
+                ),
+            )
+        }
+        val client = HttpClient(engine) { expectSuccess = false }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scopes += scope
+        val repo = LocalModelRepository(
+            deviceResources = FakeDeviceResources(
+                freeDiskBytes = model.sizeBytes + diskBufferBytes + 1,
+                modelStorageDirectory = root,
+            ),
+            httpClient = client,
+            scope = scope,
+            catalog = listOf(model),
+            modelRootOverride = root,
+        )
+
+        repo.download(model.id)
+
+        assertTrue(sawRange)
+        assertTrue(repo.isReady(model.id))
+        assertIs<LocalModelDownloadState.Succeeded>(repo.downloadState.value)
+        assertFalse(LocalModelFiles.exists(tempPath))
+    }
+
+    @Test
+    fun download_restartsWhenServerIgnoresRange() = runTest {
+        val model = testModel(sha256 = payloadSha256, sizeBytes = payload.size.toLong())
+        val root = newRoot()
+        val tempPath = LocalModelFiles.join(root, model.id, model.fileName) + ".partial"
+        LocalModelFiles.ensureDirectory(LocalModelFiles.join(root, model.id))
+        val sink = LocalModelFiles.openSink(tempPath, append = false)
+        sink.write(byteArrayOf(0x00, 0x01), 0, 2)
+        sink.close()
+
+        val engine = MockEngine {
+            respond(
+                content = payload,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/octet-stream"),
+            )
+        }
+        val client = HttpClient(engine) { expectSuccess = false }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scopes += scope
+        val repo = LocalModelRepository(
+            deviceResources = FakeDeviceResources(
+                freeDiskBytes = model.sizeBytes + diskBufferBytes + 1,
+                modelStorageDirectory = root,
+            ),
+            httpClient = client,
+            scope = scope,
+            catalog = listOf(model),
+            modelRootOverride = root,
+        )
+
+        repo.download(model.id)
+
+        assertTrue(repo.isReady(model.id))
+        assertIs<LocalModelDownloadState.Succeeded>(repo.downloadState.value)
+    }
+
+    @Test
+    fun importFromPath_verifiesSha_andMarksReady() = runTest {
+        val model = testModel(sha256 = payloadSha256, sizeBytes = payload.size.toLong())
+        val root = newRoot()
+        val source = LocalModelFiles.join(root, "import-source.litertlm")
+        val sink = LocalModelFiles.openSink(source, append = false)
+        sink.write(payload, 0, payload.size)
+        sink.close()
+
+        val repo = createRepo(
+            catalog = listOf(model),
+            modelRoot = root,
+            freeDiskBytes = model.sizeBytes + diskBufferBytes + 1,
+            responseBody = ByteArray(0),
+        )
+
+        repo.importFromPath(model.id, source)
+
+        assertTrue(repo.isReady(model.id))
+        assertIs<LocalModelDownloadState.Succeeded>(repo.downloadState.value)
+    }
+
+    @Test
+    fun importFromPath_rejectsHashMismatch() = runTest {
+        val model = testModel(
+            sha256 = "0000000000000000000000000000000000000000000000000000000000000000",
+            sizeBytes = payload.size.toLong(),
+        )
+        val root = newRoot()
+        val source = LocalModelFiles.join(root, "bad-import.litertlm")
+        val sink = LocalModelFiles.openSink(source, append = false)
+        sink.write(payload, 0, payload.size)
+        sink.close()
+
+        val repo = createRepo(
+            catalog = listOf(model),
+            modelRoot = root,
+            freeDiskBytes = model.sizeBytes + diskBufferBytes + 1,
+            responseBody = ByteArray(0),
+        )
+
+        repo.importFromPath(model.id, source)
+
+        val state = repo.downloadState.value
+        assertIs<LocalModelDownloadState.Error>(state)
+        assertEquals(LocalModelDownloadErrorKind.HASH, state.kind)
+        assertFalse(repo.isReady(model.id))
+    }
+
+    @Test
+    fun classifyTransferError_mapsTimeoutAndHttp() {
+        class SocketTimeoutException(message: String) : Exception(message)
+        class IOException(message: String) : Exception(message)
+
+        assertEquals(
+            LocalModelDownloadErrorKind.TIMEOUT,
+            LocalModelRepository.classifyTransferError(
+                RuntimeException(SocketTimeoutException("read timed out")),
+            ),
+        )
+        assertEquals(
+            LocalModelDownloadErrorKind.NETWORK,
+            LocalModelRepository.classifyTransferError(
+                IllegalStateException("Download failed with HTTP 503"),
+            ),
+        )
+        assertEquals(
+            LocalModelDownloadErrorKind.DISK,
+            LocalModelRepository.classifyTransferError(
+                IOException("No space left on device"),
+            ),
+        )
     }
 
     private fun newRoot(): String {

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepositoryTest.kt
@@ -85,14 +85,21 @@ class LocalModelRepositoryTest {
     }
 
     @Test
-    fun cancelDownload_keepsPartialForResume() = runTest {
+    fun cancelDownload_keepsNonEmptyPartialForResume() = runTest {
         val model = testModel(sha256 = payloadSha256, sizeBytes = payload.size.toLong())
         val root = newRoot()
+        val tempPath = LocalModelFiles.join(root, model.id, model.fileName) + ".partial"
+        LocalModelFiles.ensureDirectory(LocalModelFiles.join(root, model.id))
+        val prefix = payload.copyOfRange(0, 2)
+        val sink = LocalModelFiles.openSink(tempPath, append = false)
+        sink.write(prefix, 0, prefix.size)
+        sink.close()
+
         val engine = MockEngine {
             delay(10_000)
             respond(
-                content = payload,
-                status = HttpStatusCode.OK,
+                content = payload.copyOfRange(2, payload.size),
+                status = HttpStatusCode.PartialContent,
                 headers = headersOf(HttpHeaders.ContentType, "application/octet-stream"),
             )
         }
@@ -124,14 +131,44 @@ class LocalModelRepositoryTest {
 
         assertIs<LocalModelDownloadState.Idle>(repo.downloadState.value)
         assertFalse(repo.isReady(model.id))
-        val expectedPath = LocalModelFiles.join(root, model.id, model.fileName)
-        assertFalse(LocalModelFiles.exists(expectedPath))
-        // No bytes written before cancel (engine still delaying) — partial may be absent.
-        // Behavior under test: cancel leaves Idle and does not mark ready.
+        assertTrue(LocalModelFiles.exists(tempPath))
+        assertEquals(2L, LocalModelFiles.length(tempPath))
     }
 
     @Test
-    fun download_failsWhenDiskBelowSizePlus500Mb() = runTest {
+    fun download_diskCheckCreditsExistingPartial() = runTest {
+        val model = testModel(sha256 = payloadSha256, sizeBytes = 1_000L)
+        val root = newRoot()
+        val tempPath = LocalModelFiles.join(root, model.id, model.fileName) + ".partial"
+        LocalModelFiles.ensureDirectory(LocalModelFiles.join(root, model.id))
+        val sink = LocalModelFiles.openSink(tempPath, append = false)
+        val prefix = ByteArray(900) { 1 }
+        sink.write(prefix, 0, prefix.size)
+        sink.close()
+
+        val remaining = model.sizeBytes - 900L
+        val repo = createRepo(
+            catalog = listOf(model),
+            modelRoot = root,
+            // Enough for remainder + buffer, but not full size + buffer.
+            freeDiskBytes = remaining + diskBufferBytes,
+            responseBody = payload,
+        )
+
+        // Would have failed under the old full-size check; with credit it proceeds
+        // (may then fail HASH because suffix isn't real — only assert not DISK).
+        repo.download(model.id)
+
+        val state = repo.downloadState.value
+        assertFalse(
+            state is LocalModelDownloadState.Error &&
+                state.kind == LocalModelDownloadErrorKind.DISK,
+            "resume disk check should credit existing partial bytes",
+        )
+    }
+
+    @Test
+    fun download_failsWhenDiskBelowRemainingPlus500Mb() = runTest {
         val model = testModel(sha256 = payloadSha256, sizeBytes = 1_000L)
         val root = newRoot()
         val repo = createRepo(
@@ -281,6 +318,69 @@ class LocalModelRepositoryTest {
         assertIs<LocalModelDownloadState.Error>(state)
         assertEquals(LocalModelDownloadErrorKind.HASH, state.kind)
         assertFalse(repo.isReady(model.id))
+    }
+
+    @Test
+    fun cancelImport_viaSharedTransferJob() = runTest {
+        val large = ByteArray(2 * 1024 * 1024) { it.toByte() }
+        val model = testModel(
+            sha256 = "0000000000000000000000000000000000000000000000000000000000000000",
+            sizeBytes = large.size.toLong(),
+        )
+        val root = newRoot()
+        val source = LocalModelFiles.join(root, "slow-import.litertlm")
+        val sink = LocalModelFiles.openSink(source, append = false)
+        sink.write(large, 0, large.size)
+        sink.close()
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scopes += scope
+        val repo = LocalModelRepository(
+            deviceResources = FakeDeviceResources(
+                freeDiskBytes = model.sizeBytes + diskBufferBytes + 1,
+                modelStorageDirectory = root,
+            ),
+            httpClient = HttpClient(MockEngine {
+                respond(ByteArray(0), HttpStatusCode.OK)
+            }) { expectSuccess = false },
+            scope = scope,
+            catalog = listOf(model),
+            modelRootOverride = root,
+        )
+
+        val importTask = scope.launch { repo.importFromPath(model.id, source) }
+        var attempts = 0
+        while (repo.downloadState.value !is LocalModelDownloadState.Downloading && attempts < 200) {
+            delay(10)
+            attempts++
+        }
+        val downloading = repo.downloadState.value
+        assertIs<LocalModelDownloadState.Downloading>(downloading)
+        assertTrue(downloading.isImport)
+
+        repo.cancelDownload()
+        importTask.join()
+
+        assertIs<LocalModelDownloadState.Idle>(repo.downloadState.value)
+        assertFalse(repo.isReady(model.id))
+    }
+
+    @Test
+    fun notifyTransferError_setsErrorState() = runTest {
+        val model = testModel(sha256 = payloadSha256, sizeBytes = 1)
+        val root = newRoot()
+        val repo = createRepo(
+            catalog = listOf(model),
+            modelRoot = root,
+            freeDiskBytes = Long.MAX_VALUE,
+            responseBody = ByteArray(0),
+        )
+
+        repo.notifyTransferError(model.id, LocalModelDownloadErrorKind.IMPORT)
+
+        val state = repo.downloadState.value
+        assertIs<LocalModelDownloadState.Error>(state)
+        assertEquals(LocalModelDownloadErrorKind.IMPORT, state.kind)
     }
 
     @Test

--- a/shared/src/jvmMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelFiles.jvm.kt
+++ b/shared/src/jvmMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelFiles.jvm.kt
@@ -1,6 +1,7 @@
 package io.github.leogallego.ansiblejane.assistant.local
 
 import java.io.File
+import java.io.FileInputStream
 import java.io.FileOutputStream
 
 internal actual object LocalModelFiles {
@@ -32,10 +33,10 @@ internal actual object LocalModelFiles {
         }
     }
 
-    actual fun openSink(path: String): ModelFileSink {
+    actual fun openSink(path: String, append: Boolean): ModelFileSink {
         val file = File(path)
         file.parentFile?.mkdirs()
-        val out = FileOutputStream(file)
+        val out = FileOutputStream(file, append)
         return object : ModelFileSink {
             override fun write(bytes: ByteArray, offset: Int, length: Int) {
                 out.write(bytes, offset, length)
@@ -43,6 +44,18 @@ internal actual object LocalModelFiles {
 
             override fun close() {
                 out.close()
+            }
+        }
+    }
+
+    actual fun openSource(path: String): ModelFileSource {
+        val input = FileInputStream(File(path))
+        return object : ModelFileSource {
+            override fun read(bytes: ByteArray, offset: Int, length: Int): Int =
+                input.read(bytes, offset, length)
+
+            override fun close() {
+                input.close()
             }
         }
     }


### PR DESCRIPTION
## Summary
- Dedicated `litertDownload` HttpClient with infinite request timeout and 120s socket idle timeout so multi-GB HF streams no longer die on OkHttp’s ~10s default (root cause of mid-download “Download failed” on phones).
- Resume via `Range` / HTTP 206 on `.partial` files; cancel/timeout/network keep the partial. CMP-safe size (`3.4 GB`) and progress (`42%`) labels; distinct TIMEOUT / NETWORK / DISK / HASH errors.
- Import existing `.litertlm` (SAF / file picker) with catalog SHA-256; optional “Use existing file” when the catalog filename is already in Downloads.

Closes #469

## Test plan
- [x] `./gradlew --no-daemon :shared:jvmTest --tests '*LocalModelRepositoryTest*'`
- [x] `./gradlew --no-daemon :composeApp:desktopTest --tests '*LocalModelUiMapperTest*'`
- [x] `./gradlew --no-daemon :composeApp:compileAndroidMain`
- [ ] Manual (phone Wi‑Fi): start E4B download → survives brief stalls; size shows e.g. `3.4 GB`; progress % updates
- [ ] Manual: cancel mid-download → tap Download again → resumes (no full restart) when CDN returns 206
- [ ] Manual: Import file / Use existing from Downloads → hash OK → Ready → Activate
- [ ] Manual: force airplane mode mid-download → clear NETWORK/TIMEOUT message, not generic only

## Research notes
- HF Hub + CDN: `Accept-Ranges: bytes`; `Range: bytes=0-0` → 206 (verified 2026-08-08).
- Out of scope: AICore (#468), #264 PR2, Kai private filesDir.

Assisted-by: Cursor (Grok 4.5)