### PR TITLE
feat(assistant): configurable on-device LiteRT context window (#470)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -370,6 +370,8 @@
     <string name="agent_local_use_existing">Use existing file</string>
     <string name="agent_local_importing">Importing… %1$s</string>
     <string name="agent_local_import_failed">Could not read the selected model file.</string>
+    <string name="agent_local_context_size">Context: %1$s</string>
+    <string name="agent_local_context_guidance">4K default; 8K–16K OK on ≥12 GB RAM; 32K may be tight or slower.</string>
 
     <!-- ToolsTab.kt -->
     <string name="tools_section_mcp_servers">MCP Servers</string>

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantCapability.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantCapability.kt
@@ -4,7 +4,7 @@ import io.github.leogallego.ansiblejane.assistant.data.KnownProvider
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.assistant.engine.ModelCapability
 import io.github.leogallego.ansiblejane.assistant.engine.ModelCapabilityResolver
-import io.github.leogallego.ansiblejane.assistant.local.LOCAL_MODEL_CATALOG
+import io.github.leogallego.ansiblejane.assistant.local.resolveOnDeviceContextTokens
 
 /**
  * Resolves [ModelCapability] from the active LLM config (#264 / #453).
@@ -21,6 +21,9 @@ fun resolveCapabilityForConfig(config: LlmProviderConfig): ModelCapability = whe
         )
 }
 
-/** On-device context budget from catalog [defaultContextTokens]; unknown modelId → 4096. */
+/**
+ * On-device ChatEngine context budget from user-selected [LlmProviderConfig.OnDevice.contextTokens]
+ * (0 / missing → catalog default), clamped to catalog bounds (#470).
+ */
 fun resolveContextCharsForConfig(config: LlmProviderConfig.OnDevice): Int =
-    LOCAL_MODEL_CATALOG.find { it.id == config.modelId }?.defaultContextTokens ?: 4_096
+    resolveOnDeviceContextTokens(config.modelId, config.contextTokens)

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt
@@ -455,7 +455,8 @@ class AssistantViewModel(
     }
 
     private fun providerCacheIdentity(config: LlmProviderConfig): String = when (config) {
-        is LlmProviderConfig.OnDevice -> "local|${config.modelId}"
+        is LlmProviderConfig.OnDevice ->
+            "local|${config.modelId}|${resolveContextCharsForConfig(config)}"
         is LlmProviderConfig.OpenAiCompatible ->
             "${config.url}|${config.model}|${config.apiKey}"
     }

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUi.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUi.kt
@@ -21,6 +21,8 @@ data class LocalModelUi(
     val fileName: String,
     val sizeBytes: Long,
     val isRecommended: Boolean,
+    val defaultContextTokens: Int,
+    val maxContextTokens: Int,
 )
 
 enum class DevicePerformanceUi {
@@ -53,6 +55,8 @@ fun LocalModel.toUi(): LocalModelUi = LocalModelUi(
     fileName = fileName,
     sizeBytes = sizeBytes,
     isRecommended = isRecommended,
+    defaultContextTokens = defaultContextTokens,
+    maxContextTokens = maxContextTokens,
 )
 
 fun DevicePerformance.toUi(): DevicePerformanceUi = when (this) {

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsUiState.kt
@@ -45,6 +45,7 @@ sealed interface SettingsUiState {
         val localModelCatalog: List<LocalModelUi> = emptyList(),
         val localDownloadState: LocalModelDownloadUiState = LocalModelDownloadUiState.Idle,
         val localReadyIds: Set<String> = emptySet(),
+        val localModelContextTokens: Map<String, Int> = emptyMap(),
         val hasAvx2Support: Boolean = true,
         // MCP Servers
         val mcpEnabled: Boolean = false,

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -63,6 +63,9 @@ class SettingsViewModel(
             val configs = assistantRepository.loadAllLlmConfigs()
             val activeConfig = assistantRepository.loadLlmConfig()
             val initialActiveKey = assistantRepository.activeProviderKeyFlow.first()
+            // Snapshot before combine: a separate collector can emit while still Loading, and
+            // distinctUntilChanged would not replay — Ready would then miss persisted tokens.
+            val initialLocalContextTokens = assistantRepository.modelContextTokensFlow.first()
 
             // Unfiltered on purpose: Settings enable/disable UI lists every registered
             // tool. Chat routing applies auditor filtering via getRoutableTools / getToolsForQuery.
@@ -110,7 +113,8 @@ class SettingsViewModel(
                 val preservedLocalCatalog = (current as? SettingsUiState.Ready)?.localModelCatalog
                     ?: localModelCatalog
                 val preservedLocalContextTokens =
-                    (current as? SettingsUiState.Ready)?.localModelContextTokens ?: emptyMap()
+                    (current as? SettingsUiState.Ready)?.localModelContextTokens
+                        ?: initialLocalContextTokens
                 val preservedAvx2 = (current as? SettingsUiState.Ready)?.hasAvx2Support
                     ?: hasAvx2Support
 

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.assistant.data.ModelFetcher
 import io.github.leogallego.ansiblejane.assistant.local.ILocalModelRepository
 import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadErrorKind
+import io.github.leogallego.ansiblejane.assistant.local.resolveOnDeviceContextTokens
 import io.github.leogallego.ansiblejane.assistant.presentation.ModelFetchState
 import io.github.leogallego.ansiblejane.data.ITokenManager
 import io.github.leogallego.ansiblejane.data.IToolManifestRepository
@@ -108,6 +109,8 @@ class SettingsViewModel(
                     ?: computeLocalReadyIds()
                 val preservedLocalCatalog = (current as? SettingsUiState.Ready)?.localModelCatalog
                     ?: localModelCatalog
+                val preservedLocalContextTokens =
+                    (current as? SettingsUiState.Ready)?.localModelContextTokens ?: emptyMap()
                 val preservedAvx2 = (current as? SettingsUiState.Ready)?.hasAvx2Support
                     ?: hasAvx2Support
 
@@ -145,6 +148,7 @@ class SettingsViewModel(
                     localModelCatalog = preservedLocalCatalog,
                     localDownloadState = preservedLocalDownload,
                     localReadyIds = preservedLocalReadyIds,
+                    localModelContextTokens = preservedLocalContextTokens,
                     hasAvx2Support = preservedAvx2,
                     mcpEnabled = active?.mcpEnabled ?: false,
                     mcpServers = active?.mcpServerUrls ?: emptyList(),
@@ -196,6 +200,12 @@ class SettingsViewModel(
                 .collect { downloadUi ->
                     updateReady { copy(localDownloadState = downloadUi) }
                 }
+        }
+
+        viewModelScope.launch {
+            assistantRepository.modelContextTokensFlow.collect { tokens ->
+                updateReady { copy(localModelContextTokens = tokens) }
+            }
         }
     }
 
@@ -397,7 +407,12 @@ class SettingsViewModel(
 
     fun selectLocalModel(modelId: String) {
         viewModelScope.launch {
-            val config = LlmProviderConfig.OnDevice(modelId = modelId)
+            val stored = assistantRepository.getModelContextTokens(modelId)
+            val contextTokens = resolveOnDeviceContextTokens(modelId, stored ?: 0)
+            val config = LlmProviderConfig.OnDevice(
+                modelId = modelId,
+                contextTokens = contextTokens,
+            )
             val current = assistantRepository.loadAllLlmConfigs().toMutableMap()
             current[KnownProvider.LOCAL.name] = config
             assistantRepository.saveAllLlmConfigs(current)
@@ -405,10 +420,25 @@ class SettingsViewModel(
         }
     }
 
-    fun localModelPerformance(modelId: String): DevicePerformanceUi {
-        val model = localModelRepository.catalog().find { it.id == modelId }
-        val contextTokens = model?.defaultContextTokens ?: 4_096
-        return localModelRepository.devicePerformance(modelId, contextTokens).toUi()
+    fun setLocalModelContextTokens(modelId: String, contextTokens: Int) {
+        viewModelScope.launch {
+            val clamped = resolveOnDeviceContextTokens(modelId, contextTokens)
+            assistantRepository.setModelContextTokens(modelId, clamped)
+            val current = assistantRepository.loadAllLlmConfigs().toMutableMap()
+            val existing = current[KnownProvider.LOCAL.name] as? LlmProviderConfig.OnDevice
+            if (existing != null && existing.modelId == modelId) {
+                current[KnownProvider.LOCAL.name] = existing.copy(contextTokens = clamped)
+                assistantRepository.saveAllLlmConfigs(current)
+            }
+        }
+    }
+
+    fun localModelPerformance(modelId: String, contextTokens: Int? = null): DevicePerformanceUi {
+        val resolved = contextTokens
+            ?: (uiState.value as? SettingsUiState.Ready)?.localModelContextTokens?.get(modelId)
+            ?: 0
+        val tokens = resolveOnDeviceContextTokens(modelId, resolved)
+        return localModelRepository.devicePerformance(modelId, tokens).toUi()
     }
 
     private fun computeLocalReadyIds(): Set<String> =

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/AgentTab.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/AgentTab.kt
@@ -55,8 +55,9 @@ fun AgentTab(
     localModelCatalog: List<LocalModelUi> = emptyList(),
     localDownloadState: LocalModelDownloadUiState = LocalModelDownloadUiState.Idle,
     localReadyIds: Set<String> = emptySet(),
+    localModelContextTokens: Map<String, Int> = emptyMap(),
     hasAvx2Support: Boolean = true,
-    onLocalModelPerformance: (String) -> DevicePerformanceUi = { DevicePerformanceUi.POOR },
+    onLocalModelPerformance: (String, Int) -> DevicePerformanceUi = { _, _ -> DevicePerformanceUi.POOR },
     onDownloadLocalModel: (String) -> Unit = {},
     onCancelLocalModelDownload: () -> Unit = {},
     onDeleteLocalModel: (String) -> Unit = {},
@@ -64,6 +65,7 @@ fun AgentTab(
     onImportLocalModel: (modelId: String, absolutePath: String) -> Unit = { _, _ -> },
     onImportLocalModelPreparing: (modelId: String) -> Unit = {},
     onImportLocalModelPickFailed: (modelId: String) -> Unit = {},
+    onLocalModelContextTokensChange: (String, Int) -> Unit = { _, _ -> },
     onClearHistory: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -111,6 +113,7 @@ fun AgentTab(
                     catalog = localModelCatalog,
                     downloadState = localDownloadState,
                     readyIds = localReadyIds,
+                    modelContextTokens = localModelContextTokens,
                     hasAvx2Support = hasAvx2Support,
                     onPerformance = onLocalModelPerformance,
                     onToggleExpand = {
@@ -126,6 +129,7 @@ fun AgentTab(
                     onImportFromPath = onImportLocalModel,
                     onImportPreparing = onImportLocalModelPreparing,
                     onImportPickFailed = onImportLocalModelPickFailed,
+                    onContextTokensChange = onLocalModelContextTokensChange,
                 )
             } else {
                 val providerConfig = savedConfigs[provider.name] as? LlmProviderConfig.OpenAiCompatible

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/OnDeviceProviderCard.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/OnDeviceProviderCard.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -46,6 +47,8 @@ import aapremotecontrol.composeapp.generated.resources.agent_local_activate
 import aapremotecontrol.composeapp.generated.resources.agent_local_active
 import aapremotecontrol.composeapp.generated.resources.agent_local_avx_unsupported
 import aapremotecontrol.composeapp.generated.resources.agent_local_cancel
+import aapremotecontrol.composeapp.generated.resources.agent_local_context_guidance
+import aapremotecontrol.composeapp.generated.resources.agent_local_context_size
 import aapremotecontrol.composeapp.generated.resources.agent_local_delete
 import aapremotecontrol.composeapp.generated.resources.agent_local_download
 import aapremotecontrol.composeapp.generated.resources.agent_local_download_progress
@@ -72,7 +75,10 @@ import io.github.leogallego.ansiblejane.presentation.settings.formatLocalModelSi
 import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlin.math.roundToInt
 import org.jetbrains.compose.resources.stringResource
+
+private const val CONTEXT_TOKEN_STEP = 1_024
 
 @Composable
 internal fun LocalProviderCard(
@@ -83,8 +89,9 @@ internal fun LocalProviderCard(
     catalog: List<LocalModelUi>,
     downloadState: LocalModelDownloadUiState,
     readyIds: Set<String>,
+    modelContextTokens: Map<String, Int>,
     hasAvx2Support: Boolean,
-    onPerformance: (String) -> DevicePerformanceUi,
+    onPerformance: (String, Int) -> DevicePerformanceUi,
     onToggleExpand: () -> Unit,
     onDownload: (String) -> Unit,
     onCancelDownload: () -> Unit,
@@ -93,6 +100,7 @@ internal fun LocalProviderCard(
     onImportFromPath: (modelId: String, absolutePath: String) -> Unit,
     onImportPreparing: (modelId: String) -> Unit,
     onImportPickFailed: (modelId: String) -> Unit,
+    onContextTokensChange: (String, Int) -> Unit,
 ) {
     val border = if (isActive) {
         BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
@@ -180,12 +188,14 @@ internal fun LocalProviderCard(
                     }
 
                     catalog.forEach { model ->
+                        val storedTokens = modelContextTokens[model.id] ?: model.defaultContextTokens
                         LocalModelRow(
                             model = model,
                             isReady = model.id in readyIds,
                             isSelected = isActive && config?.modelId == model.id,
                             downloadState = downloadState,
-                            performance = onPerformance(model.id),
+                            storedContextTokens = storedTokens,
+                            onPerformance = { tokens -> onPerformance(model.id, tokens) },
                             actionsEnabled = hasAvx2Support,
                             onDownload = { onDownload(model.id) },
                             onCancelDownload = onCancelDownload,
@@ -194,6 +204,9 @@ internal fun LocalProviderCard(
                             onImportFromPath = { path -> onImportFromPath(model.id, path) },
                             onImportPreparing = { onImportPreparing(model.id) },
                             onImportPickFailed = { onImportPickFailed(model.id) },
+                            onContextTokensChange = { tokens ->
+                                onContextTokensChange(model.id, tokens)
+                            },
                         )
                     }
                 }
@@ -208,7 +221,8 @@ internal fun LocalModelRow(
     isReady: Boolean,
     isSelected: Boolean,
     downloadState: LocalModelDownloadUiState,
-    performance: DevicePerformanceUi,
+    storedContextTokens: Int,
+    onPerformance: (Int) -> DevicePerformanceUi,
     actionsEnabled: Boolean,
     onDownload: () -> Unit,
     onCancelDownload: () -> Unit,
@@ -217,6 +231,7 @@ internal fun LocalModelRow(
     onImportFromPath: (absolutePath: String) -> Unit,
     onImportPreparing: () -> Unit,
     onImportPickFailed: () -> Unit,
+    onContextTokensChange: (Int) -> Unit,
 ) {
     val downloading = downloadState as? LocalModelDownloadUiState.Downloading
     val isDownloadingThis = downloading?.modelId == model.id
@@ -258,6 +273,18 @@ internal fun LocalModelRow(
         },
     )
     val sizeLabel = remember(model.sizeBytes) { formatLocalModelSizeGb(model.sizeBytes) }
+
+    val steps = ((model.maxContextTokens - model.defaultContextTokens) / CONTEXT_TOKEN_STEP)
+        .coerceAtLeast(0)
+    var contextSliderValue by remember(storedContextTokens, model.id) {
+        mutableStateOf(
+            ((storedContextTokens - model.defaultContextTokens).coerceAtLeast(0) / CONTEXT_TOKEN_STEP)
+                .toFloat()
+                .coerceIn(0f, steps.toFloat()),
+        )
+    }
+    val contextTokens = model.defaultContextTokens + (contextSliderValue.roundToInt() * CONTEXT_TOKEN_STEP)
+    val performance = onPerformance(contextTokens)
 
     Column(
         modifier = Modifier
@@ -328,7 +355,34 @@ internal fun LocalModelRow(
             }
         }
 
-        if (downloading != null && downloading.modelId == model.id) {
+        if (steps > 0) {
+            Text(
+                text = stringResource(
+                    Res.string.agent_local_context_size,
+                    "${contextTokens / 1024}K",
+                ),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Slider(
+                value = contextSliderValue,
+                onValueChange = { contextSliderValue = it },
+                onValueChangeFinished = { onContextTokensChange(contextTokens) },
+                valueRange = 0f..steps.toFloat(),
+                steps = (steps - 1).coerceAtLeast(0),
+                enabled = actionsEnabled,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("slider_local_context_${model.id}"),
+            )
+            Text(
+                text = stringResource(Res.string.agent_local_context_guidance),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (isDownloadingThis && downloading != null) {
             val progress = if (downloading.totalBytes > 0) {
                 (downloading.bytesReceived.toFloat() / downloading.totalBytes.toFloat())
                     .coerceIn(0f, 1f)

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/SettingsScreen.kt
@@ -77,7 +77,9 @@ fun SettingsScreen(
                     onSwitchActiveProvider = { viewModel.switchActiveProvider(it) },
                     onFetchModels = { url, key -> viewModel.fetchAvailableModels(url, key) },
                     onClearFetchedModels = { viewModel.clearFetchedModels() },
-                    onLocalModelPerformance = { viewModel.localModelPerformance(it) },
+                    onLocalModelPerformance = { modelId, tokens ->
+                        viewModel.localModelPerformance(modelId, tokens)
+                    },
                     onDownloadLocalModel = { viewModel.downloadLocalModel(it) },
                     onCancelLocalModelDownload = { viewModel.cancelLocalModelDownload() },
                     onDeleteLocalModel = { viewModel.deleteLocalModel(it) },
@@ -87,6 +89,9 @@ fun SettingsScreen(
                     },
                     onImportLocalModelPreparing = { viewModel.markLocalModelImportPreparing(it) },
                     onImportLocalModelPickFailed = { viewModel.reportLocalModelImportPickFailed(it) },
+                    onLocalModelContextTokensChange = { modelId, tokens ->
+                        viewModel.setLocalModelContextTokens(modelId, tokens)
+                    },
                     onToggleMcp = { viewModel.toggleMcpEnabled(it) },
                     onAddMcpServer = { url, label, toolset, headers, useInstanceAuth ->
                         viewModel.addMcpServer(url, label, toolset, headers, useInstanceAuth)
@@ -131,7 +136,7 @@ private fun SettingsContent(
     onSwitchActiveProvider: (String) -> Unit,
     onFetchModels: (String, String?) -> Unit,
     onClearFetchedModels: () -> Unit,
-    onLocalModelPerformance: (String) -> DevicePerformanceUi,
+    onLocalModelPerformance: (String, Int) -> DevicePerformanceUi,
     onDownloadLocalModel: (String) -> Unit,
     onCancelLocalModelDownload: () -> Unit,
     onDeleteLocalModel: (String) -> Unit,
@@ -139,6 +144,7 @@ private fun SettingsContent(
     onImportLocalModel: (modelId: String, absolutePath: String) -> Unit,
     onImportLocalModelPreparing: (modelId: String) -> Unit,
     onImportLocalModelPickFailed: (modelId: String) -> Unit,
+    onLocalModelContextTokensChange: (String, Int) -> Unit,
     onToggleMcp: (Boolean) -> Unit,
     onAddMcpServer: (String, String, String?, Map<String, String>, Boolean) -> Unit,
     onRemoveMcpServer: (String) -> Unit,
@@ -203,6 +209,7 @@ private fun SettingsContent(
                 localModelCatalog = state.localModelCatalog,
                 localDownloadState = state.localDownloadState,
                 localReadyIds = state.localReadyIds,
+                localModelContextTokens = state.localModelContextTokens,
                 hasAvx2Support = state.hasAvx2Support,
                 onLocalModelPerformance = onLocalModelPerformance,
                 onDownloadLocalModel = onDownloadLocalModel,
@@ -212,6 +219,7 @@ private fun SettingsContent(
                 onImportLocalModel = onImportLocalModel,
                 onImportLocalModelPreparing = onImportLocalModelPreparing,
                 onImportLocalModelPickFailed = onImportLocalModelPickFailed,
+                onLocalModelContextTokensChange = onLocalModelContextTokensChange,
                 onClearHistory = onClearHistory,
                 modifier = Modifier.weight(1f)
             )

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantCapabilityTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantCapabilityTest.kt
@@ -46,6 +46,30 @@ class AssistantCapabilityTest {
     }
 
     @Test
+    fun `OnDevice uses selection when contextTokens set`() {
+        val chars = resolveContextCharsForConfig(
+            LlmProviderConfig.OnDevice(modelId = "gemma-4-e4b-it", contextTokens = 16_384),
+        )
+        assertEquals(16_384, chars)
+    }
+
+    @Test
+    fun `OnDevice zero contextTokens means catalog default`() {
+        val chars = resolveContextCharsForConfig(
+            LlmProviderConfig.OnDevice(modelId = "gemma-4-e4b-it", contextTokens = 0),
+        )
+        assertEquals(4_096, chars)
+    }
+
+    @Test
+    fun `OnDevice clamps contextTokens above catalog max`() {
+        val chars = resolveContextCharsForConfig(
+            LlmProviderConfig.OnDevice(modelId = "gemma-4-e4b-it", contextTokens = 99_999),
+        )
+        assertEquals(32_768, chars)
+    }
+
+    @Test
     fun `small Ollama OpenAiCompatible config resolves to Simple`() {
         val capability = resolveCapabilityForConfig(
             LlmProviderConfig.OpenAiCompatible(

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt
@@ -36,6 +36,10 @@ class FakeAssistantRepository : IAssistantRepository {
     private val _activeProviderKeyFlow = MutableStateFlow<String?>(null)
     override val activeProviderKeyFlow: Flow<String?> = _activeProviderKeyFlow
 
+    private val modelContextTokens = mutableMapOf<String, Int>()
+    private val _modelContextTokensFlow = MutableStateFlow<Map<String, Int>>(emptyMap())
+    override val modelContextTokensFlow: Flow<Map<String, Int>> = _modelContextTokensFlow
+
     override fun addMessage(message: ChatMessage) {
         messages.add(message)
         message.tokenUsage?.let { usage ->
@@ -90,6 +94,13 @@ class FakeAssistantRepository : IAssistantRepository {
         activeProvider = providerKey
         _activeProviderKeyFlow.value = providerKey
         _activeConfigFlow.value = allConfigs[providerKey]
+    }
+
+    override suspend fun getModelContextTokens(modelId: String): Int? = modelContextTokens[modelId]
+
+    override suspend fun setModelContextTokens(modelId: String, contextTokens: Int) {
+        modelContextTokens[modelId] = contextTokens
+        _modelContextTokensFlow.value = modelContextTokens.toMap()
     }
 
     override suspend fun getDisabledTools(): Set<String> = savedDisabledTools

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
@@ -535,4 +535,14 @@ class SettingsViewModelTest {
         assertIs<LlmProviderConfig.OnDevice>(saved)
         assertEquals(8_192, saved.contextTokens)
     }
+
+    @Test
+    fun `persisted localModelContextTokens appear in Ready at init`() = runTest {
+        fakeAssistantRepo.setModelContextTokens("gemma-4-e4b-it", 8_192)
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val ready = assertIs<SettingsUiState.Ready>(viewModel.uiState.value)
+        assertEquals(8_192, ready.localModelContextTokens["gemma-4-e4b-it"])
+    }
 }

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
@@ -502,6 +502,37 @@ class SettingsViewModelTest {
         val saved = fakeAssistantRepo.allConfigs[KnownProvider.LOCAL.name]
         assertIs<LlmProviderConfig.OnDevice>(saved)
         assertEquals("gemma-4-e4b-it", saved.modelId)
+        assertEquals(4_096, saved.contextTokens)
         assertEquals(KnownProvider.LOCAL.name, fakeAssistantRepo.activeProvider)
+    }
+
+    @Test
+    fun `setLocalModelContextTokens persists and updates active OnDevice`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.selectLocalModel("gemma-4-e4b-it")
+        advanceUntilIdle()
+        viewModel.setLocalModelContextTokens("gemma-4-e4b-it", 16_384)
+        advanceUntilIdle()
+
+        assertEquals(16_384, fakeAssistantRepo.getModelContextTokens("gemma-4-e4b-it"))
+        val active = fakeAssistantRepo.allConfigs[KnownProvider.LOCAL.name]
+        assertIs<LlmProviderConfig.OnDevice>(active)
+        assertEquals(16_384, active.contextTokens)
+        val ready = assertIs<SettingsUiState.Ready>(viewModel.uiState.value)
+        assertEquals(16_384, ready.localModelContextTokens["gemma-4-e4b-it"])
+    }
+
+    @Test
+    fun `selectLocalModel copies stored context tokens into OnDevice`() = runTest {
+        fakeAssistantRepo.setModelContextTokens("gemma-4-e4b-it", 8_192)
+        val viewModel = createViewModel()
+
+        viewModel.selectLocalModel("gemma-4-e4b-it")
+        advanceUntilIdle()
+
+        val saved = fakeAssistantRepo.allConfigs[KnownProvider.LOCAL.name]
+        assertIs<LlmProviderConfig.OnDevice>(saved)
+        assertEquals(8_192, saved.contextTokens)
     }
 }

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -475,3 +475,4 @@ tombstones or "removed" markers.
 | 1.3.1 | 2026-08-05 | Document Android-only BackgroundWorker approval polling (#433) |
 | 1.3.2 | 2026-08-06 | Document `:baselineprofile` module + JUnit4 Macrobenchmark exception (#214) |
 | 1.3.3 | 2026-08-08 | Document on-device LLM behind `LlmProvider` + `ILocalModelRepository` (#264) |
+| 1.3.4 | 2026-08-08 | Document configurable on-device LiteRT context window (#470) |

--- a/docs/architecture/service-contracts.md
+++ b/docs/architecture/service-contracts.md
@@ -127,7 +127,7 @@ the §2 same-package guideline so presentation never imports `network`.
   (`shared/.../tools/ToolStub.kt`) — a direct subtype of `Tool` in the same package,
   satisfying the sealed constraint while keeping test support out of production paths.
 
-### On-device LLM (#264)
+### On-device LLM (#264 / #470)
 
 - On-device inference is an `LlmProvider` implementation (`LocalLlmProvider` via
   `LocalLlmProviderFactory`), not a parallel engine path. ChatEngine continues to own
@@ -137,6 +137,13 @@ the §2 same-package guideline so presentation never imports `network`.
 - LiteRT types stay in `androidMain` / `jvmMain` actuals. `commonMain` / `commonTest`
   must not import LiteRT APIs — use bridge types (`BridgedAssistantMessage`, etc.) and
   repository interfaces for tests.
+- **Context window (#470):** Users may raise context from catalog `defaultContextTokens`
+  to `maxContextTokens` in 1K steps (Kai-style). The per-model map in
+  `IAssistantRepository` is the Settings slider source of truth;
+  `LlmProviderConfig.OnDevice.contextTokens` is the engine/ChatEngine authority
+  (`0` = catalog default). LiteRT receives `EngineConfig.maxNumTokens`; ChatEngine
+  budget uses the same resolved value. Pixel-class guidance: 4K default; 8K–16K OK
+  on ≥12 GB RAM; 32K may be tight or slower.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-08-issue-470-litert-context-window.md
+++ b/docs/superpowers/plans/2026-08-08-issue-470-litert-context-window.md
@@ -1,0 +1,416 @@
+# Configurable on-device LiteRT context window (Kai-style) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users set on-device LiteRT context (catalog default → max, 1K steps), persist it, wire `EngineConfig.maxNumTokens`, and use the same value for ChatEngine history budget + Settings GOOD/OK/POOR.
+
+**Architecture:** Persist a per-model context map in `AssistantRepository` (Kai-style **slider source of truth** for every catalog model, including before download). Mirror the active model’s selection onto `LlmProviderConfig.OnDevice.contextTokens` (**engine/ChatEngine authority** for the LOCAL config). Clamp to `[defaultContextTokens, maxContextTokens]` in 1024-token steps. On change, update the active OnDevice config so `AssistantViewModel` closes the cached provider; LiteRT init retries with catalog `defaultContextTokens`, then `maxNumTokens = null`, if the requested size fails.
+
+**Sync rules (dual persist):**
+1. Map = slider SoT for all models; `OnDevice.contextTokens` = authority for engine + ChatEngine when LOCAL is configured.
+2. `setLocalModelContextTokens` always writes the map **and**, if LOCAL’s `OnDevice.modelId` matches, updates that llm_configs entry (so `activeConfigFlow` invalidates the provider cache).
+3. `selectLocalModel` copies clamped map value (or catalog default if unset) into new `OnDevice.contextTokens`.
+4. `resolveOnDeviceContextTokens(modelId, contextTokens)` / ChatEngine / LiteRT read **only** from the OnDevice field (0 → catalog default). They do not read the map at inference time.
+
+**Tech Stack:** Kotlin Multiplatform, Compose Multiplatform Material3 `Slider`, DataStore preferences, LiteRT-LM 0.15.0 `EngineConfig.maxNumTokens`, existing `estimateGpuMemoryMb` / `devicePerformance`.
+
+**Issue:** [#470](https://github.com/leogallego/ansible-jane/issues/470) · Follow-up to #264 / PR #461  
+**Out of scope:** #264 PR2 dual-path, #450 compression, #469 download reliability, catalog max > 32K
+
+## Global Constraints
+
+- Defaults stay conservative: E4B → 4096, 12B → 8192 until the user moves the slider
+- Floor is catalog `defaultContextTokens` (not below); ceiling is `maxContextTokens` (32768)
+- Step size: 1024 tokens
+- Backward-compatible serialization: existing OnDevice JSON without `contextTokens` must still decode
+- LiteRT types stay in `androidMain` / `jvmMain` only
+- UI must not import repository domain types beyond existing presentation mappers (`LocalModelUi`)
+- ViewModels expose `StateFlow`; no `MutableStateFlow` to UI
+- Use `--no-daemon` on all Gradle commands in sandbox
+- Commits/PR trailer: `Assisted-by: Cursor (Grok 4.5)`
+
+## File map
+
+| Path | Change |
+|------|--------|
+| `shared/.../local/LocalModelContext.kt` (new) | `CONTEXT_TOKEN_STEP`, `clampContextTokens`, `resolveOnDeviceContextTokens(modelId, contextTokens)` — **no** `LlmProviderConfig` import |
+| `shared/.../data/AssistantConfig.kt` | `OnDevice.contextTokens: Int = 0` (0 = catalog default) |
+| `shared/.../data/IAssistantRepository.kt` | `getModelContextTokens` / `setModelContextTokens` / `modelContextTokensFlow` |
+| `shared/.../data/AssistantRepository.kt` | DataStore key `model_context_tokens` JSON map |
+| `shared/.../llm/LocalLlmProvider.android.kt` | `maxNumTokens` + fallback + `loadedContextTokens` (clear in `releaseEngine`) |
+| `shared/.../llm/LocalLlmProvider.jvm.kt` | Same |
+| `composeApp/.../AssistantCapability.kt` | Thin wrapper → `resolveOnDeviceContextTokens` |
+| `composeApp/.../AssistantViewModel.kt` | Cache identity includes resolved contextTokens |
+| `composeApp/.../LocalModelUi.kt` | Add `defaultContextTokens`, `maxContextTokens` |
+| `composeApp/.../SettingsUiState.kt` | `Ready.localModelContextTokens: Map<String, Int>` from flow |
+| `composeApp/.../SettingsViewModel.kt` | Slider persist + performance-at-selection; keep on-device helpers cohesive (file already >400 LOC — accept growth for #470; no drive-by split) |
+| `composeApp/.../OnDeviceProviderCard.kt` | Slider UI + live badge via VM performance callback only |
+| `composeApp/.../AgentTab.kt` / `SettingsScreen.kt` | Wire callbacks |
+| `composeApp/src/commonMain/composeResources/values/strings.xml` | Context label (+ short guidance) |
+| `docs/architecture/service-contracts.md` or litert design note | Pixel-class guidance |
+| Tests + fakes | Clamp/persist/resolve/VM |
+
+---
+
+### Task 1: Clamp helper + OnDevice field + repository map
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelContext.kt`
+- Modify: `shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantConfig.kt`
+- Modify: `shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt`
+- Modify: `shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt`
+- Test: `shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelContextTest.kt`
+- Test: `shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/data/OnDeviceConfigTest.kt`
+- Test: `composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeAssistantRepository.kt`
+
+**Interfaces:**
+- Produces: `const val CONTEXT_TOKEN_STEP = 1024`
+- Produces: `fun clampContextTokens(defaultTokens: Int, maxTokens: Int, requested: Int): Int`
+- Produces: `fun resolveOnDeviceContextTokens(modelId: String, contextTokens: Int): Int` — catalog lookup + clamp; `contextTokens <= 0` → catalog default; **no** `LlmProviderConfig` import in `assistant.local`
+- Produces: `OnDevice(modelId, tokenSavingMode, contextTokens: Int = 0)` — `0` means “use catalog default”
+- Produces: `suspend fun getModelContextTokens(modelId: String): Int?` (null = unset)
+- Produces: `suspend fun setModelContextTokens(modelId: String, contextTokens: Int)`
+- Produces: `val modelContextTokensFlow: Flow<Map<String, Int>>`
+
+- [ ] **Step 1: Write failing clamp + serialization tests**
+
+```kotlin
+// LocalModelContextTest.kt
+@Test
+fun clamp_roundsDownToStep_andBounds() {
+    assertEquals(4096, clampContextTokens(4096, 32768, 0))
+    assertEquals(4096, clampContextTokens(4096, 32768, 5000)) // rounds toward default step
+    assertEquals(8192, clampContextTokens(4096, 32768, 8192))
+    assertEquals(32768, clampContextTokens(4096, 32768, 99999))
+}
+
+// OnDeviceConfigTest — extend
+@Test
+fun onDevice_roundTrip_includesContextTokens() {
+    val original = LlmProviderConfig.OnDevice(modelId = "gemma-4-e4b-it", contextTokens = 8192)
+    val json = Json.encodeToString(LlmProviderConfig.serializer(), original)
+    val decoded = Json.decodeFromString(LlmProviderConfig.serializer(), json)
+    assertEquals(original, decoded)
+}
+
+@Test
+fun onDevice_missingContextTokens_defaultsToZero() {
+    val json = """{"type":"on_device","modelId":"gemma-4-e4b-it"}"""
+    val decoded = Json.decodeFromString(LlmProviderConfig.serializer(), json) as LlmProviderConfig.OnDevice
+    assertEquals(0, decoded.contextTokens)
+}
+```
+
+Clamp rule (match Kai discrete steps):  
+`val stepped = defaultTokens + (((requested - defaultTokens).coerceAtLeast(0) / CONTEXT_TOKEN_STEP) * CONTEXT_TOKEN_STEP)`  
+then `stepped.coerceIn(defaultTokens, maxTokens)`.
+
+- [ ] **Step 2: Implement helper + OnDevice field + repository APIs**
+
+DataStore key: `stringPreferencesKey("model_context_tokens")` storing `Map<String, Int>` JSON (same Json style as `llm_configs`).
+
+`setModelContextTokens` must clamp using catalog lookup when available; repository may accept already-clamped ints from the VM and store as-is — prefer clamping in a shared helper called from the VM **and** repository for defense.
+
+- [ ] **Step 3: Update FakeAssistantRepository** with in-memory map + flow.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+./gradlew :shared:jvmTest --tests '*LocalModelContextTest*' --tests '*OnDeviceConfigTest*' --no-daemon
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(assistant): persist per-model LiteRT context tokens
+
+Add clamp helper, OnDevice.contextTokens, and DataStore map for Kai-style
+context preferences (#470).
+
+Assisted-by: Cursor (Grok 4.5)
+EOF
+)"
+```
+
+---
+
+### Task 2: ChatEngine budget + provider cache identity
+
+**Files:**
+- Modify: `composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantCapability.kt`
+- Modify: `composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantViewModel.kt`
+- Test: `composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/presentation/AssistantCapabilityTest.kt`
+
+**Interfaces:**
+- Consumes: `resolveOnDeviceContextTokens(modelId, contextTokens)` from Task 1
+- Produces: `resolveContextCharsForConfig` thin wrapper → shared resolve
+- Produces: `providerCacheIdentity(OnDevice) = "local|${modelId}|${resolvedContextTokens}"`
+
+- [ ] **Step 1: Update AssistantCapabilityTest**
+
+```kotlin
+@Test
+fun resolveContextChars_usesSelectionWhenSet() {
+    val chars = resolveContextCharsForConfig(
+        LlmProviderConfig.OnDevice(modelId = "gemma-4-e4b-it", contextTokens = 16384)
+    )
+    assertEquals(16384, chars)
+}
+
+@Test
+fun resolveContextChars_zeroMeansCatalogDefault() {
+    val chars = resolveContextCharsForConfig(
+        LlmProviderConfig.OnDevice(modelId = "gemma-4-e4b-it", contextTokens = 0)
+    )
+    assertEquals(4096, chars)
+}
+
+@Test
+fun resolveContextChars_clampsAboveMax() {
+    val chars = resolveContextCharsForConfig(
+        LlmProviderConfig.OnDevice(modelId = "gemma-4-e4b-it", contextTokens = 99999)
+    )
+    assertEquals(32768, chars)
+}
+```
+
+Keep existing E4B/12B/unknown default tests (they use `contextTokens = 0` implicitly).
+
+- [ ] **Step 2: Implement resolve + cache identity**
+
+```kotlin
+fun resolveContextCharsForConfig(config: LlmProviderConfig.OnDevice): Int =
+    resolveOnDeviceContextTokens(config.modelId, config.contextTokens)
+```
+
+```kotlin
+is LlmProviderConfig.OnDevice ->
+    "local|${config.modelId}|${resolveContextCharsForConfig(config)}"
+```
+
+`activeConfigFlow` already closes the cached provider when identity changes — no Settings→engine direct call required.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+./gradlew :composeApp:desktopTest --tests '*AssistantCapabilityTest*' --no-daemon
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(assistant): use selected LiteRT context for ChatEngine budget
+
+Resolve contextChars from OnDevice.contextTokens and include it in the
+provider cache identity so engines re-init on change (#470).
+
+Assisted-by: Cursor (Grok 4.5)
+EOF
+)"
+```
+
+---
+
+### Task 3: LiteRT `maxNumTokens` + fallback (android + jvm)
+
+**Files:**
+- Modify: `shared/src/androidMain/kotlin/io/github/leogallego/ansiblejane/assistant/llm/LocalLlmProvider.android.kt`
+- Modify: `shared/src/jvmMain/kotlin/io/github/leogallego/ansiblejane/assistant/llm/LocalLlmProvider.jvm.kt`
+
+**Interfaces:**
+- Consumes: `resolveOnDeviceContextTokens(config.modelId, config.contextTokens)` from Task 1
+- Produces: `EngineConfig(..., maxNumTokens = requested)` with fallback: requested → catalog default → `null`
+- Produces: track `loadedContextTokens`; clear to `null` in `releaseEngine`; re-init when model or context differs
+
+- [ ] **Step 1: Wire EngineConfig (both platforms)** using shared resolve helper (already in Task 1).
+
+```kotlin
+fun initWithBackend(backend: Backend, maxNumTokens: Int?): Engine {
+    val instance = Engine(
+        EngineConfig(
+            modelPath = modelPath,
+            backend = backend,
+            cacheDir = cacheDir,
+            maxNumTokens = maxNumTokens,
+        )
+    )
+    instance.initialize()
+    return instance
+}
+
+val resolved = resolveOnDeviceContextTokens(config.modelId, config.contextTokens)
+val catalogDefault = LOCAL_MODEL_CATALOG.find { it.id == config.modelId }?.defaultContextTokens ?: 4_096
+// Try: resolved → (if resolved != default) catalogDefault → null
+// On success, set loadedContextTokens to the tokens actually passed (catalogDefault or resolved;
+// for null fallback use catalogDefault so ChatEngine/engine metadata stay aligned with a known size).
+// Preference in the map/OnDevice stays at the user's requested value (retry next message may succeed).
+```
+
+Preserve existing GPU→CPU backend fallback and speculative-decoding flag behavior. Clear `loadedContextTokens` in `releaseEngine`.
+
+- [ ] **Step 2: Manual note** — unit-testing LiteRT Engine is not practical in CI; document in PR that device verification needs a downloaded model (#469).
+
+- [ ] **Step 3: Compile shared android/jvm**
+
+```bash
+./gradlew :shared:compileDebugKotlinAndroid :shared:compileKotlinJvm --no-daemon
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(assistant): pass maxNumTokens into LiteRT EngineConfig
+
+Wire user-selected context into EngineConfig with null fallback when
+init fails at the requested KV size (#470).
+
+Assisted-by: Cursor (Grok 4.5)
+EOF
+)"
+```
+
+---
+
+### Task 4: Settings UI slider + ViewModel
+
+**Files:**
+- Modify: `composeApp/.../presentation/settings/LocalModelUi.kt`
+- Modify: `composeApp/.../presentation/settings/SettingsViewModel.kt`
+- Modify: `composeApp/.../ui/settings/OnDeviceProviderCard.kt`
+- Modify: `composeApp/.../ui/settings/AgentTab.kt` (if callbacks pass through)
+- Modify: `composeApp/.../ui/settings/SettingsScreen.kt`
+- Modify: `composeApp/src/commonMain/composeResources/values/strings.xml`
+- Test: `composeApp/.../SettingsViewModelTest.kt`
+- Test: `composeApp/.../LocalModelUiMapperTest.kt` (if present)
+
+**Interfaces:**
+- Consumes: `modelContextTokensFlow`, `setModelContextTokens`, `devicePerformance(modelId, contextTokens)`
+- Produces: `fun setLocalModelContextTokens(modelId: String, contextTokens: Int)`
+- Produces: UiState includes `localModelContextTokens: Map<String, Int>` (or read from dedicated StateFlow)
+- Produces: `localModelPerformance(modelId)` uses selected/clamped tokens
+- Produces: `selectLocalModel` writes `OnDevice(modelId, contextTokens = resolved)`
+
+**UI (Kai parity):**
+- Label: `Context: 8K` via string `agent_local_context_size` with `%1$s`
+- Material3 `Slider`: `valueRange = 0f..steps`, `steps = steps - 1`, persist on `onValueChangeFinished`
+- Live performance: while dragging, call VM `localModelPerformance(modelId, previewTokens)` → `ILocalModelRepository.devicePerformance` only (no estimate math in the composable)
+- `testTag("slider_local_context_${model.id}")`
+
+Extend `LocalModelUi`:
+
+```kotlin
+data class LocalModelUi(
+    val id: String,
+    val displayName: String,
+    val sizeBytes: Long,
+    val isRecommended: Boolean,
+    val defaultContextTokens: Int,
+    val maxContextTokens: Int,
+)
+```
+
+- [ ] **Step 1: Failing VM test**
+
+```kotlin
+@Test
+fun setLocalModelContextTokens_persistsAndUpdatesActiveOnDevice() = runTest {
+    // given LOCAL active with e4b
+    viewModel.selectLocalModel("gemma-4-e4b-it")
+    advanceUntilIdle()
+    viewModel.setLocalModelContextTokens("gemma-4-e4b-it", 16384)
+    advanceUntilIdle()
+    val stored = repository.getModelContextTokens("gemma-4-e4b-it")
+    assertEquals(16384, stored)
+    val active = repository.loadLlmConfig() as LlmProviderConfig.OnDevice
+    assertEquals(16384, active.contextTokens)
+}
+```
+
+- [ ] **Step 2: Implement VM + UI + strings**
+
+When setting tokens for the active on-device model, update both the map and the LOCAL entry in `llm_configs` so `activeConfigFlow` invalidates the provider cache.
+
+Add short guidance string under the slider, e.g.  
+`agent_local_context_guidance` = `4K default; 8K–16K OK on ≥12 GB RAM; 32K may be tight or slower.`
+
+- [ ] **Step 3: Run Settings / mapper tests**
+
+```bash
+./gradlew :composeApp:desktopTest --tests '*SettingsViewModelTest*' --tests '*LocalModelUiMapperTest*' --tests '*AssistantCapabilityTest*' --no-daemon
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(ui): Kai-style on-device context size slider
+
+Add Settings slider with live GOOD/OK/POOR estimates and persist
+selection into the active OnDevice config (#470).
+
+Assisted-by: Cursor (Grok 4.5)
+EOF
+)"
+```
+
+---
+
+### Task 5: Docs + acceptance sweep
+
+**Files:**
+- Modify: `docs/architecture/service-contracts.md` (on-device section) **or** short note in `docs/superpowers/specs/2026-08-07-litert-lm-on-device-design.md`
+- Verify all AC checkboxes from #470
+
+- [ ] **Step 1: Document Pixel-class guidance** (4K default; 8K–16K OK on ≥12 GB; 32K may be tight/slower). Unlock the PR1 “contextChars = default only” lock in the design doc with a pointer to #470.
+
+- [ ] **Step 2: Run focused regression suite**
+
+```bash
+./gradlew :shared:jvmTest --tests '*LocalModel*' --tests '*OnDevice*' --tests '*IdleRelease*' --no-daemon
+./gradlew :composeApp:desktopTest --tests '*AssistantCapability*' --tests '*SettingsViewModel*' --tests '*LocalModelUi*' --no-daemon
+```
+
+- [ ] **Step 3: Commit docs**
+
+```bash
+git commit -m "$(cat <<'EOF'
+docs: document configurable LiteRT context window guidance
+
+Record Pixel-class context recommendations and unlock the PR1 default-only
+lock for #470.
+
+Assisted-by: Cursor (Grok 4.5)
+EOF
+)"
+```
+
+---
+
+## Acceptance criteria coverage
+
+| Criterion | Task |
+|-----------|------|
+| Slider between catalog min/max (1K steps) | 4 |
+| Persists across restarts | 1, 4 |
+| LiteRT `maxNumTokens` matches selection | 3 |
+| ChatEngine `contextChars` uses selection | 2 |
+| Performance badge uses selection | 4 |
+| Engine re-inits on context change | 2 (cache identity) + 3 (loadedContextTokens) |
+| Unit tests clamp/persist/resolve + VM | 1, 2, 4 |
+| Pixel guidance documented | 5 |
+
+## Migration / compat
+
+No migration job needed. `contextTokens` default `0` and missing JSON field → catalog default. Empty context map → defaults.
+
+## Test plan (PR)
+
+- [ ] Unit: clamp, OnDevice JSON, resolveContextChars, SettingsVM set/select
+- [ ] Compile android + jvm LocalLlmProvider
+- [ ] Manual (device with downloaded model): move slider 4K→16K, send message, confirm re-init / no crash; kill app and confirm persistence
+)

--- a/docs/superpowers/specs/2026-08-07-litert-lm-on-device-design.md
+++ b/docs/superpowers/specs/2026-08-07-litert-lm-on-device-design.md
@@ -177,7 +177,7 @@ data class OnDevice(
 - **PR1:** `resolve(..., onDevice = true)` → always `Simple` for every on-device model (including 12B if downloaded). Matches #453 today.  
 - **PR2 must extend #453** — see [12B policy vs Simple](#12b-policy-vs-453-simple). Until that lands, 12B must not claim MCP / TOKEN_SAVER behavior.  
 - Device tier UI: show GOOD/OK/POOR; **block download only on insufficient disk**; POOR is a warning  
-- **Context budget:** when active provider is OnDevice, set ChatEngine `contextChars = catalog.defaultContextTokens` (Jane’s existing char budgets are already token-shaped: 4K/8K/16K). E4B → 4096, 12B → 8192. Do not leave cloud TOOLS_ONLY’s 4K budget as the only knob once LARGE is active in PR2.
+- **Context budget:** when active provider is OnDevice, set ChatEngine `contextChars` from the user-selected on-device context (#470), falling back to catalog `defaultContextTokens` when unset (E4B → 4096, 12B → 8192). Settings exposes a Kai-style slider (`defaultContextTokens`…`maxContextTokens`, 1K steps); LiteRT `EngineConfig.maxNumTokens` uses the same selection. Do not leave cloud TOOLS_ONLY’s 4K budget as the only knob once LARGE is active in PR2.
 
 ## PR1 — Inference bridge (sync / manual)
 
@@ -387,7 +387,7 @@ Fakes must implement `ILocalModelRepository`. No LiteRT types in `commonMain` te
 | PR1 vs #453 `onDevice → Simple` | **Solved** — intentional; E4B and 12B both Simple until PR2 |
 | PR2 12B vs Simple no-MCP / TOOLS_ONLY | **Solved in design** — `OnDeviceLarge` + ToolRouter/VM/resolver touch list (not enum-only) |
 | Fake-as-`Full` anti-pattern | Explicitly forbidden |
-| Residual ambiguity | Locked `contextChars = defaultContextTokens`; no open OR left on that point |
+| Residual ambiguity | Unlocked by #470 — user-selectable context (defaults remain catalog defaults) |
 | Remaining risks (not conflicts) | LiteRT schema-only spike; pinned HF URLs/SHAs at implement time; async tool-event wiring |
 
 **Verdict:** Conflict solved. Spec ready for implementation planning.

--- a/shared/src/androidMain/kotlin/io/github/leogallego/ansiblejane/assistant/llm/LocalLlmProvider.android.kt
+++ b/shared/src/androidMain/kotlin/io/github/leogallego/ansiblejane/assistant/llm/LocalLlmProvider.android.kt
@@ -19,6 +19,8 @@ import com.google.ai.edge.litertlm.ToolCall as LiteRtToolCall
 import com.google.ai.edge.litertlm.tool
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.assistant.local.ILocalModelRepository
+import io.github.leogallego.ansiblejane.assistant.local.LOCAL_MODEL_CATALOG
+import io.github.leogallego.ansiblejane.assistant.local.resolveOnDeviceContextTokens
 import java.io.File
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -65,6 +67,7 @@ class LocalLlmProvider internal constructor(
     @Volatile private var engine: Engine? = null
     @Volatile private var conversation: Conversation? = null
     @Volatile private var loadedModelId: String? = null
+    @Volatile private var loadedContextTokens: Int? = null
     private val idleRelease = IdleReleaseScheduler(scope) { releaseEngine() }
 
     override fun generateStream(
@@ -137,8 +140,9 @@ class LocalLlmProvider internal constructor(
         val modelPath = modelRepository.modelPath(config.modelId)
             ?: throw LlmServerException("On-device model not downloaded: ${config.modelId}")
 
-        if (loadedModelId != config.modelId || engine == null) {
-            swapEngine(modelPath)
+        val requestedContext = resolveOnDeviceContextTokens(config.modelId, config.contextTokens)
+        if (loadedModelId != config.modelId || loadedContextTokens != requestedContext || engine == null) {
+            swapEngine(modelPath, requestedContext)
         }
         val currentEngine = engine ?: throw LlmServerException("On-device engine failed to initialize")
 
@@ -169,7 +173,7 @@ class LocalLlmProvider internal constructor(
         return next
     }
 
-    private suspend fun swapEngine(modelPath: String) {
+    private suspend fun swapEngine(modelPath: String, requestedContext: Int) {
         val hadExisting = engine != null
         releaseEngine()
         _engineState.value = LocalEngineState.Loading
@@ -181,26 +185,66 @@ class LocalLlmProvider internal constructor(
         }
         try {
             val cacheDir = File(modelPath).parentFile?.absolutePath
-            fun initWithBackend(backend: Backend): Engine {
-                val instance = Engine(EngineConfig(modelPath = modelPath, backend = backend, cacheDir = cacheDir))
+            fun initWithBackend(backend: Backend, maxNumTokens: Int?): Engine {
+                val instance = Engine(
+                    EngineConfig(
+                        modelPath = modelPath,
+                        backend = backend,
+                        cacheDir = cacheDir,
+                        maxNumTokens = maxNumTokens,
+                    )
+                )
                 instance.initialize()
                 return instance
             }
 
-            val newEngine = try {
-                initWithBackend(Backend.GPU()).also {
-                    // Only set once GPU init actually succeeds — never leave a stale `true`
-                    // stuck on a CPU-only engine from an earlier GPU init (#264 Task 6 Important #5).
-                    ExperimentalFlags.enableSpeculativeDecoding = true
+            fun initGpuThenCpu(maxNumTokens: Int?): Engine {
+                return try {
+                    initWithBackend(Backend.GPU(), maxNumTokens).also {
+                        // Only set once GPU init actually succeeds — never leave a stale `true`
+                        // stuck on a CPU-only engine from an earlier GPU init (#264 Task 6 Important #5).
+                        ExperimentalFlags.enableSpeculativeDecoding = true
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    ExperimentalFlags.enableSpeculativeDecoding = false
+                    initWithBackend(Backend.CPU(), maxNumTokens)
                 }
+            }
+
+            val catalogDefault = LOCAL_MODEL_CATALOG.find { it.id == config.modelId }?.defaultContextTokens
+                ?: 4_096
+            // Prefer requested size; fall back to catalog default, then engine default (null).
+            // On success always record the *requested* context (Kai pattern) so we do not
+            // thrash re-init when LiteRT accepted a smaller window; user preference stays put
+            // for a later retry after restart / model swap.
+            val newEngine = try {
+                initGpuThenCpu(requestedContext)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                ExperimentalFlags.enableSpeculativeDecoding = false
-                initWithBackend(Backend.CPU())
+                if (requestedContext != catalogDefault) {
+                    try {
+                        initGpuThenCpu(catalogDefault)
+                    } catch (e2: CancellationException) {
+                        throw e2
+                    } catch (_: Exception) {
+                        initGpuThenCpu(null)
+                    }
+                } else {
+                    try {
+                        initGpuThenCpu(null)
+                    } catch (e2: CancellationException) {
+                        throw e2
+                    } catch (_: Exception) {
+                        throw e
+                    }
+                }
             }
             engine = newEngine
             loadedModelId = config.modelId
+            loadedContextTokens = requestedContext
         } catch (e: CancellationException) {
             _engineState.value = LocalEngineState.Error
             throw e
@@ -216,6 +260,7 @@ class LocalLlmProvider internal constructor(
         conversation = null
         engine = null
         loadedModelId = null
+        loadedContextTokens = null
         runCatching { conv?.close() }
         runCatching { eng?.close() }
         _engineState.value = LocalEngineState.Uninitialized

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantConfig.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantConfig.kt
@@ -45,5 +45,10 @@ sealed interface LlmProviderConfig {
     data class OnDevice(
         val modelId: String,
         override val tokenSavingMode: TokenSavingMode = TokenSavingMode.TOOLS_ONLY,
+        /**
+         * User-selected LiteRT context window in tokens.
+         * `0` means “use catalog [defaultContextTokens]” (backward-compatible default).
+         */
+        val contextTokens: Int = 0,
     ) : LlmProviderConfig
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/AssistantRepository.kt
@@ -40,9 +40,11 @@ class AssistantRepository(
         private const val TAG = "AssistantRepository"
         val KEY_LLM_CONFIGS = stringPreferencesKey("llm_configs")
         val KEY_ACTIVE_PROVIDER = stringPreferencesKey("active_provider")
+        val KEY_MODEL_CONTEXT_TOKENS = stringPreferencesKey("model_context_tokens")
         val KEY_DISABLED_TOOLS = stringPreferencesKey("disabled_tools")
         val KEY_ENABLED_OVERRIDES = stringPreferencesKey("enabled_overrides")
         const val MAX_MESSAGES = 100
+        private val STRING_INT_MAP = MapSerializer(String.serializer(), Int.serializer())
     }
 
     override fun addMessage(message: ChatMessage) {
@@ -223,6 +225,42 @@ class AssistantRepository(
     override suspend fun switchActiveProvider(providerKey: String) {
         assistantDataStore.edit { prefs ->
             prefs[KEY_ACTIVE_PROVIDER] = providerKey
+        }
+    }
+
+    override suspend fun getModelContextTokens(modelId: String): Int? =
+        loadModelContextTokensMap()[modelId]
+
+    override suspend fun setModelContextTokens(modelId: String, contextTokens: Int) {
+        val current = loadModelContextTokensMap().toMutableMap()
+        current[modelId] = contextTokens
+        val mapJson = json.encodeToString(STRING_INT_MAP, current)
+        assistantDataStore.edit { prefs ->
+            prefs[KEY_MODEL_CONTEXT_TOKENS] = mapJson
+        }
+    }
+
+    override val modelContextTokensFlow: Flow<Map<String, Int>> =
+        assistantDataStore.data.map { prefs ->
+            val mapJson = prefs[KEY_MODEL_CONTEXT_TOKENS] ?: return@map emptyMap()
+            try {
+                json.decodeFromString(STRING_INT_MAP, mapJson)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                DebugLog.w(TAG, "Failed to deserialize model context tokens: ${e.message}")
+                emptyMap()
+            }
+        }.distinctUntilChanged()
+
+    private suspend fun loadModelContextTokensMap(): Map<String, Int> {
+        val prefs = assistantDataStore.data.first()
+        val mapJson = prefs[KEY_MODEL_CONTEXT_TOKENS] ?: return emptyMap()
+        return try {
+            json.decodeFromString(STRING_INT_MAP, mapJson)
+        } catch (e: Exception) {
+            DebugLog.w(TAG, "Failed to deserialize model context tokens: ${e.message}")
+            emptyMap()
         }
     }
 

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/data/IAssistantRepository.kt
@@ -21,6 +21,10 @@ interface IAssistantRepository {
     val savedConfigsFlow: Flow<Map<String, LlmProviderConfig>>
     val activeProviderKeyFlow: Flow<String?>
     suspend fun switchActiveProvider(providerKey: String)
+    /** Per-model on-device context preference; `null` if unset (use catalog default). */
+    suspend fun getModelContextTokens(modelId: String): Int?
+    suspend fun setModelContextTokens(modelId: String, contextTokens: Int)
+    val modelContextTokensFlow: Flow<Map<String, Int>>
     suspend fun getDisabledTools(): Set<String>
     suspend fun getEnabledOverrides(): Set<String>
     suspend fun saveToolState(disabled: Set<String>, enabledOverrides: Set<String>)

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelContext.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelContext.kt
@@ -1,0 +1,29 @@
+package io.github.leogallego.ansiblejane.assistant.local
+
+/** Discrete step for on-device context size sliders (Kai-style, 1K tokens). */
+const val CONTEXT_TOKEN_STEP = 1_024
+
+/**
+ * Clamps [requested] into `[defaultTokens, maxTokens]` on [CONTEXT_TOKEN_STEP] boundaries.
+ * Values below [defaultTokens] snap up to the default (floor is catalog default, not a lower safe floor).
+ */
+fun clampContextTokens(defaultTokens: Int, maxTokens: Int, requested: Int): Int {
+    val lo = defaultTokens.coerceAtMost(maxTokens)
+    val hi = maxTokens.coerceAtLeast(lo)
+    if (requested <= lo) return lo
+    val stepped = lo + (((requested - lo) / CONTEXT_TOKEN_STEP) * CONTEXT_TOKEN_STEP)
+    return stepped.coerceIn(lo, hi)
+}
+
+/**
+ * Resolves the effective on-device context window for a catalog model.
+ *
+ * @param contextTokens user selection; `<= 0` means “use catalog default”
+ */
+fun resolveOnDeviceContextTokens(modelId: String, contextTokens: Int): Int {
+    val model = LOCAL_MODEL_CATALOG.find { it.id == modelId }
+    val defaultTokens = model?.defaultContextTokens ?: 4_096
+    val maxTokens = model?.maxContextTokens ?: defaultTokens
+    val requested = if (contextTokens > 0) contextTokens else defaultTokens
+    return clampContextTokens(defaultTokens, maxTokens, requested)
+}

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/data/OnDeviceConfigTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/data/OnDeviceConfigTest.kt
@@ -20,7 +20,26 @@ class OnDeviceConfigTest {
         assertEquals(cfg, decoded)
         assertIs<LlmProviderConfig.OnDevice>(decoded)
         assertEquals(TokenSavingMode.TOOLS_ONLY, decoded.tokenSavingMode)
+        assertEquals(0, decoded.contextTokens)
         assertTrue(encoded.contains("on_device"), "serialized JSON should use on_device discriminator")
+    }
+
+    @Test
+    fun onDevice_roundTrip_includesContextTokens() {
+        val original = LlmProviderConfig.OnDevice(modelId = "gemma-4-e4b-it", contextTokens = 8192)
+        val encoded = json.encodeToString(LlmProviderConfig.serializer(), original)
+        val decoded = json.decodeFromString(LlmProviderConfig.serializer(), encoded)
+        assertEquals(original, decoded)
+        assertIs<LlmProviderConfig.OnDevice>(decoded)
+        assertEquals(8192, decoded.contextTokens)
+    }
+
+    @Test
+    fun onDevice_missingContextTokens_defaultsToZero() {
+        val jsonStr = """{"type":"on_device","modelId":"gemma-4-e4b-it"}"""
+        val decoded = json.decodeFromString(LlmProviderConfig.serializer(), jsonStr)
+        assertIs<LlmProviderConfig.OnDevice>(decoded)
+        assertEquals(0, decoded.contextTokens)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelContextTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelContextTest.kt
@@ -1,0 +1,43 @@
+package io.github.leogallego.ansiblejane.assistant.local
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LocalModelContextTest {
+
+    @Test
+    fun clamp_boundsAndSteps() {
+        assertEquals(4096, clampContextTokens(4096, 32768, 0))
+        assertEquals(4096, clampContextTokens(4096, 32768, 4096))
+        assertEquals(4096, clampContextTokens(4096, 32768, 5000))
+        assertEquals(8192, clampContextTokens(4096, 32768, 8192))
+        assertEquals(16384, clampContextTokens(4096, 32768, 16384))
+        assertEquals(32768, clampContextTokens(4096, 32768, 32768))
+        assertEquals(32768, clampContextTokens(4096, 32768, 99999))
+    }
+
+    @Test
+    fun clamp_12bDefaultFloor() {
+        assertEquals(8192, clampContextTokens(8192, 32768, 4096))
+        assertEquals(8192, clampContextTokens(8192, 32768, 8192))
+        assertEquals(9216, clampContextTokens(8192, 32768, 9216))
+    }
+
+    @Test
+    fun resolve_zeroMeansCatalogDefault() {
+        assertEquals(4096, resolveOnDeviceContextTokens("gemma-4-e4b-it", 0))
+        assertEquals(8192, resolveOnDeviceContextTokens("gemma-4-12b-it", 0))
+    }
+
+    @Test
+    fun resolve_selectionAndClamp() {
+        assertEquals(16384, resolveOnDeviceContextTokens("gemma-4-e4b-it", 16384))
+        assertEquals(32768, resolveOnDeviceContextTokens("gemma-4-e4b-it", 99999))
+    }
+
+    @Test
+    fun resolve_unknownModelDefaultsTo4096() {
+        assertEquals(4096, resolveOnDeviceContextTokens("unknown-model", 0))
+        assertEquals(4096, resolveOnDeviceContextTokens("unknown-model", 8192))
+    }
+}

--- a/shared/src/jvmMain/kotlin/io/github/leogallego/ansiblejane/assistant/llm/LocalLlmProvider.jvm.kt
+++ b/shared/src/jvmMain/kotlin/io/github/leogallego/ansiblejane/assistant/llm/LocalLlmProvider.jvm.kt
@@ -19,6 +19,8 @@ import com.google.ai.edge.litertlm.ToolCall as LiteRtToolCall
 import com.google.ai.edge.litertlm.tool
 import io.github.leogallego.ansiblejane.assistant.data.LlmProviderConfig
 import io.github.leogallego.ansiblejane.assistant.local.ILocalModelRepository
+import io.github.leogallego.ansiblejane.assistant.local.LOCAL_MODEL_CATALOG
+import io.github.leogallego.ansiblejane.assistant.local.resolveOnDeviceContextTokens
 import java.io.File
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -64,6 +66,7 @@ class LocalLlmProvider internal constructor(
     @Volatile private var engine: Engine? = null
     @Volatile private var conversation: Conversation? = null
     @Volatile private var loadedModelId: String? = null
+    @Volatile private var loadedContextTokens: Int? = null
     private val idleRelease = IdleReleaseScheduler(scope) { releaseEngine() }
 
     override fun generateStream(
@@ -136,8 +139,9 @@ class LocalLlmProvider internal constructor(
         val modelPath = modelRepository.modelPath(config.modelId)
             ?: throw LlmServerException("On-device model not downloaded: ${config.modelId}")
 
-        if (loadedModelId != config.modelId || engine == null) {
-            swapEngine(modelPath)
+        val requestedContext = resolveOnDeviceContextTokens(config.modelId, config.contextTokens)
+        if (loadedModelId != config.modelId || loadedContextTokens != requestedContext || engine == null) {
+            swapEngine(modelPath, requestedContext)
         }
         val currentEngine = engine ?: throw LlmServerException("On-device engine failed to initialize")
 
@@ -168,7 +172,7 @@ class LocalLlmProvider internal constructor(
         return next
     }
 
-    private suspend fun swapEngine(modelPath: String) {
+    private suspend fun swapEngine(modelPath: String, requestedContext: Int) {
         val hadExisting = engine != null
         releaseEngine()
         _engineState.value = LocalEngineState.Loading
@@ -180,26 +184,66 @@ class LocalLlmProvider internal constructor(
         }
         try {
             val cacheDir = File(modelPath).parentFile?.absolutePath
-            fun initWithBackend(backend: Backend): Engine {
-                val instance = Engine(EngineConfig(modelPath = modelPath, backend = backend, cacheDir = cacheDir))
+            fun initWithBackend(backend: Backend, maxNumTokens: Int?): Engine {
+                val instance = Engine(
+                    EngineConfig(
+                        modelPath = modelPath,
+                        backend = backend,
+                        cacheDir = cacheDir,
+                        maxNumTokens = maxNumTokens,
+                    )
+                )
                 instance.initialize()
                 return instance
             }
 
-            val newEngine = try {
-                initWithBackend(Backend.GPU()).also {
-                    // Only set once GPU init actually succeeds — never leave a stale `true`
-                    // stuck on a CPU-only engine from an earlier GPU init (#264 Task 6 Important #5).
-                    ExperimentalFlags.enableSpeculativeDecoding = true
+            fun initGpuThenCpu(maxNumTokens: Int?): Engine {
+                return try {
+                    initWithBackend(Backend.GPU(), maxNumTokens).also {
+                        // Only set once GPU init actually succeeds — never leave a stale `true`
+                        // stuck on a CPU-only engine from an earlier GPU init (#264 Task 6 Important #5).
+                        ExperimentalFlags.enableSpeculativeDecoding = true
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    ExperimentalFlags.enableSpeculativeDecoding = false
+                    initWithBackend(Backend.CPU(), maxNumTokens)
                 }
+            }
+
+            val catalogDefault = LOCAL_MODEL_CATALOG.find { it.id == config.modelId }?.defaultContextTokens
+                ?: 4_096
+            // Prefer requested size; fall back to catalog default, then engine default (null).
+            // On success always record the *requested* context (Kai pattern) so we do not
+            // thrash re-init when LiteRT accepted a smaller window; user preference stays put
+            // for a later retry after restart / model swap.
+            val newEngine = try {
+                initGpuThenCpu(requestedContext)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                ExperimentalFlags.enableSpeculativeDecoding = false
-                initWithBackend(Backend.CPU())
+                if (requestedContext != catalogDefault) {
+                    try {
+                        initGpuThenCpu(catalogDefault)
+                    } catch (e2: CancellationException) {
+                        throw e2
+                    } catch (_: Exception) {
+                        initGpuThenCpu(null)
+                    }
+                } else {
+                    try {
+                        initGpuThenCpu(null)
+                    } catch (e2: CancellationException) {
+                        throw e2
+                    } catch (_: Exception) {
+                        throw e
+                    }
+                }
             }
             engine = newEngine
             loadedModelId = config.modelId
+            loadedContextTokens = requestedContext
         } catch (e: CancellationException) {
             _engineState.value = LocalEngineState.Error
             throw e
@@ -215,6 +259,7 @@ class LocalLlmProvider internal constructor(
         conversation = null
         engine = null
         loadedModelId = null
+        loadedContextTokens = null
         runCatching { conv?.close() }
         runCatching { eng?.close() }
         _engineState.value = LocalEngineState.Uninitialized


### PR DESCRIPTION
## Summary

- Kai-style on-device context slider (catalog default → max, 1K steps) with live GOOD/OK/POOR estimates
- Persist per-model preferences; mirror onto `OnDevice.contextTokens` for LiteRT `maxNumTokens` and ChatEngine budget
- Engine re-inits on context change via provider cache identity; init falls back requested → catalog default → null

Closes #470

## Changes

- `LocalModelContext` clamp/resolve helpers + DataStore `model_context_tokens` map
- `OnDevice.contextTokens` (0 = catalog default; backward-compatible JSON)
- `LocalLlmProvider` android/jvm: `EngineConfig.maxNumTokens` + fallback; track loaded context
- Settings `OnDeviceProviderCard` slider + ViewModel dual-write sync
- Docs: service contracts + litert design unlock for user-selectable context

## Test plan

- [x] `./gradlew :shared:jvmTest --tests '*LocalModelContextTest*' --tests '*OnDeviceConfigTest*' --no-daemon`
- [x] `./gradlew :composeApp:desktopTest --tests '*AssistantCapabilityTest*' --tests '*SettingsViewModelTest*' --tests '*LocalModelUiMapperTest*' --no-daemon`
- [x] `./gradlew :shared:compileKotlinJvm :shared:compileAndroidMain --no-daemon`
- [ ] Manual (device with downloaded model): move slider 4K→16K, send a message, confirm re-init / no crash; restart app and confirm persistence

## Review findings addressed

- **Plan review** (`git-plan`): dual-persist sync rules, shared resolve helper without `LlmProviderConfig` in `assistant.local`, SettingsUiState field, VM performance path only
- **Implementation review** (`git-implement`): fixed LiteRT fallback re-init thrash by recording requested context on success (Kai pattern); preference stays for later retry

## Acknowledged debt

- If LiteRT init falls back to a smaller window, ChatEngine may still budget the user-requested size until preference is changed (Kai behaves the same)
- `SettingsViewModel` remains above the 400 LOC soft guideline; no drive-by split in this PR

## Stack position

- **Base**: `main`
- **Next**: end of chain

Assisted-by: Cursor (Grok 4.5)