### PR TITLE
fix(android): harden LiteRT download FGS start/stop and notify throttle

### DIFF
--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserver.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserver.kt
@@ -1,7 +1,10 @@
 package io.github.leogallego.ansiblejane.notification
 
+import android.app.Activity
+import android.app.Application
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
 import android.util.Log
 import androidx.core.content.ContextCompat
 import io.github.leogallego.ansiblejane.assistant.local.ILocalModelRepository
@@ -16,13 +19,23 @@ import kotlinx.coroutines.launch
  *
  * Starts the FGS only for network catalog downloads (`Downloading && !isImport`).
  * Import/SAF transfers stay in-process without a foreground service.
+ *
+ * Stop uses [ModelDownloadForegroundService.ACTION_STOP] via `startForegroundService`
+ * (never bare `stopService`) so a fast Downloading→Error cannot kill the service
+ * before `startForeground` (#494). Retries start when any activity reaches STARTED
+ * if a network download is still desired after a failed/background start.
  */
 class ModelDownloadForegroundObserver(
     private val appContext: Context,
     private val repository: ILocalModelRepository,
     private val scope: CoroutineScope,
-) {
+) : Application.ActivityLifecycleCallbacks {
+    @Volatile
+    private var networkDownloadDesired: Boolean = false
+
     fun start() {
+        val app = appContext.applicationContext as Application
+        app.registerActivityLifecycleCallbacks(this)
         scope.launch {
             repository.downloadState
                 .map { state ->
@@ -30,16 +43,36 @@ class ModelDownloadForegroundObserver(
                 }
                 .distinctUntilChanged()
                 .collect { networkDownloadActive ->
+                    val wasDesired = networkDownloadDesired
+                    networkDownloadDesired = networkDownloadActive
+                    ModelDownloadForegroundService.desiredActive = networkDownloadActive
                     if (networkDownloadActive) {
-                        startService()
-                    } else {
-                        stopService()
+                        requestStart()
+                    } else if (wasDesired) {
+                        // Only handshake-stop after an active download — never on
+                        // the initial Idle emission from StateFlow (#494).
+                        requestStop()
                     }
                 }
         }
     }
 
-    private fun startService() {
+    /** Retry FGS when returning to foreground if download is still active (#494). */
+    override fun onActivityStarted(activity: Activity) {
+        if (networkDownloadDesired) {
+            ModelDownloadForegroundService.desiredActive = true
+            requestStart()
+        }
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+    override fun onActivityResumed(activity: Activity) = Unit
+    override fun onActivityPaused(activity: Activity) = Unit
+    override fun onActivityStopped(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+    override fun onActivityDestroyed(activity: Activity) = Unit
+
+    private fun requestStart() {
         try {
             val intent = Intent(appContext, ModelDownloadForegroundService::class.java)
             ContextCompat.startForegroundService(appContext, intent)
@@ -48,11 +81,21 @@ class ModelDownloadForegroundObserver(
         }
     }
 
-    private fun stopService() {
+    private fun requestStop() {
         try {
-            appContext.stopService(Intent(appContext, ModelDownloadForegroundService::class.java))
+            // Handshake: deliver stop through startForegroundService so onCreate can
+            // always call startForeground before tearing down (#494).
+            val intent = Intent(appContext, ModelDownloadForegroundService::class.java).apply {
+                action = ModelDownloadForegroundService.ACTION_STOP
+            }
+            ContextCompat.startForegroundService(appContext, intent)
         } catch (e: Exception) {
-            Log.w(TAG, "Unable to stop model download FGS", e)
+            Log.w(TAG, "Unable to signal model download FGS stop; falling back", e)
+            try {
+                appContext.stopService(Intent(appContext, ModelDownloadForegroundService::class.java))
+            } catch (stopError: Exception) {
+                Log.w(TAG, "Unable to stop model download FGS", stopError)
+            }
         }
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserver.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserver.kt
@@ -57,10 +57,14 @@ class ModelDownloadForegroundObserver(
         }
     }
 
-    /** Retry FGS when returning to foreground if download is still active (#494). */
+    /**
+     * Retry FGS when returning to foreground if download is still active (#494).
+     * Do **not** force [ModelDownloadForegroundService.desiredActive] back to true —
+     * notification Cancel clears that latch while [networkDownloadDesired] can lag
+     * until Idle; forcing true would revive the FGS after Cancel.
+     */
     override fun onActivityStarted(activity: Activity) {
-        if (networkDownloadDesired) {
-            ModelDownloadForegroundService.desiredActive = true
+        if (networkDownloadDesired && ModelDownloadForegroundService.desiredActive) {
             requestStart()
         }
     }
@@ -84,18 +88,16 @@ class ModelDownloadForegroundObserver(
     private fun requestStop() {
         try {
             // Handshake: deliver stop through startForegroundService so onCreate can
-            // always call startForeground before tearing down (#494).
+            // always call startForeground before tearing down (#494). Never fall back
+            // to stopService — that reintroduces the pre-startForeground race.
             val intent = Intent(appContext, ModelDownloadForegroundService::class.java).apply {
                 action = ModelDownloadForegroundService.ACTION_STOP
             }
             ContextCompat.startForegroundService(appContext, intent)
         } catch (e: Exception) {
-            Log.w(TAG, "Unable to signal model download FGS stop; falling back", e)
-            try {
-                appContext.stopService(Intent(appContext, ModelDownloadForegroundService::class.java))
-            } catch (stopError: Exception) {
-                Log.w(TAG, "Unable to stop model download FGS", stopError)
-            }
+            // desiredActive is already false; a pending onCreate will startForeground
+            // then stopAndClear(), or the service's downloadState collector will tear down.
+            Log.w(TAG, "Unable to signal model download FGS stop", e)
         }
     }
 

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundService.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundService.kt
@@ -8,6 +8,8 @@ import android.app.Service
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.IBinder
+import android.os.SystemClock
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import io.github.leogallego.ansiblejane.MainActivity
@@ -28,6 +30,8 @@ import org.koin.android.ext.android.inject
  * SAF/import transfers never start this service — see [ModelDownloadForegroundObserver].
  * Observes [ILocalModelRepository.downloadState] for progress and self-stops on
  * Idle / Error / Succeeded / cancel, or when the OS fires [onTimeout].
+ *
+ * Progress notifications are throttled (#494) to avoid per-buffer notify floods.
  */
 class ModelDownloadForegroundService : Service() {
 
@@ -35,11 +39,38 @@ class ModelDownloadForegroundService : Service() {
         const val CHANNEL_ID = "litert_model_download"
         const val NOTIFICATION_ID = 0x4A414E46 // "JANF" — distinct from approval summary
         const val ACTION_CANCEL = "io.github.leogallego.ansiblejane.action.CANCEL_MODEL_DOWNLOAD"
+        /** Observer stop handshake — always paired with startForegroundService (#494). */
+        const val ACTION_STOP = "io.github.leogallego.ansiblejane.action.STOP_MODEL_DOWNLOAD"
+        internal const val NOTIFY_MIN_INTERVAL_MS = 300L
+
+        /**
+         * Desired running flag set by [ModelDownloadForegroundObserver].
+         * Checked after [startForeground] so a raced stop cannot skip the FG contract.
+         */
+        @Volatile
+        var desiredActive: Boolean = false
+
+        private const val TAG = "ModelDownloadFgs"
+
+        /** Pure throttle gate for tests and [notifyProgress]. */
+        internal fun shouldPublishProgress(
+            lastNotifyAtElapsedMs: Long,
+            lastNotifiedPercent: Int?,
+            percent: Int?,
+            nowElapsedMs: Long,
+            minIntervalMs: Long = NOTIFY_MIN_INTERVAL_MS,
+        ): Boolean {
+            if (lastNotifyAtElapsedMs == 0L) return true
+            if (percent != null && percent != lastNotifiedPercent) return true
+            return nowElapsedMs - lastNotifyAtElapsedMs >= minIntervalMs
+        }
     }
 
     private val repository: ILocalModelRepository by inject()
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var observing = false
+    private var lastNotifyAtElapsedMs = 0L
+    private var lastNotifiedPercent: Int? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -52,19 +83,36 @@ class ModelDownloadForegroundService : Service() {
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
             )
             true
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Log.w(TAG, "startForeground failed", e)
             false
         }
         if (!started) {
             stopSelf()
             return
         }
+        if (!desiredActive) {
+            stopAndClear()
+            return
+        }
         startObserving()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        if (intent?.action == ACTION_CANCEL) {
-            repository.cancelDownload()
+        when (intent?.action) {
+            ACTION_CANCEL -> {
+                repository.cancelDownload()
+                desiredActive = false
+                stopAndClear()
+                return START_NOT_STICKY
+            }
+            ACTION_STOP -> {
+                desiredActive = false
+                stopAndClear()
+                return START_NOT_STICKY
+            }
+        }
+        if (!desiredActive) {
             stopAndClear()
             return START_NOT_STICKY
         }
@@ -78,6 +126,7 @@ class ModelDownloadForegroundService : Service() {
 
     override fun onTimeout(startId: Int, fgsType: Int) {
         repository.cancelDownload()
+        desiredActive = false
         stopAndClear()
     }
 
@@ -96,6 +145,7 @@ class ModelDownloadForegroundService : Service() {
                 when (state) {
                     is LocalModelDownloadState.Downloading -> {
                         if (state.isImport) {
+                            desiredActive = false
                             stopAndClear()
                         } else {
                             val percent = progressPercent(state.bytesReceived, state.totalBytes)
@@ -112,7 +162,10 @@ class ModelDownloadForegroundService : Service() {
                             )
                         }
                     }
-                    else -> stopAndClear()
+                    else -> {
+                        desiredActive = false
+                        stopAndClear()
+                    }
                 }
             }
         }
@@ -123,10 +176,20 @@ class ModelDownloadForegroundService : Service() {
 
     private fun progressPercent(bytesReceived: Long, totalBytes: Long): Int? {
         if (totalBytes <= 0L) return null
-        return ((bytesReceived * 100L) / totalBytes).toInt().coerceIn(0, 100)
+        return ((bytesReceived * 100L) / totalBytes).toInt().coerceAtLeast(0).coerceAtMost(100)
     }
 
+    /**
+     * Notify at most once per [NOTIFY_MIN_INTERVAL_MS] unless the rounded percent changes.
+     * First update always goes through.
+     */
     private fun notifyProgress(title: String, text: String, percent: Int?) {
+        val now = SystemClock.elapsedRealtime()
+        if (!shouldPublishProgress(lastNotifyAtElapsedMs, lastNotifiedPercent, percent, now)) {
+            return
+        }
+        lastNotifyAtElapsedMs = now
+        lastNotifiedPercent = percent
         val manager = getSystemService(NotificationManager::class.java)
         manager.notify(
             NOTIFICATION_ID,

--- a/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundService.kt
+++ b/app/src/main/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundService.kt
@@ -107,8 +107,15 @@ class ModelDownloadForegroundService : Service() {
                 return START_NOT_STICKY
             }
             ACTION_STOP -> {
-                desiredActive = false
-                stopAndClear()
+                // Honor STOP only while the observer still wants us down. A terminal
+                //→retry can enqueue STOP then set desiredActive=true for a new
+                // download; an unconditional clear here would kill the new session
+                // and leave the transfer without FGS (#498 Bugbot).
+                if (!desiredActive) {
+                    stopAndClear()
+                } else if (!observing) {
+                    startObserving()
+                }
                 return START_NOT_STICKY
             }
         }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserverTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserverTest.kt
@@ -328,7 +328,7 @@ class ModelDownloadForegroundObserverTest {
     }
 
     @Test
-    fun actionStop_clearsDesiredAndStopsWithoutCancel() = runTest {
+    fun actionStop_stopsWhenDesiredInactiveWithoutCancel() = runTest {
         val repo = FakeLocalModelRepository()
         val context = RuntimeEnvironment.getApplication()
         ModelDownloadForegroundService.desiredActive = true
@@ -354,6 +354,8 @@ class ModelDownloadForegroundObserverTest {
                 ModelDownloadForegroundService::class.java,
                 Intent(context, ModelDownloadForegroundService::class.java),
             ).create().get()
+            // Observer clears the latch before enqueueing ACTION_STOP.
+            ModelDownloadForegroundService.desiredActive = false
             service.onStartCommand(
                 Intent(context, ModelDownloadForegroundService::class.java).apply {
                     action = ModelDownloadForegroundService.ACTION_STOP
@@ -363,6 +365,60 @@ class ModelDownloadForegroundObserverTest {
             )
             assertEquals(0, repo.cancelCount)
             assertFalse(ModelDownloadForegroundService.desiredActive)
+        } finally {
+            org.koin.core.context.stopKoin()
+        }
+    }
+
+    @Test
+    fun actionStop_ignoredWhenDesiredActiveAgainAfterRetry() = runTest {
+        val repo = FakeLocalModelRepository()
+        val context = RuntimeEnvironment.getApplication()
+        ModelDownloadForegroundService.desiredActive = true
+        repo.emit(
+            LocalModelDownloadState.Downloading(
+                modelId = "gemma-4-e4b-it",
+                bytesReceived = 500L,
+                totalBytes = 1_000L,
+                isImport = false,
+            ),
+        )
+        org.koin.core.context.startKoin {
+            modules(
+                org.koin.dsl.module {
+                    single<io.github.leogallego.ansiblejane.assistant.local.ILocalModelRepository> {
+                        repo
+                    }
+                },
+            )
+        }
+        try {
+            val controller = org.robolectric.Robolectric.buildService(
+                ModelDownloadForegroundService::class.java,
+                Intent(context, ModelDownloadForegroundService::class.java),
+            ).create()
+            val service = controller.get()
+            // Stale STOP from a prior terminal state arrives after a retry already
+            // flipped desiredActive back to true — must not tear down the new session.
+            ModelDownloadForegroundService.desiredActive = true
+            service.onStartCommand(
+                Intent(context, ModelDownloadForegroundService::class.java).apply {
+                    action = ModelDownloadForegroundService.ACTION_STOP
+                },
+                0,
+                1,
+            )
+            assertEquals(0, repo.cancelCount)
+            assertTrue(ModelDownloadForegroundService.desiredActive)
+            assertEquals(
+                LocalModelDownloadState.Downloading(
+                    modelId = "gemma-4-e4b-it",
+                    bytesReceived = 500L,
+                    totalBytes = 1_000L,
+                    isImport = false,
+                ),
+                repo.downloadState.value,
+            )
         } finally {
             org.koin.core.context.stopKoin()
         }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserverTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserverTest.kt
@@ -10,8 +10,11 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -21,6 +24,11 @@ import org.robolectric.Shadows.shadowOf
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 class ModelDownloadForegroundObserverTest {
+
+    @Before
+    fun resetDesired() {
+        ModelDownloadForegroundService.desiredActive = false
+    }
 
     @Test
     fun startsService_forNetworkDownloading() = runTest {
@@ -50,6 +58,7 @@ class ModelDownloadForegroundObserverTest {
             ModelDownloadForegroundService::class.java.name,
             started!!.component!!.className,
         )
+        assertTrue(ModelDownloadForegroundService.desiredActive)
     }
 
     @Test
@@ -72,10 +81,11 @@ class ModelDownloadForegroundObserverTest {
         advanceUntilIdle()
 
         assertNull(shadow.nextStartedService)
+        assertFalse(ModelDownloadForegroundService.desiredActive)
     }
 
     @Test
-    fun stopsService_onTerminalStates() = runTest {
+    fun stopUsesStartForegroundServiceHandshake_onTerminalStates() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = TestScope(dispatcher)
         val repo = FakeLocalModelRepository()
@@ -96,12 +106,11 @@ class ModelDownloadForegroundObserverTest {
 
         repo.emit(LocalModelDownloadState.Succeeded("gemma-4-e4b-it"))
         advanceUntilIdle()
-        val stopped = shadow.nextStoppedService
-        assertNotNull(stopped)
-        assertEquals(
-            ModelDownloadForegroundService::class.java.name,
-            stopped!!.component!!.className,
-        )
+        val stopIntent = shadow.nextStartedService
+        assertNotNull(stopIntent)
+        assertEquals(ModelDownloadForegroundService.ACTION_STOP, stopIntent!!.action)
+        assertFalse(ModelDownloadForegroundService.desiredActive)
+        assertNull(shadow.nextStoppedService)
 
         repo.emit(
             LocalModelDownloadState.Downloading(
@@ -121,7 +130,9 @@ class ModelDownloadForegroundObserverTest {
             ),
         )
         advanceUntilIdle()
-        assertNotNull(shadow.nextStoppedService)
+        val errorStop = shadow.nextStartedService
+        assertNotNull(errorStop)
+        assertEquals(ModelDownloadForegroundService.ACTION_STOP, errorStop!!.action)
 
         repo.emit(
             LocalModelDownloadState.Downloading(
@@ -136,13 +147,116 @@ class ModelDownloadForegroundObserverTest {
 
         repo.emit(LocalModelDownloadState.Idle)
         advanceUntilIdle()
-        assertNotNull(shadow.nextStoppedService)
+        val idleStop = shadow.nextStartedService
+        assertNotNull(idleStop)
+        assertEquals(ModelDownloadForegroundService.ACTION_STOP, idleStop!!.action)
+    }
+
+    @Test
+    fun fastDownloadingToError_usesStopHandshakeNotBareStopService() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = TestScope(dispatcher)
+        val repo = FakeLocalModelRepository()
+        val context = RuntimeEnvironment.getApplication()
+        val shadow = shadowOf(context)
+
+        ModelDownloadForegroundObserver(context, repo, scope).start()
+        repo.emit(
+            LocalModelDownloadState.Downloading(
+                modelId = "gemma-4-e4b-it",
+                bytesReceived = 1L,
+                totalBytes = 10_000L,
+                isImport = false,
+            ),
+        )
+        repo.emit(
+            LocalModelDownloadState.Error(
+                "gemma-4-e4b-it",
+                LocalModelDownloadErrorKind.NETWORK,
+            ),
+        )
+        advanceUntilIdle()
+
+        val first = shadow.nextStartedService
+        assertNotNull(first)
+        val second = shadow.nextStartedService
+        assertNotNull(second)
+        assertEquals(ModelDownloadForegroundService.ACTION_STOP, second!!.action)
+        assertNull(shadow.nextStoppedService)
+        assertFalse(ModelDownloadForegroundService.desiredActive)
+    }
+
+    @Test
+    fun onActivityStarted_retriesStart_whenDownloadStillDesired() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = TestScope(dispatcher)
+        val repo = FakeLocalModelRepository()
+        val context = RuntimeEnvironment.getApplication()
+        val shadow = shadowOf(context)
+        val observer = ModelDownloadForegroundObserver(context, repo, scope)
+        observer.start()
+
+        repo.emit(
+            LocalModelDownloadState.Downloading(
+                modelId = "gemma-4-e4b-it",
+                bytesReceived = 1_000L,
+                totalBytes = 10_000L,
+                isImport = false,
+            ),
+        )
+        advanceUntilIdle()
+        assertNotNull(shadow.nextStartedService)
+
+        // Simulate returning to foreground after a failed/background start attempt.
+        observer.onActivityStarted(org.robolectric.Robolectric.buildActivity(android.app.Activity::class.java).get())
+        advanceUntilIdle()
+        val retry = shadow.nextStartedService
+        assertNotNull(retry)
+        assertNull(retry!!.action)
+        assertTrue(ModelDownloadForegroundService.desiredActive)
+    }
+
+    @Test
+    fun progressThrottle_publishesFirstAndPercentOrIntervalChanges() {
+        assertTrue(
+            ModelDownloadForegroundService.shouldPublishProgress(
+                lastNotifyAtElapsedMs = 0L,
+                lastNotifiedPercent = null,
+                percent = 1,
+                nowElapsedMs = 100L,
+            ),
+        )
+        assertFalse(
+            ModelDownloadForegroundService.shouldPublishProgress(
+                lastNotifyAtElapsedMs = 1_000L,
+                lastNotifiedPercent = 10,
+                percent = 10,
+                nowElapsedMs = 1_100L,
+            ),
+        )
+        assertTrue(
+            ModelDownloadForegroundService.shouldPublishProgress(
+                lastNotifyAtElapsedMs = 1_000L,
+                lastNotifiedPercent = 10,
+                percent = 11,
+                nowElapsedMs = 1_100L,
+            ),
+        )
+        assertTrue(
+            ModelDownloadForegroundService.shouldPublishProgress(
+                lastNotifyAtElapsedMs = 1_000L,
+                lastNotifiedPercent = 10,
+                percent = 10,
+                nowElapsedMs = 1_000L + ModelDownloadForegroundService.NOTIFY_MIN_INTERVAL_MS,
+            ),
+        )
     }
 
     @Test
     fun cancelAction_callsRepositoryCancel() = runTest {
         val repo = FakeLocalModelRepository()
         val context = RuntimeEnvironment.getApplication()
+        ModelDownloadForegroundService.desiredActive = true
         repo.emit(
             LocalModelDownloadState.Downloading(
                 modelId = "gemma-4-e4b-it",
@@ -174,6 +288,48 @@ class ModelDownloadForegroundObserverTest {
             )
             assertEquals(1, repo.cancelCount)
             assertEquals(LocalModelDownloadState.Idle, repo.downloadState.value)
+            assertFalse(ModelDownloadForegroundService.desiredActive)
+        } finally {
+            org.koin.core.context.stopKoin()
+        }
+    }
+
+    @Test
+    fun actionStop_clearsDesiredAndStopsWithoutCancel() = runTest {
+        val repo = FakeLocalModelRepository()
+        val context = RuntimeEnvironment.getApplication()
+        ModelDownloadForegroundService.desiredActive = true
+        repo.emit(
+            LocalModelDownloadState.Downloading(
+                modelId = "gemma-4-e4b-it",
+                bytesReceived = 500L,
+                totalBytes = 1_000L,
+                isImport = false,
+            ),
+        )
+        org.koin.core.context.startKoin {
+            modules(
+                org.koin.dsl.module {
+                    single<io.github.leogallego.ansiblejane.assistant.local.ILocalModelRepository> {
+                        repo
+                    }
+                },
+            )
+        }
+        try {
+            val service = org.robolectric.Robolectric.buildService(
+                ModelDownloadForegroundService::class.java,
+                Intent(context, ModelDownloadForegroundService::class.java),
+            ).create().get()
+            service.onStartCommand(
+                Intent(context, ModelDownloadForegroundService::class.java).apply {
+                    action = ModelDownloadForegroundService.ACTION_STOP
+                },
+                0,
+                1,
+            )
+            assertEquals(0, repo.cancelCount)
+            assertFalse(ModelDownloadForegroundService.desiredActive)
         } finally {
             org.koin.core.context.stopKoin()
         }

--- a/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserverTest.kt
+++ b/app/src/test/kotlin/io/github/leogallego/ansiblejane/notification/ModelDownloadForegroundObserverTest.kt
@@ -217,6 +217,39 @@ class ModelDownloadForegroundObserverTest {
     }
 
     @Test
+    fun onActivityStarted_doesNotReviveFgs_afterCancelClearsDesiredActive() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = TestScope(dispatcher)
+        val repo = FakeLocalModelRepository()
+        val context = RuntimeEnvironment.getApplication()
+        val shadow = shadowOf(context)
+        val observer = ModelDownloadForegroundObserver(context, repo, scope)
+        observer.start()
+
+        repo.emit(
+            LocalModelDownloadState.Downloading(
+                modelId = "gemma-4-e4b-it",
+                bytesReceived = 1_000L,
+                totalBytes = 10_000L,
+                isImport = false,
+            ),
+        )
+        advanceUntilIdle()
+        assertNotNull(shadow.nextStartedService)
+
+        // Notification Cancel clears desiredActive while downloadState may still be
+        // Downloading briefly — retry must not force the latch back on.
+        ModelDownloadForegroundService.desiredActive = false
+        observer.onActivityStarted(
+            org.robolectric.Robolectric.buildActivity(android.app.Activity::class.java).get(),
+        )
+        advanceUntilIdle()
+
+        assertNull(shadow.nextStartedService)
+        assertFalse(ModelDownloadForegroundService.desiredActive)
+    }
+
+    @Test
     fun progressThrottle_publishesFirstAndPercentOrIntervalChanges() {
         assertTrue(
             ModelDownloadForegroundService.shouldPublishProgress(


### PR DESCRIPTION
## Summary
- Harden LiteRT download foreground service stop via `startForegroundService(ACTION_STOP)` so `startForeground` always runs before teardown (Android FGS handshake).
- Retry FGS start when activities reach `STARTED` if a network download is still desired.
- Throttle progress notification updates to reduce notify churn during downloads.
- Expand unit coverage for observer start/stop handshake, retry, and notify throttle behavior.

## Test plan
- [ ] Unit tests for `ModelDownloadForegroundObserver` pass
- [ ] Start a LiteRT model download with app in foreground; FGS notification appears
- [ ] Background/foreground the app during download; service stays healthy (no crash from missing `startForeground`)
- [ ] Cancel/complete download; service stops cleanly via ACTION_STOP path
- [ ] Confirm progress notifies are throttled (not flooding the shade)

Closes #494

Assisted-by: Cursor (Grok 4.5)