### PR TITLE
docs+refactor(local-model): transfer scope docs + Downloads discovery behind repo

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.android.kt
@@ -2,7 +2,6 @@ package io.github.leogallego.ansiblejane.ui.settings
 
 import android.content.Context
 import android.net.Uri
-import android.os.Environment
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
@@ -71,16 +70,6 @@ actual fun rememberLocalModelImportController(
                 state.job = null
             }
         }
-    }
-}
-
-actual fun findCatalogModelInDownloads(fileName: String): String? {
-    val downloads = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-    val candidate = File(downloads, fileName)
-    return if (candidate.isFile && candidate.canRead() && candidate.length() > 0L) {
-        candidate.absolutePath
-    } else {
-        null
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUi.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUi.kt
@@ -23,6 +23,8 @@ data class LocalModelUi(
     val isRecommended: Boolean,
     val defaultContextTokens: Int,
     val maxContextTokens: Int,
+    /** Absolute path to a Downloads candidate for import, if the repository found one. */
+    val existingImportPath: String? = null,
 )
 
 enum class DevicePerformanceUi {
@@ -49,7 +51,7 @@ sealed interface LocalModelDownloadUiState {
     ) : LocalModelDownloadUiState
 }
 
-fun LocalModel.toUi(): LocalModelUi = LocalModelUi(
+fun LocalModel.toUi(existingImportPath: String? = null): LocalModelUi = LocalModelUi(
     id = id,
     displayName = displayName,
     fileName = fileName,
@@ -57,6 +59,7 @@ fun LocalModel.toUi(): LocalModelUi = LocalModelUi(
     isRecommended = isRecommended,
     defaultContextTokens = defaultContextTokens,
     maxContextTokens = maxContextTokens,
+    existingImportPath = existingImportPath,
 )
 
 fun DevicePerformance.toUi(): DevicePerformanceUi = when (this) {

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -22,7 +22,6 @@ import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
 import io.ktor.http.parseUrl
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -33,7 +32,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.datetime.TimeZone
 
@@ -110,8 +108,7 @@ class SettingsViewModel(
                     ?: localModelRepository.downloadState.value.toUi()
                 val preservedLocalReadyIds = (current as? SettingsUiState.Ready)?.localReadyIds
                     ?: computeLocalReadyIds()
-                // Avoid filesystem Downloads scan on the combine collector thread; refreshed
-                // asynchronously via refreshLocalReadyIds() (Dispatchers.Default).
+                // Initial catalog without Downloads scan; refreshLocalReadyIds() fills paths.
                 val preservedLocalCatalog = (current as? SettingsUiState.Ready)?.localModelCatalog
                     ?: localModelRepository.catalog().map { it.toUi() }
                 val preservedLocalContextTokens =
@@ -214,7 +211,7 @@ class SettingsViewModel(
             }
         }
 
-        // Downloads discovery may touch the filesystem (#479) — keep off the main thread.
+        // Best-effort Downloads discovery (#479); single File.exists per catalog row.
         viewModelScope.launch {
             refreshLocalReadyIds()
         }
@@ -468,11 +465,9 @@ class SettingsViewModel(
             model.toUi(existingImportPath = existing)
         }
 
-    private suspend fun refreshLocalReadyIds() {
-        val (readyIds, catalogUi) = withContext(Dispatchers.Default) {
-            val ready = computeLocalReadyIds()
-            ready to buildLocalModelCatalog(ready)
-        }
+    private fun refreshLocalReadyIds() {
+        val readyIds = computeLocalReadyIds()
+        val catalogUi = buildLocalModelCatalog(readyIds)
         updateReady {
             copy(
                 localReadyIds = readyIds,

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -22,6 +22,7 @@ import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
 import io.ktor.http.parseUrl
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -32,6 +33,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.datetime.TimeZone
 
@@ -52,8 +54,6 @@ class SettingsViewModel(
     private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
-    private val localModelCatalog: List<LocalModelUi> =
-        localModelRepository.catalog().map { it.toUi() }
     private val hasAvx2Support: Boolean = localModelRepository.hasAvx2Support()
 
     init {
@@ -110,8 +110,10 @@ class SettingsViewModel(
                     ?: localModelRepository.downloadState.value.toUi()
                 val preservedLocalReadyIds = (current as? SettingsUiState.Ready)?.localReadyIds
                     ?: computeLocalReadyIds()
+                // Avoid filesystem Downloads scan on the combine collector thread; refreshed
+                // asynchronously via refreshLocalReadyIds() (Dispatchers.Default).
                 val preservedLocalCatalog = (current as? SettingsUiState.Ready)?.localModelCatalog
-                    ?: localModelCatalog
+                    ?: localModelRepository.catalog().map { it.toUi() }
                 val preservedLocalContextTokens =
                     (current as? SettingsUiState.Ready)?.localModelContextTokens
                         ?: initialLocalContextTokens
@@ -210,6 +212,11 @@ class SettingsViewModel(
             assistantRepository.modelContextTokensFlow.collect { tokens ->
                 updateReady { copy(localModelContextTokens = tokens) }
             }
+        }
+
+        // Downloads discovery may touch the filesystem (#479) — keep off the main thread.
+        viewModelScope.launch {
+            refreshLocalReadyIds()
         }
     }
 
@@ -451,8 +458,27 @@ class SettingsViewModel(
             .filter { localModelRepository.isReady(it) }
             .toSet()
 
-    private fun refreshLocalReadyIds() {
-        updateReady { copy(localReadyIds = computeLocalReadyIds()) }
+    private fun buildLocalModelCatalog(readyIds: Set<String>): List<LocalModelUi> =
+        localModelRepository.catalog().map { model ->
+            val existing = if (model.id in readyIds) {
+                null
+            } else {
+                localModelRepository.findExistingImportCandidate(model.id)
+            }
+            model.toUi(existingImportPath = existing)
+        }
+
+    private suspend fun refreshLocalReadyIds() {
+        val (readyIds, catalogUi) = withContext(Dispatchers.Default) {
+            val ready = computeLocalReadyIds()
+            ready to buildLocalModelCatalog(ready)
+        }
+        updateReady {
+            copy(
+                localReadyIds = readyIds,
+                localModelCatalog = catalogUi,
+            )
+        }
     }
 
     // --- Tools (MCP) ---

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.kt
@@ -25,9 +25,3 @@ expect fun rememberLocalModelImportController(
     onPreparing: () -> Unit,
     onResult: (LocalModelImportPick) -> Unit,
 ): LocalModelImportController
-
-/**
- * Best-effort lookup of a catalog filename under the user Downloads folder.
- * Call from a background dispatcher — may touch the filesystem.
- */
-expect fun findCatalogModelInDownloads(fileName: String): String?

--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/OnDeviceProviderCard.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/OnDeviceProviderCard.kt
@@ -31,7 +31,6 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -73,8 +72,6 @@ import io.github.leogallego.ansiblejane.presentation.settings.LocalModelDownload
 import io.github.leogallego.ansiblejane.presentation.settings.LocalModelUi
 import io.github.leogallego.ansiblejane.presentation.settings.formatLocalModelSizeGb
 import io.github.leogallego.ansiblejane.ui.theme.AnsibleJaneTheme
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlin.math.roundToInt
 import org.jetbrains.compose.resources.stringResource
 
@@ -237,16 +234,7 @@ internal fun LocalModelRow(
     val isDownloadingThis = downloading?.modelId == model.id
     val error = downloadState as? LocalModelDownloadUiState.Error
     val errorForThis = error?.takeIf { it.modelId == model.id }
-    var existingPath by remember(model.fileName) { mutableStateOf<String?>(null) }
-    LaunchedEffect(model.fileName, isReady) {
-        existingPath = if (isReady) {
-            null
-        } else {
-            withContext(Dispatchers.IO) {
-                findCatalogModelInDownloads(model.fileName)
-            }
-        }
-    }
+    val existingPath = model.existingImportPath
     var importPrepareStarted by remember { mutableStateOf(false) }
     val importController = rememberLocalModelImportController(
         onPreparing = {

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeLocalModelRepository.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/fakes/FakeLocalModelRepository.kt
@@ -28,6 +28,7 @@ class FakeLocalModelRepository(
         private set
     var importCalls: List<Pair<String, String>> = emptyList()
         private set
+    var existingImportCandidates: Map<String, String> = emptyMap()
 
     override fun catalog(): List<LocalModel> = models
 
@@ -73,6 +74,9 @@ class FakeLocalModelRepository(
             isImport = true,
         )
     }
+
+    override fun findExistingImportCandidate(modelId: String): String? =
+        existingImportCandidates[modelId]
 
     override fun devicePerformance(modelId: String, contextTokens: Int): DevicePerformance =
         performance

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUiMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/LocalModelUiMapperTest.kt
@@ -8,11 +8,13 @@ import aapremotecontrol.composeapp.generated.resources.agent_local_download_time
 import aapremotecontrol.composeapp.generated.resources.agent_local_hash_mismatch
 import aapremotecontrol.composeapp.generated.resources.agent_local_import_failed
 import io.github.leogallego.ansiblejane.assistant.local.DevicePerformance
+import io.github.leogallego.ansiblejane.assistant.local.LOCAL_MODEL_CATALOG
 import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadErrorKind
 import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadState
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class LocalModelUiMapperTest {
@@ -77,5 +79,15 @@ class LocalModelUiMapperTest {
         assertEquals("3.4", formatLocalModelSizeGb(3_659_530_240L))
         assertEquals("6.1", formatLocalModelSizeGb(6_547_589_312L))
         assertEquals("0.0", formatLocalModelSizeGb(0L))
+    }
+
+    @Test
+    fun `toUi carries optional existing import path`() {
+        val model = LOCAL_MODEL_CATALOG.first()
+        assertNull(model.toUi().existingImportPath)
+        assertEquals(
+            "/downloads/${model.fileName}",
+            model.toUi(existingImportPath = "/downloads/${model.fileName}").existingImportPath,
+        )
     }
 }

--- a/composeApp/src/desktopMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/io/github/leogallego/ansiblejane/ui/settings/LocalModelImport.desktop.kt
@@ -38,16 +38,6 @@ actual fun rememberLocalModelImportController(
     }
 }
 
-actual fun findCatalogModelInDownloads(fileName: String): String? {
-    val home = System.getProperty("user.home") ?: return null
-    val candidate = File(home, "Downloads${File.separator}$fileName")
-    return if (candidate.isFile && candidate.canRead() && candidate.length() > 0L) {
-        candidate.absolutePath
-    } else {
-        null
-    }
-}
-
 private suspend fun pickFileOnEdt(): LocalModelImportPick =
     withContext(Dispatchers.IO) {
         suspendCancellableCoroutine { cont ->

--- a/shared/src/androidMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelFiles.android.kt
+++ b/shared/src/androidMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelFiles.android.kt
@@ -1,5 +1,6 @@
 package io.github.leogallego.ansiblejane.assistant.local
 
+import android.os.Environment
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -66,5 +67,15 @@ internal actual object LocalModelFiles {
             file = File(file, part)
         }
         return file.path
+    }
+
+    actual fun findInUserDownloads(fileName: String): String? {
+        val downloads = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        val candidate = File(downloads, fileName)
+        return if (candidate.isFile && candidate.canRead() && candidate.length() > 0L) {
+            candidate.absolutePath
+        } else {
+            null
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/di/AssistantDiModule.kt
@@ -32,6 +32,9 @@ import org.koin.dsl.module
 val sharedAssistantModule = module {
     single<IDeviceResources> { get<DeviceResources>().asIDeviceResources() }
 
+    // Process-scoped transfer scope (#478): must outlive Settings ViewModel so multi-GB
+    // LiteRT download/import is not cancelled when leaving the screen. Do not use viewModelScope.
+    // Optional later: inject named("localModelTransfers") with the same process lifetime.
     single {
         LocalModelRepository(
             deviceResources = get(),

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/ILocalModelRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/ILocalModelRepository.kt
@@ -2,6 +2,14 @@ package io.github.leogallego.ansiblejane.assistant.local
 
 import kotlinx.coroutines.flow.StateFlow
 
+/**
+ * On-device LiteRT model catalog, readiness, and multi-GB transfer orchestration (#264 / #469).
+ *
+ * **Transfer scope:** implementations that perform download/import own a **process-scoped**
+ * coroutine scope (Koin singleton — not `viewModelScope`). Multi-GB transfers must survive
+ * leaving Settings; callers cancel via [cancelDownload], not by clearing the ViewModel.
+ * A future `@Named("localModelTransfers")` injected scope is fine if it stays process-scoped.
+ */
 interface ILocalModelRepository {
     val downloadState: StateFlow<LocalModelDownloadState>
     fun catalog(): List<LocalModel>
@@ -19,6 +27,12 @@ interface ILocalModelRepository {
     fun notifyTransferError(modelId: String, kind: LocalModelDownloadErrorKind)
     /** Show Importing progress while a platform prepare/copy runs before [importFromPath]. */
     fun markImportPreparing(modelId: String)
+    /**
+     * Best-effort absolute path to a catalog [modelId] file already present under the user
+     * Downloads folder (readable, non-empty). Null when unknown/ready/missing. May touch the
+     * filesystem — call off the main thread when used from UI.
+     */
+    fun findExistingImportCandidate(modelId: String): String?
     fun devicePerformance(modelId: String, contextTokens: Int): DevicePerformance
     fun hasAvx2Support(): Boolean
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelFiles.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelFiles.kt
@@ -21,4 +21,9 @@ internal expect object LocalModelFiles {
     fun openSink(path: String, append: Boolean = false): ModelFileSink
     fun openSource(path: String): ModelFileSource
     fun join(parent: String, vararg parts: String): String
+    /**
+     * Best-effort lookup of [fileName] under the user Downloads directory.
+     * Returns an absolute path when the file exists, is readable, and non-empty.
+     */
+    fun findInUserDownloads(fileName: String): String?
 }

--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepository.kt
@@ -21,6 +21,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
+/**
+ * Default [ILocalModelRepository].
+ *
+ * [scope] must be process-scoped (see interface KDoc / #478). Transfers run on [scope] via
+ * exclusive jobs so cancel/resume survive Settings navigation; do not pass `viewModelScope`.
+ */
 class LocalModelRepository(
     private val deviceResources: IDeviceResources,
     private val httpClient: HttpClient,
@@ -143,6 +149,12 @@ class LocalModelRepository(
             totalBytes = 1L,
             isImport = true,
         )
+    }
+
+    override fun findExistingImportCandidate(modelId: String): String? {
+        val model = catalog.find { it.id == modelId } ?: return null
+        if (isReady(modelId)) return null
+        return LocalModelFiles.findInUserDownloads(model.fileName)
     }
 
     override fun devicePerformance(modelId: String, contextTokens: Int): DevicePerformance {

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepositoryTest.kt
@@ -55,6 +55,20 @@ class LocalModelRepositoryTest {
         assertNotNull(repo.modelPath(model.id))
         assertTrue(LocalModelFiles.exists(checkNotNull(repo.modelPath(model.id))))
         assertIs<LocalModelDownloadState.Succeeded>(repo.downloadState.value)
+        // Ready models never advertise a Downloads candidate (#479).
+        assertNull(repo.findExistingImportCandidate(model.id))
+    }
+
+    @Test
+    fun findExistingImportCandidate_unknownModel_returnsNull() = runTest {
+        val model = testModel(sha256 = payloadSha256, sizeBytes = payload.size.toLong())
+        val repo = createRepo(
+            catalog = listOf(model),
+            modelRoot = newRoot(),
+            freeDiskBytes = model.sizeBytes + diskBufferBytes + 1,
+            responseBody = payload,
+        )
+        assertNull(repo.findExistingImportCandidate("does-not-exist"))
     }
 
     @Test

--- a/shared/src/jvmMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelFiles.jvm.kt
+++ b/shared/src/jvmMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelFiles.jvm.kt
@@ -67,4 +67,14 @@ internal actual object LocalModelFiles {
         }
         return file.path
     }
+
+    actual fun findInUserDownloads(fileName: String): String? {
+        val home = System.getProperty("user.home") ?: return null
+        val candidate = File(home, "Downloads${File.separator}$fileName")
+        return if (candidate.isFile && candidate.canRead() && candidate.length() > 0L) {
+            candidate.absolutePath
+        } else {
+            null
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- **#478:** KDoc/comments documenting why `LocalModelRepository` owns a process-scoped transfer `CoroutineScope` (must outlive Settings / not use `viewModelScope`).
- **#479:** `ILocalModelRepository.findExistingImportCandidate` + `LocalModelFiles.findInUserDownloads`; UI reads `LocalModelUi.existingImportPath` from the ViewModel (no Compose filesystem scan).
- Built on current `main` including #474 context-window fields.

## Test plan
- [x] `:shared:jvmTest` — `LocalModelRepositoryTest`
- [x] `:composeApp:desktopTest` — `LocalModelUiMapperTest`
- [ ] Settings → Agent → On-device: "Use existing file" still appears when a catalog `.litertlm` is in Downloads
- [ ] Architecture review (contracts) before merge

## Sequence
Follow-ups: #480 (extract transfer), #481 (FGS).

Closes #478
Closes #479

Assisted-by: Cursor (Grok 4.5)