### PR TITLE
fix(local-model): keep transferJob until process-scoped transfer ends

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelTransfer.kt
+++ b/shared/src/commonMain/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelTransfer.kt
@@ -106,21 +106,26 @@ internal class LocalModelTransfer(
     }
 
     private suspend fun runExclusiveTransfer(block: suspend () -> Unit) {
+        // Launch on the process-scoped [scope] so the transfer survives Settings
+        // leaving (caller cancel). Clear [transferJob] only when *this* job
+        // completes — never in a finally around join(), or cancelDownload()
+        // loses the handle while the transfer keeps running (#492).
         val job = synchronized(transferJobLock) {
             transferJob?.cancel()
             scope.launch {
-                block()
+                try {
+                    block()
+                } finally {
+                    val self = currentCoroutineContext()[Job]
+                    synchronized(transferJobLock) {
+                        if (transferJob === self) {
+                            transferJob = null
+                        }
+                    }
+                }
             }.also { transferJob = it }
         }
-        try {
-            job.join()
-        } finally {
-            synchronized(transferJobLock) {
-                if (transferJob === job) {
-                    transferJob = null
-                }
-            }
-        }
+        job.join()
     }
 
     private suspend fun runImport(

--- a/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/leogallego/ansiblejane/assistant/local/LocalModelRepositoryTest.kt
@@ -150,6 +150,62 @@ class LocalModelRepositoryTest {
     }
 
     @Test
+    fun cancelDownload_stillWorksAfterCallerScopeCancelled() = runTest {
+        // Process scope owns the transfer; a separate caller scope simulates
+        // Settings viewModelScope leaving mid-download (#492).
+        val model = testModel(sha256 = payloadSha256, sizeBytes = payload.size.toLong())
+        val root = newRoot()
+        val engine = MockEngine {
+            delay(10_000)
+            respond(
+                content = payload,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/octet-stream"),
+            )
+        }
+        val client = HttpClient(engine) { expectSuccess = false }
+        val processScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scopes += processScope
+        val repo = LocalModelRepository(
+            deviceResources = FakeDeviceResources(
+                freeDiskBytes = model.sizeBytes + diskBufferBytes + 1,
+                modelStorageDirectory = root,
+            ),
+            httpClient = client,
+            scope = processScope,
+            catalog = listOf(model),
+            modelRootOverride = root,
+        )
+
+        val callerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scopes += callerScope
+        callerScope.launch { repo.download(model.id) }
+
+        var attempts = 0
+        while (repo.downloadState.value !is LocalModelDownloadState.Downloading && attempts < 100) {
+            delay(50)
+            attempts++
+        }
+        assertIs<LocalModelDownloadState.Downloading>(repo.downloadState.value)
+
+        callerScope.cancel()
+        delay(100)
+        assertIs<LocalModelDownloadState.Downloading>(
+            repo.downloadState.value,
+            "process-scoped transfer must keep running after caller cancel",
+        )
+
+        repo.cancelDownload()
+        attempts = 0
+        while (repo.downloadState.value is LocalModelDownloadState.Downloading && attempts < 100) {
+            delay(50)
+            attempts++
+        }
+        assertIs<LocalModelDownloadState.Idle>(repo.downloadState.value)
+        assertFalse(repo.isReady(model.id))
+    }
+
+    @Test
     fun download_diskCheckCreditsExistingPartial() = runTest {
         val model = testModel(sha256 = payloadSha256, sizeBytes = 1_000L)
         val root = newRoot()


### PR DESCRIPTION
## Summary
- Clear `transferJob` only when the process-scoped transfer job completes, not when the awaiting Settings caller is cancelled.
- Fixes Cancel from Settings / FGS notification / timeout no-op after leaving Settings (#492).
- Regression test: separate caller scope cancelled mid-download; `cancelDownload()` still stops the transfer.

## Architecture review
- [x] `pr-architecture-review` + coroutines structured-concurrency — **Clean**

## Test plan
- [x] `./gradlew --no-daemon :shared:jvmTest --tests 'io.github.leogallego.ansiblejane.assistant.local.LocalModelRepositoryTest'`
- [ ] Manual: start LiteRT download → leave Settings → Cancel from notification → transfer stops

Closes #492

Assisted-by: Cursor (Grok 4.5)