### PR TITLE
fix(settings): off-main Downloads discovery after first Ready

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModel.kt
@@ -22,6 +22,8 @@ import io.github.leogallego.ansiblejane.assistant.tools.ToolSource
 import io.github.leogallego.ansiblejane.ui.components.DateFormatter
 import io.github.leogallego.ansiblejane.ui.components.TimeFormat
 import io.ktor.http.parseUrl
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -32,6 +34,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.datetime.TimeZone
 
@@ -46,7 +49,9 @@ class SettingsViewModel(
     private val toolRouter: ToolRouter,
     private val localModelRepository: ILocalModelRepository,
     private val json: Json,
-    private val modelFetcher: ModelFetcher
+    private val modelFetcher: ModelFetcher,
+    /** Off-main dispatcher for local-model FS discovery; tests inject a test dispatcher. */
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
@@ -161,8 +166,20 @@ class SettingsViewModel(
                     expandedMcpServers = preservedExpandedMcp,
                     expandedCategories = preservedExpandedCats
                 )
-            }.collect { state ->
-                _uiState.update { state }
+            }.collect { incoming ->
+                // Keep refresh-owned local-model fields. A combine transform can
+                // capture Ready before Downloads discovery finishes and later
+                // overwrite existingImportPath (#493).
+                _uiState.update { prev ->
+                    if (prev is SettingsUiState.Ready && incoming is SettingsUiState.Ready) {
+                        incoming.copy(
+                            localReadyIds = prev.localReadyIds,
+                            localModelCatalog = prev.localModelCatalog,
+                        )
+                    } else {
+                        incoming
+                    }
+                }
             }
         }
 
@@ -211,8 +228,10 @@ class SettingsViewModel(
             }
         }
 
-        // Best-effort Downloads discovery (#479); single File.exists per catalog row.
+        // Best-effort Downloads discovery (#479). Wait for Ready so updateReady is
+        // not a no-op while Loading (#493); hop off Main for FS I/O.
         viewModelScope.launch {
+            uiState.first { it is SettingsUiState.Ready }
             refreshLocalReadyIds()
         }
     }
@@ -465,9 +484,11 @@ class SettingsViewModel(
             model.toUi(existingImportPath = existing)
         }
 
-    private fun refreshLocalReadyIds() {
-        val readyIds = computeLocalReadyIds()
-        val catalogUi = buildLocalModelCatalog(readyIds)
+    private suspend fun refreshLocalReadyIds() {
+        val (readyIds, catalogUi) = withContext(ioDispatcher) {
+            val readyIds = computeLocalReadyIds()
+            readyIds to buildLocalModelCatalog(readyIds)
+        }
         updateReady {
             copy(
                 localReadyIds = readyIds,

--- a/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/leogallego/ansiblejane/presentation/settings/SettingsViewModelTest.kt
@@ -28,6 +28,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -91,6 +92,7 @@ class SettingsViewModelTest {
     private fun createViewModel(
         localTools: List<LocalTool> = emptyList(),
         localModelRepository: FakeLocalModelRepository = fakeLocalModelRepo,
+        ioDispatcher: kotlinx.coroutines.CoroutineDispatcher = UnconfinedTestDispatcher(),
     ) = SettingsViewModel(
         tokenManager = fakeTokenManager,
         authRepository = fakeAuthRepository,
@@ -113,7 +115,8 @@ class SettingsViewModelTest {
                     }
                 }
             }
-        }
+        },
+        ioDispatcher = ioDispatcher,
     )
 
     @Test
@@ -544,5 +547,35 @@ class SettingsViewModelTest {
 
         val ready = assertIs<SettingsUiState.Ready>(viewModel.uiState.value)
         assertEquals(8_192, ready.localModelContextTokens["gemma-4-e4b-it"])
+    }
+
+    @Test
+    fun `Downloads existingImportPath appears after Ready when candidate exists`() = runTest {
+        // Regression #493: refresh must run after Ready (not while Loading) and via
+        // injected ioDispatcher so withContext does not hang under runTest.
+        fakeLocalModelRepo.existingImportCandidates = mapOf(
+            "gemma-4-e4b-it" to "/fake/Downloads/gemma.litertlm",
+        )
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val ready = assertIs<SettingsUiState.Ready>(viewModel.uiState.value)
+        val model = ready.localModelCatalog.first { it.id == "gemma-4-e4b-it" }
+        assertEquals("/fake/Downloads/gemma.litertlm", model.existingImportPath)
+    }
+
+    @Test
+    fun `Downloads existingImportPath stays null when model already ready`() = runTest {
+        fakeLocalModelRepo = FakeLocalModelRepository(readyIds = setOf("gemma-4-e4b-it"))
+        fakeLocalModelRepo.existingImportCandidates = mapOf(
+            "gemma-4-e4b-it" to "/fake/Downloads/gemma.litertlm",
+        )
+        val viewModel = createViewModel(localModelRepository = fakeLocalModelRepo)
+        advanceUntilIdle()
+
+        val ready = assertIs<SettingsUiState.Ready>(viewModel.uiState.value)
+        val model = ready.localModelCatalog.first { it.id == "gemma-4-e4b-it" }
+        assertNull(model.existingImportPath)
+        assertTrue("gemma-4-e4b-it" in ready.localReadyIds)
     }
 }


### PR DESCRIPTION
## Summary
- Inject `ioDispatcher` (default `Dispatchers.Default`) and hop off Main for Downloads/`isReady` discovery in `refreshLocalReadyIds`.
- Wait for first `SettingsUiState.Ready` before refresh so `updateReady` is not a no-op while Loading.
- Preserve refresh-owned `localReadyIds` / `localModelCatalog` across main combine collects so a stale snapshot cannot wipe `existingImportPath`.
- Regression tests for candidate path after Ready + null when already ready.

## Architecture review
- [x] Injected dispatcher + Ready gate + combine preserve (review Fixable → addressed)

## Test plan
- [x] `./gradlew --no-daemon :composeApp:desktopTest --tests 'io.github.leogallego.ansiblejane.presentation.settings.SettingsViewModelTest'`
- [ ] Manual: open Settings → Agent/On-device with a matching Downloads `.litertlm` → “Use existing” appears without leaving/re-entering

Closes #493

Assisted-by: Cursor (Grok 4.5)