### PR TITLE
feat(android): foreground service for LiteRT model downloads

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application
         android:name=".AnsibleJaneApp"
@@ -37,6 +39,10 @@
         <receiver
             android:name=".notification.ApprovalActionReceiver"
             android:exported="false" />
+        <service
+            android:name=".notification.ModelDownloadForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/AnsibleJaneApp.kt
@@ -9,8 +9,10 @@ import androidx.work.WorkManager
 import io.github.leogallego.ansiblejane.data.IUserPreferencesRepository
 import io.github.leogallego.ansiblejane.model.PollInterval
 import io.github.leogallego.ansiblejane.data.dataModule
+import io.github.leogallego.ansiblejane.assistant.local.ILocalModelRepository
 import io.github.leogallego.ansiblejane.notification.ApprovalNotificationManager
 import io.github.leogallego.ansiblejane.notification.ApprovalPollingWorker
+import io.github.leogallego.ansiblejane.notification.ModelDownloadForegroundObserver
 import io.github.leogallego.ansiblejane.platform.DataStoreFactory
 import io.github.leogallego.ansiblejane.platform.SecureKeyStorage
 import io.github.leogallego.ansiblejane.platform.TinkMigration
@@ -59,6 +61,13 @@ class AnsibleJaneApp : Application() {
         }
 
         ApprovalNotificationManager.createChannel(this)
+
+        val localModelRepository: ILocalModelRepository by inject()
+        ModelDownloadForegroundObserver(
+            appContext = this,
+            repository = localModelRepository,
+            scope = appScope,
+        ).start()
 
         val userPreferences: IUserPreferencesRepository by inject()
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserver.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserver.kt
@@ -1,0 +1,62 @@
+package io.github.leogallego.ansiblejane.notification
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.content.ContextCompat
+import io.github.leogallego.ansiblejane.assistant.local.ILocalModelRepository
+import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+/**
+ * Bridges [ILocalModelRepository.downloadState] to [ModelDownloadForegroundService].
+ *
+ * Starts the FGS only for network catalog downloads (`Downloading && !isImport`).
+ * Import/SAF transfers stay in-process without a foreground service.
+ */
+class ModelDownloadForegroundObserver(
+    private val appContext: Context,
+    private val repository: ILocalModelRepository,
+    private val scope: CoroutineScope,
+) {
+    fun start() {
+        scope.launch {
+            repository.downloadState
+                .map { state ->
+                    state is LocalModelDownloadState.Downloading && !state.isImport
+                }
+                .distinctUntilChanged()
+                .collect { networkDownloadActive ->
+                    if (networkDownloadActive) {
+                        startService()
+                    } else {
+                        stopService()
+                    }
+                }
+        }
+    }
+
+    private fun startService() {
+        try {
+            val intent = Intent(appContext, ModelDownloadForegroundService::class.java)
+            ContextCompat.startForegroundService(appContext, intent)
+        } catch (e: Exception) {
+            Log.w(TAG, "Unable to start model download FGS", e)
+        }
+    }
+
+    private fun stopService() {
+        try {
+            appContext.stopService(Intent(appContext, ModelDownloadForegroundService::class.java))
+        } catch (e: Exception) {
+            Log.w(TAG, "Unable to stop model download FGS", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "ModelDownloadFgs"
+    }
+}

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundService.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundService.kt
@@ -1,0 +1,208 @@
+package io.github.leogallego.ansiblejane.notification
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import io.github.leogallego.ansiblejane.MainActivity
+import io.github.leogallego.ansiblejane.R
+import io.github.leogallego.ansiblejane.assistant.local.ILocalModelRepository
+import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
+
+/**
+ * Ongoing foreground service for LiteRT **network** model downloads (#481).
+ *
+ * SAF/import transfers never start this service — see [ModelDownloadForegroundObserver].
+ * Observes [ILocalModelRepository.downloadState] for progress and self-stops on
+ * Idle / Error / Succeeded / cancel, or when the OS fires [onTimeout].
+ */
+class ModelDownloadForegroundService : Service() {
+
+    companion object {
+        const val CHANNEL_ID = "litert_model_download"
+        const val NOTIFICATION_ID = 0x4A414E46 // "JANF" — distinct from approval summary
+        const val ACTION_CANCEL = "io.github.leogallego.ansiblejane.action.CANCEL_MODEL_DOWNLOAD"
+    }
+
+    private val repository: ILocalModelRepository by inject()
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var observing = false
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+        val started = try {
+            ServiceCompat.startForeground(
+                this,
+                NOTIFICATION_ID,
+                buildNotification(indeterminate = true),
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+            true
+        } catch (_: Exception) {
+            false
+        }
+        if (!started) {
+            stopSelf()
+            return
+        }
+        startObserving()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_CANCEL) {
+            repository.cancelDownload()
+            stopAndClear()
+            return START_NOT_STICKY
+        }
+        if (!observing) {
+            startObserving()
+        }
+        return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onTimeout(startId: Int, fgsType: Int) {
+        repository.cancelDownload()
+        stopAndClear()
+    }
+
+    override fun onDestroy() {
+        serviceScope.cancel()
+        observing = false
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        super.onDestroy()
+    }
+
+    private fun startObserving() {
+        if (observing) return
+        observing = true
+        serviceScope.launch {
+            repository.downloadState.collectLatest { state ->
+                when (state) {
+                    is LocalModelDownloadState.Downloading -> {
+                        if (state.isImport) {
+                            stopAndClear()
+                        } else {
+                            val percent = progressPercent(state.bytesReceived, state.totalBytes)
+                            val title = displayName(state.modelId)
+                            val text = if (percent != null) {
+                                getString(R.string.model_download_notification_progress, percent)
+                            } else {
+                                getString(R.string.model_download_notification_text)
+                            }
+                            notifyProgress(
+                                title = title,
+                                text = text,
+                                percent = percent,
+                            )
+                        }
+                    }
+                    else -> stopAndClear()
+                }
+            }
+        }
+    }
+
+    private fun displayName(modelId: String): String =
+        repository.catalog().find { it.id == modelId }?.displayName ?: modelId
+
+    private fun progressPercent(bytesReceived: Long, totalBytes: Long): Int? {
+        if (totalBytes <= 0L) return null
+        return ((bytesReceived * 100L) / totalBytes).toInt().coerceIn(0, 100)
+    }
+
+    private fun notifyProgress(title: String, text: String, percent: Int?) {
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.notify(
+            NOTIFICATION_ID,
+            buildNotification(
+                title = title,
+                text = text,
+                percent = percent,
+                indeterminate = percent == null,
+            ),
+        )
+    }
+
+    private fun stopAndClear() {
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.model_download_channel_name),
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = getString(R.string.model_download_channel_description)
+        }
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(
+        title: String = getString(R.string.app_name),
+        text: String = getString(R.string.model_download_notification_text),
+        percent: Int? = null,
+        indeterminate: Boolean = true,
+    ): Notification {
+        val contentIntent = packageManager.getLaunchIntentForPackage(packageName)?.apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        } ?: Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val contentPendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            contentIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val cancelIntent = Intent(this, ModelDownloadForegroundService::class.java).apply {
+            action = ACTION_CANCEL
+        }
+        val cancelPendingIntent = PendingIntent.getService(
+            this,
+            1,
+            cancelIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setContentIntent(contentPendingIntent)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .addAction(
+                0,
+                getString(R.string.action_cancel),
+                cancelPendingIntent,
+            )
+
+        if (indeterminate || percent == null) {
+            builder.setProgress(100, 0, true)
+        } else {
+            builder.setProgress(100, percent, false)
+        }
+        return builder.build()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,12 @@
     <string name="notification_approval_failed_message">Please try again</string>
     <string name="notification_no_active_instance">No active instance</string>
 
+    <!-- Notification: LiteRT model download FGS (#481) -->
+    <string name="model_download_channel_name">Model downloads</string>
+    <string name="model_download_channel_description">Progress for on-device LiteRT model downloads</string>
+    <string name="model_download_notification_text">Downloading model…</string>
+    <string name="model_download_notification_progress">Downloading… %1$d%%</string>
+
 
     <!-- Shared component text -->
     <string name="show_details">Show details</string>

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeLocalModelRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeLocalModelRepository.kt
@@ -1,0 +1,61 @@
+package io.github.leogallego.ansiblejane.fakes
+
+import io.github.leogallego.ansiblejane.assistant.local.DevicePerformance
+import io.github.leogallego.ansiblejane.assistant.local.ILocalModelRepository
+import io.github.leogallego.ansiblejane.assistant.local.LOCAL_MODEL_CATALOG
+import io.github.leogallego.ansiblejane.assistant.local.LocalModel
+import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadErrorKind
+import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakeLocalModelRepository(
+    private val models: List<LocalModel> = LOCAL_MODEL_CATALOG,
+) : ILocalModelRepository {
+    private val _downloadState =
+        MutableStateFlow<LocalModelDownloadState>(LocalModelDownloadState.Idle)
+    override val downloadState: StateFlow<LocalModelDownloadState> = _downloadState.asStateFlow()
+
+    var cancelCount: Int = 0
+        private set
+
+    fun emit(state: LocalModelDownloadState) {
+        _downloadState.value = state
+    }
+
+    override fun catalog(): List<LocalModel> = models
+
+    override fun isReady(modelId: String): Boolean = false
+
+    override fun modelPath(modelId: String): String? = null
+
+    override suspend fun download(modelId: String) = Unit
+
+    override fun cancelDownload() {
+        cancelCount++
+        _downloadState.value = LocalModelDownloadState.Idle
+    }
+
+    override suspend fun delete(modelId: String) = Unit
+
+    override suspend fun importFromPath(modelId: String, sourceAbsolutePath: String) = Unit
+
+    override fun notifyTransferError(modelId: String, kind: LocalModelDownloadErrorKind) {
+        _downloadState.value = LocalModelDownloadState.Error(modelId, kind)
+    }
+
+    override fun markImportPreparing(modelId: String) {
+        _downloadState.value = LocalModelDownloadState.Downloading(
+            modelId = modelId,
+            bytesReceived = 0L,
+            totalBytes = 0L,
+            isImport = true,
+        )
+    }
+
+    override fun devicePerformance(modelId: String, contextTokens: Int): DevicePerformance =
+        DevicePerformance.OK
+
+    override fun hasAvx2Support(): Boolean = true
+}

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeLocalModelRepository.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/fakes/FakeLocalModelRepository.kt
@@ -54,6 +54,8 @@ class FakeLocalModelRepository(
         )
     }
 
+    override fun findExistingImportCandidate(modelId: String): String? = null
+
     override fun devicePerformance(modelId: String, contextTokens: Int): DevicePerformance =
         DevicePerformance.OK
 

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserverTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserverTest.kt
@@ -1,0 +1,181 @@
+package io.github.leogallego.ansiblejane.notification
+
+import android.content.Intent
+import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadErrorKind
+import io.github.leogallego.ansiblejane.assistant.local.LocalModelDownloadState
+import io.github.leogallego.ansiblejane.fakes.FakeLocalModelRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class ModelDownloadForegroundObserverTest {
+
+    @Test
+    fun startsService_forNetworkDownloading() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = TestScope(dispatcher)
+        val repo = FakeLocalModelRepository()
+        val context = RuntimeEnvironment.getApplication()
+        val shadow = shadowOf(context)
+
+        ModelDownloadForegroundObserver(context, repo, scope).start()
+        advanceUntilIdle()
+        assertNull(shadow.nextStartedService)
+
+        repo.emit(
+            LocalModelDownloadState.Downloading(
+                modelId = "gemma-4-e4b-it",
+                bytesReceived = 1_000L,
+                totalBytes = 10_000L,
+                isImport = false,
+            ),
+        )
+        advanceUntilIdle()
+
+        val started = shadow.nextStartedService
+        assertNotNull(started)
+        assertEquals(
+            ModelDownloadForegroundService::class.java.name,
+            started!!.component!!.className,
+        )
+    }
+
+    @Test
+    fun doesNotStartService_forImportDownloading() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = TestScope(dispatcher)
+        val repo = FakeLocalModelRepository()
+        val context = RuntimeEnvironment.getApplication()
+        val shadow = shadowOf(context)
+
+        ModelDownloadForegroundObserver(context, repo, scope).start()
+        repo.emit(
+            LocalModelDownloadState.Downloading(
+                modelId = "gemma-4-e4b-it",
+                bytesReceived = 1_000L,
+                totalBytes = 10_000L,
+                isImport = true,
+            ),
+        )
+        advanceUntilIdle()
+
+        assertNull(shadow.nextStartedService)
+    }
+
+    @Test
+    fun stopsService_onTerminalStates() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = TestScope(dispatcher)
+        val repo = FakeLocalModelRepository()
+        val context = RuntimeEnvironment.getApplication()
+        val shadow = shadowOf(context)
+
+        ModelDownloadForegroundObserver(context, repo, scope).start()
+        repo.emit(
+            LocalModelDownloadState.Downloading(
+                modelId = "gemma-4-e4b-it",
+                bytesReceived = 1_000L,
+                totalBytes = 10_000L,
+                isImport = false,
+            ),
+        )
+        advanceUntilIdle()
+        assertNotNull(shadow.nextStartedService)
+
+        repo.emit(LocalModelDownloadState.Succeeded("gemma-4-e4b-it"))
+        advanceUntilIdle()
+        val stopped = shadow.nextStoppedService
+        assertNotNull(stopped)
+        assertEquals(
+            ModelDownloadForegroundService::class.java.name,
+            stopped!!.component!!.className,
+        )
+
+        repo.emit(
+            LocalModelDownloadState.Downloading(
+                modelId = "gemma-4-e4b-it",
+                bytesReceived = 0L,
+                totalBytes = 10_000L,
+                isImport = false,
+            ),
+        )
+        advanceUntilIdle()
+        assertNotNull(shadow.nextStartedService)
+
+        repo.emit(
+            LocalModelDownloadState.Error(
+                "gemma-4-e4b-it",
+                LocalModelDownloadErrorKind.NETWORK,
+            ),
+        )
+        advanceUntilIdle()
+        assertNotNull(shadow.nextStoppedService)
+
+        repo.emit(
+            LocalModelDownloadState.Downloading(
+                modelId = "gemma-4-e4b-it",
+                bytesReceived = 0L,
+                totalBytes = 10_000L,
+                isImport = false,
+            ),
+        )
+        advanceUntilIdle()
+        assertNotNull(shadow.nextStartedService)
+
+        repo.emit(LocalModelDownloadState.Idle)
+        advanceUntilIdle()
+        assertNotNull(shadow.nextStoppedService)
+    }
+
+    @Test
+    fun cancelAction_callsRepositoryCancel() = runTest {
+        val repo = FakeLocalModelRepository()
+        val context = RuntimeEnvironment.getApplication()
+        repo.emit(
+            LocalModelDownloadState.Downloading(
+                modelId = "gemma-4-e4b-it",
+                bytesReceived = 500L,
+                totalBytes = 1_000L,
+                isImport = false,
+            ),
+        )
+        org.koin.core.context.startKoin {
+            modules(
+                org.koin.dsl.module {
+                    single<io.github.leogallego.ansiblejane.assistant.local.ILocalModelRepository> {
+                        repo
+                    }
+                },
+            )
+        }
+        try {
+            val service = org.robolectric.Robolectric.buildService(
+                ModelDownloadForegroundService::class.java,
+                Intent(context, ModelDownloadForegroundService::class.java),
+            ).create().get()
+            service.onStartCommand(
+                Intent(context, ModelDownloadForegroundService::class.java).apply {
+                    action = ModelDownloadForegroundService.ACTION_CANCEL
+                },
+                0,
+                1,
+            )
+            assertEquals(1, repo.cancelCount)
+            assertEquals(LocalModelDownloadState.Idle, repo.downloadState.value)
+        } finally {
+            org.koin.core.context.stopKoin()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Android FGS (`dataSync`) + observer for LiteRT **network** downloads (`Downloading && !isImport`).
- Starts/updates/stops notification from `ILocalModelRepository.downloadState`.
- Import/SAF path does not use FGS.
- Unit tests for observer start/stop/import-skip.

## Test plan
- [x] `:app:testDebugUnitTest` — `ModelDownloadForegroundObserverTest`
- [ ] Phone smoke: start E4B download, home + lock; cancel clears notification
- [ ] Architecture review before merge

Closes #481

Assisted-by: Cursor (Grok 4.5)